### PR TITLE
Replace twilio-innovation org references with twilio

### DIFF
--- a/.claude/skills/sync-to-ts-sdk/SKILL.md
+++ b/.claude/skills/sync-to-ts-sdk/SKILL.md
@@ -14,7 +14,7 @@ This skill analyzes changes from the Python SDK (`twilio-agent-connect-python`) 
 
 The skill accepts the following arguments (can be combined):
 
-1. **GitHub PR URL**: `https://github.com/twilio-innovation/twilio-agent-connect-python/pull/123`
+1. **GitHub PR URL**: `https://github.com/twilio/twilio-agent-connect-python/pull/123`
 2. **No commit flag**: `--no-commit` (makes and stages changes, but skips commit/push/PR)
 
 **Examples:**
@@ -30,7 +30,7 @@ The skill accepts the following arguments (can be combined):
 
 - Python SDK (source): Current working directory (this repo)
 - TypeScript SDK (target): Clone to `~/.claude/cache/sync-to-ts-sdk/twilio-agent-connect-typescript` (user's home directory)
-- GitHub org: `twilio-innovation`
+- GitHub org: `twilio`
 
 ## Determine Input Mode
 
@@ -68,12 +68,12 @@ Arguments: $ARGUMENTS (the full argument string)
 Before doing anything else, verify that the `gh` CLI is installed and authenticated with access to the target repo:
 
 ```bash
-gh repo view twilio-innovation/twilio-agent-connect-typescript --json name --jq '.name'
+gh repo view twilio/twilio-agent-connect-typescript --json name --jq '.name'
 ```
 
 - If this command succeeds (prints `twilio-agent-connect-typescript`), proceed to Phase 1.
 - If it fails for **any reason** (gh not installed, not authenticated, no repo access, network error, etc.), **STOP the skill immediately** and tell the user:
-  > This skill requires the GitHub CLI (`gh`) to be installed and authenticated with access to `twilio-innovation/twilio-agent-connect-typescript`.
+  > This skill requires the GitHub CLI (`gh`) to be installed and authenticated with access to `twilio/twilio-agent-connect-typescript`.
   >
   > Run `gh auth status` to check your authentication, or `gh auth login` to authenticate.
 
@@ -126,7 +126,7 @@ git clean -fd
 
 ```bash
 mkdir -p "$HOME/.claude/cache/sync-to-ts-sdk"
-gh repo clone twilio-innovation/twilio-agent-connect-typescript "$TS_SDK_DIR"
+gh repo clone twilio/twilio-agent-connect-typescript "$TS_SDK_DIR"
 ```
 
 ### Phase 2: Analyze Python SDK Changes
@@ -137,13 +137,13 @@ Fetch PR details and diff using GitHub CLI:
 
 ```bash
 # Get PR metadata
-gh pr view <PR_NUMBER> --repo twilio-innovation/twilio-agent-connect-python --json title,body,headRefName,baseRefName,files,url
+gh pr view <PR_NUMBER> --repo twilio/twilio-agent-connect-python --json title,body,headRefName,baseRefName,files,url
 
 # Get the diff
-gh pr diff <PR_NUMBER> --repo twilio-innovation/twilio-agent-connect-python
+gh pr diff <PR_NUMBER> --repo twilio/twilio-agent-connect-python
 
 # Get list of changed files
-gh pr view <PR_NUMBER> --repo twilio-innovation/twilio-agent-connect-python --json files --jq '.files[].path'
+gh pr view <PR_NUMBER> --repo twilio/twilio-agent-connect-python --json files --jq '.files[].path'
 ```
 
 Store:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@
 
 ## SDK Parity
 
-This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio-innovation/twilio-agent-connect-typescript) is updated as well.
+This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.
 
 > **Tip:** Use the `/sync-to-ts-sdk` skill in Claude Code to automatically generate and create a TypeScript SDK PR from your changes.
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@
   </h2>
 
   <div align="center">
-    <a href="https://github.com/twilio-innovation/twilio-agent-connect-python"><img alt="Python SDK" src="https://img.shields.io/badge/Python-3.10+-3776AB.svg"/></a>
-    <a href="https://github.com/twilio-innovation/twilio-agent-connect-typescript"><img alt="TypeScript SDK" src="https://img.shields.io/badge/TypeScript-5.0+-3178C6.svg"/></a>
+    <a href="https://github.com/twilio/twilio-agent-connect-python"><img alt="Python SDK" src="https://img.shields.io/badge/Python-3.10+-3776AB.svg"/></a>
+    <a href="https://github.com/twilio/twilio-agent-connect-typescript"><img alt="TypeScript SDK" src="https://img.shields.io/badge/TypeScript-5.0+-3178C6.svg"/></a>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-green.svg"/></a>
     <a href="https://www.twilio.com/docs/platform/tac/quickstart"><img alt="Getting Started" src="https://img.shields.io/badge/Getting%20Started-Quickstart-F22F46.svg"/></a>
   </div>
   
   <p>
     <a href="https://www.twilio.com/docs/platform/tac/overview">Documentation</a>
-    ◆ <a href="https://github.com/twilio-innovation/twilio-agent-connect-python">Python SDK</a>
-    ◆ <a href="https://github.com/twilio-innovation/twilio-agent-connect-typescript">TypeScript SDK</a>
+    ◆ <a href="https://github.com/twilio/twilio-agent-connect-python">Python SDK</a>
+    ◆ <a href="https://github.com/twilio/twilio-agent-connect-typescript">TypeScript SDK</a>
     ◆ <a href="getting_started/examples">Examples</a>
   </p>
 </div>
@@ -50,10 +50,10 @@ We recommend using [uv](https://docs.astral.sh/uv/) for the best development exp
 
 ```bash
 uv init
-uv add git+https://github.com/twilio-innovation/twilio-agent-connect-python.git
+uv add git+https://github.com/twilio/twilio-agent-connect-python.git
 
 # Install with server support (includes FastAPI and uvicorn for TACFastAPIServer)
-uv add git+https://github.com/twilio-innovation/twilio-agent-connect-python.git --extra server
+uv add git+https://github.com/twilio/twilio-agent-connect-python.git --extra server
 ```
 
 ### pip/venv (Alternative)
@@ -63,10 +63,10 @@ If you prefer using pip and venv:
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-pip install git+https://github.com/twilio-innovation/twilio-agent-connect-python.git
+pip install git+https://github.com/twilio/twilio-agent-connect-python.git
 
 # Install with server support
-pip install "git+https://github.com/twilio-innovation/twilio-agent-connect-python.git[server]"
+pip install "git+https://github.com/twilio/twilio-agent-connect-python.git[server]"
 ```
 
 ## Quick Examples
@@ -76,7 +76,7 @@ pip install "git+https://github.com/twilio-innovation/twilio-agent-connect-pytho
 Use the [Twilio Setup Wizard](getting_started/twilio_setup/) to automatically create a Memory Store and Conversation Configuration and generate your `.env` file:
 
 ```bash
-git clone https://github.com/twilio-innovation/twilio-agent-connect-python.git
+git clone https://github.com/twilio/twilio-agent-connect-python.git
 cd twilio-agent-connect-python
 make setup  # Open http://localhost:8080
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ version = "0.0.3"
 description = "A Python framework for building agentic applications with Twilio"
 authors = [{ name = "Twilio Conversation AI", email = "team_conversational-ai@twilio.com" }]
 readme = "README.md"
-homepage = "https://github.com/twilio-innovation/twilio-agent-connect-python"
-repository = "https://github.com/twilio-innovation/twilio-agent-connect-python"
+homepage = "https://github.com/twilio/twilio-agent-connect-python"
+repository = "https://github.com/twilio/twilio-agent-connect-python"
 requires-python = ">=3.10,<4"
 classifiers = [
     "Typing :: Typed",


### PR DESCRIPTION
## Summary

Replace all `twilio-innovation` GitHub org references with `twilio` following the repo migration to `twilio/twilio-agent-connect-python` and `twilio/twilio-agent-connect-typescript`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)