### PR TITLE
chore: Remove unused callback handler and update repository links

### DIFF
--- a/.claude/skills/sync-to-ts-sdk/SKILL.md
+++ b/.claude/skills/sync-to-ts-sdk/SKILL.md
@@ -14,7 +14,7 @@ This skill analyzes changes from the Python SDK (`twilio-agent-connect-python`) 
 
 The skill accepts the following arguments (can be combined):
 
-1. **GitHub PR URL**: `https://github.com/twilio-innovation/twilio-agent-connect-python/pull/123`
+1. **GitHub PR URL**: `https://github.com/twilio/twilio-agent-connect-python/pull/123`
 2. **No commit flag**: `--no-commit` (makes and stages changes, but skips commit/push/PR)
 
 **Examples:**
@@ -30,7 +30,7 @@ The skill accepts the following arguments (can be combined):
 
 - Python SDK (source): Current working directory (this repo)
 - TypeScript SDK (target): Clone to `~/.claude/cache/sync-to-ts-sdk/twilio-agent-connect-typescript` (user's home directory)
-- GitHub org: `twilio-innovation`
+- GitHub org: `twilio`
 
 ## Determine Input Mode
 
@@ -68,12 +68,12 @@ Arguments: $ARGUMENTS (the full argument string)
 Before doing anything else, verify that the `gh` CLI is installed and authenticated with access to the target repo:
 
 ```bash
-gh repo view twilio-innovation/twilio-agent-connect-typescript --json name --jq '.name'
+gh repo view twilio/twilio-agent-connect-typescript --json name --jq '.name'
 ```
 
 - If this command succeeds (prints `twilio-agent-connect-typescript`), proceed to Phase 1.
 - If it fails for **any reason** (gh not installed, not authenticated, no repo access, network error, etc.), **STOP the skill immediately** and tell the user:
-  > This skill requires the GitHub CLI (`gh`) to be installed and authenticated with access to `twilio-innovation/twilio-agent-connect-typescript`.
+  > This skill requires the GitHub CLI (`gh`) to be installed and authenticated with access to `twilio/twilio-agent-connect-typescript`.
   >
   > Run `gh auth status` to check your authentication, or `gh auth login` to authenticate.
 
@@ -126,7 +126,7 @@ git clean -fd
 
 ```bash
 mkdir -p "$HOME/.claude/cache/sync-to-ts-sdk"
-gh repo clone twilio-innovation/twilio-agent-connect-typescript "$TS_SDK_DIR"
+gh repo clone twilio/twilio-agent-connect-typescript "$TS_SDK_DIR"
 ```
 
 ### Phase 2: Analyze Python SDK Changes
@@ -137,13 +137,13 @@ Fetch PR details and diff using GitHub CLI:
 
 ```bash
 # Get PR metadata
-gh pr view <PR_NUMBER> --repo twilio-innovation/twilio-agent-connect-python --json title,body,headRefName,baseRefName,files,url
+gh pr view <PR_NUMBER> --repo twilio/twilio-agent-connect-python --json title,body,headRefName,baseRefName,files,url
 
 # Get the diff
-gh pr diff <PR_NUMBER> --repo twilio-innovation/twilio-agent-connect-python
+gh pr diff <PR_NUMBER> --repo twilio/twilio-agent-connect-python
 
 # Get list of changed files
-gh pr view <PR_NUMBER> --repo twilio-innovation/twilio-agent-connect-python --json files --jq '.files[].path'
+gh pr view <PR_NUMBER> --repo twilio/twilio-agent-connect-python --json files --jq '.files[].path'
 ```
 
 Store:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@
 
 ## SDK Parity
 
-This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio-innovation/twilio-agent-connect-typescript) is updated as well.
+This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.
 
 > **Tip:** Use the `/sync-to-ts-sdk` skill in Claude Code to automatically generate and create a TypeScript SDK PR from your changes.
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@
   </h2>
 
   <div align="center">
-    <a href="https://github.com/twilio-innovation/twilio-agent-connect-python"><img alt="Python SDK" src="https://img.shields.io/badge/Python-3.10+-3776AB.svg"/></a>
-    <a href="https://github.com/twilio-innovation/twilio-agent-connect-typescript"><img alt="TypeScript SDK" src="https://img.shields.io/badge/TypeScript-5.0+-3178C6.svg"/></a>
+    <a href="https://github.com/twilio/twilio-agent-connect-python"><img alt="Python SDK" src="https://img.shields.io/badge/Python-3.10+-3776AB.svg"/></a>
+    <a href="https://github.com/twilio/twilio-agent-connect-typescript"><img alt="TypeScript SDK" src="https://img.shields.io/badge/TypeScript-5.0+-3178C6.svg"/></a>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache%202.0-green.svg"/></a>
     <a href="https://www.twilio.com/docs/platform/tac/quickstart"><img alt="Getting Started" src="https://img.shields.io/badge/Getting%20Started-Quickstart-F22F46.svg"/></a>
   </div>
   
   <p>
     <a href="https://www.twilio.com/docs/platform/tac/overview">Documentation</a>
-    ◆ <a href="https://github.com/twilio-innovation/twilio-agent-connect-python">Python SDK</a>
-    ◆ <a href="https://github.com/twilio-innovation/twilio-agent-connect-typescript">TypeScript SDK</a>
+    ◆ <a href="https://github.com/twilio/twilio-agent-connect-python">Python SDK</a>
+    ◆ <a href="https://github.com/twilio/twilio-agent-connect-typescript">TypeScript SDK</a>
     ◆ <a href="getting_started/examples">Examples</a>
   </p>
 </div>
@@ -50,10 +50,10 @@ We recommend using [uv](https://docs.astral.sh/uv/) for the best development exp
 
 ```bash
 uv init
-uv add git+https://github.com/twilio-innovation/twilio-agent-connect-python.git
+uv add git+https://github.com/twilio/twilio-agent-connect-python.git
 
 # Install with server support (includes FastAPI and uvicorn for TACFastAPIServer)
-uv add git+https://github.com/twilio-innovation/twilio-agent-connect-python.git --extra server
+uv add git+https://github.com/twilio/twilio-agent-connect-python.git --extra server
 ```
 
 ### pip/venv (Alternative)
@@ -63,10 +63,10 @@ If you prefer using pip and venv:
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-pip install git+https://github.com/twilio-innovation/twilio-agent-connect-python.git
+pip install git+https://github.com/twilio/twilio-agent-connect-python.git
 
 # Install with server support
-pip install "git+https://github.com/twilio-innovation/twilio-agent-connect-python.git[server]"
+pip install "git+https://github.com/twilio/twilio-agent-connect-python.git[server]"
 ```
 
 ## Quick Examples
@@ -76,7 +76,7 @@ pip install "git+https://github.com/twilio-innovation/twilio-agent-connect-pytho
 Use the [Twilio Setup Wizard](getting_started/twilio_setup/) to automatically create a Memory Store and Conversation Configuration and generate your `.env` file:
 
 ```bash
-git clone https://github.com/twilio-innovation/twilio-agent-connect-python.git
+git clone https://github.com/twilio/twilio-agent-connect-python.git
 cd twilio-agent-connect-python
 make setup  # Open http://localhost:8080
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ version = "0.0.3"
 description = "A Python framework for building agentic applications with Twilio"
 authors = [{ name = "Twilio Conversation AI", email = "team_conversational-ai@twilio.com" }]
 readme = "README.md"
-homepage = "https://github.com/twilio-innovation/twilio-agent-connect-python"
-repository = "https://github.com/twilio-innovation/twilio-agent-connect-python"
+homepage = "https://github.com/twilio/twilio-agent-connect-python"
+repository = "https://github.com/twilio/twilio-agent-connect-python"
 requires-python = ">=3.10,<4"
 classifiers = [
     "Typing :: Typed",

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -15,7 +15,6 @@ from tac.core.tac import TAC
 from tac.models.outbound import InitiateVoiceConversationOptions, InitiateVoiceConversationResult
 from tac.models.session import AuthorInfo
 from tac.models.voice import (
-    ConversationRelayCallbackPayload,
     InterruptMessage,
     PromptMessage,
     SetupMessage,
@@ -134,36 +133,6 @@ class VoiceChannel(BaseChannel):
                 conversation_configuration=self.tac.config.conversation_configuration_id,
             )
         )
-
-    async def handle_conversation_relay_callback(
-        self,
-        payload_dict: dict[str, str],
-    ) -> str | None:
-        """
-        Handle ConversationRelay callback webhook from Twilio.
-
-        This method processes the callback sent by Twilio when a ConversationRelay
-        session ends. Conversation lifecycle is managed by CO — the SDK does not
-        manually close conversations.
-
-        Args:
-            payload_dict: Raw form data dict from the webhook request.
-                Validated internally into ConversationRelayCallbackPayload.
-
-        Returns:
-            None for simple acknowledgment.
-
-        Raises:
-            ValidationError: If the payload dict fails validation.
-        """
-        payload = ConversationRelayCallbackPayload(**payload_dict)
-
-        self.logger.info(
-            f"[ConversationRelay Callback] CallSid: {payload.call_sid}, "
-            f"Status: {payload.call_status}"
-        )
-
-        return None
 
     async def _initialize_conversation(
         self,

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -1189,65 +1189,6 @@ class TestVoiceChannel:
         assert "user_language" not in twiml
 
 
-class TestHandleConversationRelayCallback:
-    """Test handle_conversation_relay_callback behavior."""
-
-    @staticmethod
-    def _make_payload(**overrides: str) -> dict[str, str]:
-        """Create a valid callback payload with optional overrides."""
-        base = {
-            "AccountSid": "ACtest123",
-            "CallSid": "CA123",
-            "CallStatus": "completed",
-            "From": "+15551234567",
-            "To": "+15559876543",
-            "Direction": "inbound",
-        }
-        base.update(overrides)
-        return base
-
-    @pytest.mark.asyncio
-    async def test_completed_call_does_not_close_conversations(self) -> None:
-        """Test that completed call status does not manually close conversations.
-
-        Conversation lifecycle is managed by CO, not the SDK.
-        """
-        tac = TAC(get_test_config())
-        channel = VoiceChannel(tac)
-
-        tac.conversation_orchestrator_client.list_conversations = AsyncMock()
-        tac.conversation_orchestrator_client.update_conversation = AsyncMock()
-
-        payload = self._make_payload(CallStatus="completed")
-        result = await channel.handle_conversation_relay_callback(payload)
-
-        assert result is None
-        tac.conversation_orchestrator_client.list_conversations.assert_not_called()
-        tac.conversation_orchestrator_client.update_conversation.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_other_status_returns_none(self) -> None:
-        """Test that non-handoff, non-completed status returns None."""
-        tac = TAC(get_test_config())
-        channel = VoiceChannel(tac)
-
-        payload = self._make_payload(CallStatus="ringing")
-        result = await channel.handle_conversation_relay_callback(payload)
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_invalid_payload_raises_validation_error(self) -> None:
-        """Test that invalid payload raises ValidationError."""
-        from pydantic import ValidationError
-
-        tac = TAC(get_test_config())
-        channel = VoiceChannel(tac)
-
-        with pytest.raises(ValidationError):
-            await channel.handle_conversation_relay_callback({})
-
-
 class TestConversationInitializationFlow:
     """Test new conversation initialization flow with ConversationRelay."""
 


### PR DESCRIPTION
## Summary

This PR performs two cleanup tasks:

1. **Removes dead code**: The `handle_conversation_relay_callback` method in `VoiceChannel` was never integrated into the codebase. No route was registered in `TACFastAPIServer` to call this method, making it completely unused.

2. **Updates repository references**: All GitHub repository links have been updated from the old `twilio-innovation` organization to the current `twilio` organization.

### Changes

**Dead Code Removal:**
- Removed `handle_conversation_relay_callback` method from `VoiceChannel`
- Removed `ConversationRelayCallbackPayload` import 
- Removed `TestHandleConversationRelayCallback` test class

**Repository Link Updates:**
- Updated `pyproject.toml` homepage and repository URLs
- Updated README.md badges, links, and installation commands
- Updated `.github/PULL_REQUEST_TEMPLATE.md` TypeScript SDK reference
- Updated `.claude/skills/sync-to-ts-sdk/SKILL.md` with correct org references

### Testing

- All 569 tests pass
- No functional changes to existing features

## Type of Change

- [x] Refactoring
- [x] Documentation update

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested E2E

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)