### PR TITLE
feat: Scrub PII from SDK logs

### DIFF
--- a/src/tac/__init__.py
+++ b/src/tac/__init__.py
@@ -8,6 +8,7 @@ __version__ = version("twilio-agent-connect")
 from tac.core import TAC, TACConfig, get_logger
 from tac.context.base import PartnerConnector
 from tac.models import TwiMLOptions
+from tac.utils.redaction import mask_address, mask_email, mask_phone
 
 # isort: on
 
@@ -17,5 +18,8 @@ __all__ = [
     "PartnerConnector",
     "get_logger",
     "TwiMLOptions",
+    "mask_address",
+    "mask_email",
+    "mask_phone",
     "__version__",
 ]

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -22,6 +22,7 @@ from tac.models.conversation import (
 )
 from tac.models.outbound import InitiateConversationResult, InitiateMessagingConversationOptions
 from tac.models.session import AuthorInfo
+from tac.utils.redaction import mask_address
 
 
 class MessagingChannelConfig(BaseModel):
@@ -402,7 +403,7 @@ class MessagingChannel(BaseChannel):
             self.logger.info(
                 f"Outbound {self.get_channel_name()} conversation initiated",
                 conversation_id=conversation_id,
-                to=options.to,
+                to=mask_address(options.to),
             )
             return InitiateConversationResult(conversation_id=conversation_id, session=session)
 
@@ -453,7 +454,7 @@ class MessagingChannel(BaseChannel):
             "No agent participant found, creating AI_AGENT",
             conversation_id=conversation_id,
             channel=agent_address.channel,
-            address=agent_address.address,
+            address=mask_address(agent_address.address),
         )
         try:
             agent = await self.tac.conversation_orchestrator_client.add_participant(

--- a/src/tac/channels/sms.py
+++ b/src/tac/channels/sms.py
@@ -19,6 +19,7 @@ from tac.models.outbound import (
     InitiateConversationResult,
     InitiateMessagingConversationOptions,
 )
+from tac.utils.redaction import mask_phone
 
 
 class SMSChannelConfig(MessagingChannelConfig):
@@ -174,7 +175,7 @@ class SMSChannel(MessagingChannel):
             self.logger.info(
                 "Sent SMS response via Actions API",
                 conversation_id=conversation_id,
-                to_address=customer_address,
+                to_address=mask_phone(customer_address),
             )
         except Exception as e:
             self.logger.error(

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -22,6 +22,7 @@ from tac.models.voice import (
     TwiMLOptions,
 )
 from tac.session import SessionState
+from tac.utils.redaction import mask_phone
 
 from . import twiml
 from .config import VoiceChannelConfig
@@ -321,8 +322,8 @@ class VoiceChannel(BaseChannel):
 
         self.logger.info(
             "Initiating outbound voice conversation",
-            to=options.to,
-            from_number=from_number,
+            to=mask_phone(options.to),
+            from_number=mask_phone(from_number) if from_number else None,
         )
 
         try:
@@ -344,7 +345,7 @@ class VoiceChannel(BaseChannel):
             self.logger.info(
                 "Outbound voice call placed",
                 call_sid=call.sid,
-                to=options.to,
+                to=mask_phone(options.to),
             )
 
             return InitiateVoiceConversationResult(call_sid=call.sid)
@@ -352,7 +353,7 @@ class VoiceChannel(BaseChannel):
         except Exception as e:
             self.logger.error(
                 "Failed to initiate outbound call",
-                to=options.to,
+                to=mask_phone(options.to),
                 error=str(e),
                 exc_info=True,
             )

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -323,7 +323,7 @@ class VoiceChannel(BaseChannel):
         self.logger.info(
             "Initiating outbound voice conversation",
             to=mask_phone(options.to),
-            from_number=mask_phone(from_number) if from_number else None,
+            from_number=mask_phone(from_number),
         )
 
         try:

--- a/src/tac/core/logging.py
+++ b/src/tac/core/logging.py
@@ -33,7 +33,13 @@ _RESERVED_LOG_ATTRS = {
 }
 
 
-_PHONE_RE = re.compile(r"\+\d[\d\-\s()]{6,}\d")
+_PHONE_RE = re.compile(
+    r"(?<!\w)"
+    r"(?:\+\d[\d\-\s()]{6,}\d"
+    r"|(?:\(\d{3}\)\s*|\d{3}[\-.\s]?)\d{3}[\-.\s]?\d{4}"
+    r"|\d{10})"
+    r"(?!\w)"
+)
 _EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
 _REDACTED = "***"
 

--- a/src/tac/core/logging.py
+++ b/src/tac/core/logging.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 import sys
 from typing import Any
 
@@ -30,6 +31,37 @@ _RESERVED_LOG_ATTRS = {
     "stack_info",
     "taskName",
 }
+
+
+_PHONE_RE = re.compile(r"\+\d[\d\-\s()]{6,}\d")
+_EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
+_REDACTED = "***"
+
+
+class PIISafetyFilter(logging.Filter):
+    """Safety-net filter that catches PII missed by per-callsite masking."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.msg = self._scrub(record.msg)
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = {k: self._scrub(v) for k, v in record.args.items()}
+            elif isinstance(record.args, tuple):
+                record.args = tuple(self._scrub(a) for a in record.args)
+        for key in list(record.__dict__):
+            if key not in _RESERVED_LOG_ATTRS and not key.startswith("_"):
+                val = record.__dict__[key]
+                if isinstance(val, str):
+                    record.__dict__[key] = self._scrub(val)
+        return True
+
+    @staticmethod
+    def _scrub(value: Any) -> Any:
+        if not isinstance(value, str):
+            return value
+        value = _PHONE_RE.sub(_REDACTED, value)
+        value = _EMAIL_RE.sub(_REDACTED, value)
+        return value
 
 
 class JSONFormatter(logging.Formatter):
@@ -240,6 +272,7 @@ def setup_logging(log_level: str = "INFO", log_format: str = "json") -> logging.
         )
 
     handler.setFormatter(formatter)
+    handler.addFilter(PIISafetyFilter())
     logger.addHandler(handler)
 
     # Prevent propagation to root logger to avoid duplicate messages

--- a/src/tac/core/logging.py
+++ b/src/tac/core/logging.py
@@ -38,30 +38,11 @@ _EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
 _REDACTED = "***"
 
 
-class PIISafetyFilter(logging.Filter):
-    """Safety-net filter that catches PII missed by per-callsite masking."""
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        record.msg = self._scrub(record.msg)
-        if record.args:
-            if isinstance(record.args, dict):
-                record.args = {k: self._scrub(v) for k, v in record.args.items()}
-            elif isinstance(record.args, tuple):
-                record.args = tuple(self._scrub(a) for a in record.args)
-        for key in list(record.__dict__):
-            if key not in _RESERVED_LOG_ATTRS and not key.startswith("_"):
-                val = record.__dict__[key]
-                if isinstance(val, str):
-                    record.__dict__[key] = self._scrub(val)
-        return True
-
-    @staticmethod
-    def _scrub(value: Any) -> Any:
-        if not isinstance(value, str):
-            return value
-        value = _PHONE_RE.sub(_REDACTED, value)
-        value = _EMAIL_RE.sub(_REDACTED, value)
-        return value
+def _scrub_pii(value: str) -> str:
+    """Replace phone-number and email patterns with ``***``."""
+    value = _PHONE_RE.sub(_REDACTED, value)
+    value = _EMAIL_RE.sub(_REDACTED, value)
+    return value
 
 
 class JSONFormatter(logging.Formatter):
@@ -101,7 +82,7 @@ class JSONFormatter(logging.Formatter):
             if key not in _RESERVED_LOG_ATTRS and not key.startswith("_"):
                 log_data[key] = value
 
-        return json.dumps(log_data, default=str)
+        return _scrub_pii(json.dumps(log_data, default=str))
 
 
 class ConsoleFormatter(logging.Formatter):
@@ -128,7 +109,7 @@ class ConsoleFormatter(logging.Formatter):
         # Format base message
         formatted = super().format(record)
 
-        return f"{formatted}{context_str}"
+        return _scrub_pii(f"{formatted}{context_str}")
 
 
 class ContextLogger:
@@ -272,7 +253,6 @@ def setup_logging(log_level: str = "INFO", log_format: str = "json") -> logging.
         )
 
     handler.setFormatter(formatter)
-    handler.addFilter(PIISafetyFilter())
     logger.addHandler(handler)
 
     # Prevent propagation to root logger to avoid duplicate messages

--- a/src/tac/core/logging.py
+++ b/src/tac/core/logging.py
@@ -68,27 +68,27 @@ class JSONFormatter(logging.Formatter):
         Returns:
             JSON-formatted log string
         """
-        log_data = {
+        log_data: dict[str, Any] = {
             "timestamp": self.formatTime(record, self.datefmt),
             "level": record.levelname,
             "logger": record.name,
             "module": record.module,
             "function": record.funcName,
             "line": record.lineno,
-            "message": record.getMessage(),
+            "message": _scrub_pii(record.getMessage()),
         }
 
         # Add exception info if present
         if record.exc_info:
-            log_data["exception"] = self.formatException(record.exc_info)
+            log_data["exception"] = _scrub_pii(self.formatException(record.exc_info))
 
         # Add extra fields from LogRecord
         # Skip standard fields and internal fields
         for key, value in record.__dict__.items():
             if key not in _RESERVED_LOG_ATTRS and not key.startswith("_"):
-                log_data[key] = value
+                log_data[key] = _scrub_pii(str(value)) if isinstance(value, str) else value
 
-        return _scrub_pii(json.dumps(log_data, default=str))
+        return json.dumps(log_data, default=str)
 
 
 class ConsoleFormatter(logging.Formatter):

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -16,6 +16,7 @@ from tac.models.intelligence import OperatorProcessingResult
 from tac.models.memory import ProfileLookupResponse
 from tac.models.session import ConversationSession
 from tac.models.tac import TACMemoryResponse
+from tac.utils.redaction import mask_address
 
 
 class TAC:
@@ -152,7 +153,7 @@ class TAC:
                         conversation_context.profile_id = lookup_response.profiles[0]
                         self.logger.debug(f"Found profile_id: {conversation_context.profile_id}")
                     else:
-                        self.logger.debug(f"No profile found for address {address}")
+                        self.logger.debug(f"No profile found for address {mask_address(address)}")
                         raise ValueError("No profile found for address")
                 else:
                     self.logger.debug(

--- a/src/tac/tools/handoff.py
+++ b/src/tac/tools/handoff.py
@@ -9,6 +9,7 @@ from tac import get_logger
 from tac.models.handoff import HandoffPayload, PendingHandoffData
 from tac.models.session import ConversationSession
 from tac.tools.base import InjectedToolArg, TACTool, function_tool
+from tac.utils.redaction import mask_address
 
 if TYPE_CHECKING:
     from tac.core.tac import TAC
@@ -111,8 +112,8 @@ async def post_studio_handoff(
     logger.debug(
         "Handoff payload delivered",
         handoff_url=handoff_url,
-        to=to_address,
-        from_=from_address,
+        to=mask_address(to_address),
+        from_=mask_address(from_address),
     )
 
 

--- a/src/tac/utils/__init__.py
+++ b/src/tac/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions for the Twilio Agent Connect."""
+
+from tac.utils.redaction import mask_address, mask_email, mask_phone
+
+__all__ = ["mask_address", "mask_email", "mask_phone"]

--- a/src/tac/utils/redaction.py
+++ b/src/tac/utils/redaction.py
@@ -3,30 +3,20 @@
 _MASK = "***"
 
 
-def mask_phone(value: str) -> str:
+def mask_phone(value: str | None) -> str:
     """Mask a phone number, preserving the first 2 and last 4 characters.
 
-    Returns ``"***"`` for empty or short (< 7 char) inputs.
-
-    Example::
-
-        >>> mask_phone("+15551234567")
-        '+1***4567'
+    Returns ``"***"`` for ``None``, empty, or short (< 7 char) inputs.
     """
     if not value or not value.strip() or len(value) < 7:
         return _MASK
     return value[:2] + _MASK + value[-4:]
 
 
-def mask_email(value: str) -> str:
+def mask_email(value: str | None) -> str:
     """Mask an email address, preserving the first character and full domain.
 
-    Returns ``"***"`` for empty inputs or strings without ``@``.
-
-    Example::
-
-        >>> mask_email("user@example.com")
-        'u***@example.com'
+    Returns ``"***"`` for ``None``, empty, or strings without ``@``.
     """
     if not value or not value.strip():
         return _MASK
@@ -36,18 +26,11 @@ def mask_email(value: str) -> str:
     return value[0] + _MASK + value[at_index:]
 
 
-def mask_address(value: str) -> str:
+def mask_address(value: str | None) -> str:
     """Auto-detect address type and apply the appropriate mask.
 
     Delegates to :func:`mask_email` if the value contains ``@``,
     otherwise to :func:`mask_phone`.
-
-    Example::
-
-        >>> mask_address("+15551234567")
-        '+1***4567'
-        >>> mask_address("user@example.com")
-        'u***@example.com'
     """
     if not value or not value.strip():
         return _MASK

--- a/src/tac/utils/redaction.py
+++ b/src/tac/utils/redaction.py
@@ -8,7 +8,10 @@ def mask_phone(value: str | None) -> str:
 
     Returns ``"***"`` for ``None``, empty, or short (< 7 char) inputs.
     """
-    if not value or not value.strip() or len(value) < 7:
+    if not value:
+        return _MASK
+    value = value.strip()
+    if not value or len(value) < 7:
         return _MASK
     return value[:2] + _MASK + value[-4:]
 
@@ -18,7 +21,10 @@ def mask_email(value: str | None) -> str:
 
     Returns ``"***"`` for ``None``, empty, or strings without ``@``.
     """
-    if not value or not value.strip():
+    if not value:
+        return _MASK
+    value = value.strip()
+    if not value:
         return _MASK
     at_index = value.find("@")
     if at_index < 1:

--- a/src/tac/utils/redaction.py
+++ b/src/tac/utils/redaction.py
@@ -1,0 +1,56 @@
+"""PII redaction utilities for log output."""
+
+_MASK = "***"
+
+
+def mask_phone(value: str) -> str:
+    """Mask a phone number, preserving the first 2 and last 4 characters.
+
+    Returns ``"***"`` for empty or short (< 7 char) inputs.
+
+    Example::
+
+        >>> mask_phone("+15551234567")
+        '+1***4567'
+    """
+    if not value or not value.strip() or len(value) < 7:
+        return _MASK
+    return value[:2] + _MASK + value[-4:]
+
+
+def mask_email(value: str) -> str:
+    """Mask an email address, preserving the first character and full domain.
+
+    Returns ``"***"`` for empty inputs or strings without ``@``.
+
+    Example::
+
+        >>> mask_email("user@example.com")
+        'u***@example.com'
+    """
+    if not value or not value.strip():
+        return _MASK
+    at_index = value.find("@")
+    if at_index < 1:
+        return _MASK
+    return value[0] + _MASK + value[at_index:]
+
+
+def mask_address(value: str) -> str:
+    """Auto-detect address type and apply the appropriate mask.
+
+    Delegates to :func:`mask_email` if the value contains ``@``,
+    otherwise to :func:`mask_phone`.
+
+    Example::
+
+        >>> mask_address("+15551234567")
+        '+1***4567'
+        >>> mask_address("user@example.com")
+        'u***@example.com'
+    """
+    if not value or not value.strip():
+        return _MASK
+    if "@" in value:
+        return mask_email(value)
+    return mask_phone(value)

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -195,6 +195,29 @@ class TestFormatterSafetyNet:
         assert "(555) 123-4567" not in output
         assert "***" in output
 
+    def test_json_formatter_output_remains_valid_json(self) -> None:
+        import json
+
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            "tac.test", logging.INFO, "", 0, "Calling +15559876543", (), None
+        )
+        record.to = "+447911123456"  # type: ignore[attr-defined]
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert "+15559876543" not in parsed["message"]
+        assert "+447911123456" not in str(parsed.get("to", ""))
+
+    def test_json_formatter_int_field_not_corrupted(self) -> None:
+        import json
+
+        formatter = JSONFormatter()
+        record = logging.LogRecord("tac.test", logging.INFO, "", 0, "call placed", (), None)
+        record.retry_count = 5551234567  # type: ignore[attr-defined]
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert isinstance(parsed["retry_count"], int)
+
     def test_formatters_pass_clean_messages_through(self) -> None:
         for formatter in [JSONFormatter(), ConsoleFormatter(fmt="%(message)s")]:
             record = logging.LogRecord(

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from tac.core.logging import ContextLogger, PIISafetyFilter
+from tac.core.logging import ConsoleFormatter, ContextLogger, JSONFormatter
 from tac.utils.redaction import mask_address, mask_email, mask_phone
 
 
@@ -21,6 +21,9 @@ class TestMaskPhone:
 
     def test_empty(self) -> None:
         assert mask_phone("") == "***"
+
+    def test_none(self) -> None:
+        assert mask_phone(None) == "***"
 
     def test_whitespace(self) -> None:
         assert mask_phone("   ") == "***"
@@ -42,6 +45,9 @@ class TestMaskEmail:
     def test_empty(self) -> None:
         assert mask_email("") == "***"
 
+    def test_none(self) -> None:
+        assert mask_email(None) == "***"
+
     def test_no_at_sign(self) -> None:
         assert mask_email("not-an-email") == "***"
 
@@ -62,48 +68,46 @@ class TestMaskAddress:
     def test_empty(self) -> None:
         assert mask_address("") == "***"
 
+    def test_none(self) -> None:
+        assert mask_address(None) == "***"
+
     def test_whitespace(self) -> None:
         assert mask_address("   ") == "***"
 
 
 class TestLogOutputRedaction:
-    """Integration tests: verify PII is masked in actual log output."""
+    """Integration tests: verify PII is masked in actual log output via ContextLogger."""
 
-    def _capture_log(self, logger: ContextLogger, caplog: logging.Handler) -> None:
-        """Helper to attach caplog handler to the underlying logger."""
-        logger.logger.addHandler(caplog.handler)  # type: ignore[attr-defined]
-        logger.logger.setLevel(logging.DEBUG)
-
-    def test_phone_masked_in_log_message(self, caplog: object) -> None:
+    def test_phone_masked_in_log_message(self) -> None:
         raw_phone = "+15551234567"
         base = logging.getLogger("tac.test.redaction_phone")
         ctx_logger = ContextLogger(base)
 
-        with _CaplogContext(base, caplog) as records:
+        with _RecordCapture(base) as records:
             ctx_logger.debug(f"No profile found for address {mask_address(raw_phone)}")
 
         assert len(records) == 1
         assert raw_phone not in records[0].getMessage()
         assert "+1***4567" in records[0].getMessage()
 
-    def test_email_masked_in_log_message(self, caplog: object) -> None:
+    def test_email_masked_in_log_message(self) -> None:
         raw_email = "alice@example.com"
         base = logging.getLogger("tac.test.redaction_email")
         ctx_logger = ContextLogger(base)
 
-        with _CaplogContext(base, caplog) as records:
+        with _RecordCapture(base) as records:
             ctx_logger.info(f"Outbound conversation initiated to {mask_address(raw_email)}")
 
         assert len(records) == 1
         assert raw_email not in records[0].getMessage()
         assert "a***@example.com" in records[0].getMessage()
 
-    def test_phone_masked_in_structured_extra(self, caplog: object) -> None:
+    def test_phone_masked_in_structured_extra(self) -> None:
         raw_phone = "+447911123456"
         base = logging.getLogger("tac.test.redaction_extra")
         ctx_logger = ContextLogger(base)
 
-        with _CaplogContext(base, caplog) as records:
+        with _RecordCapture(base) as records:
             ctx_logger.info("Outbound voice call placed", to=mask_phone(raw_phone))
 
         assert len(records) == 1
@@ -112,87 +116,82 @@ class TestLogOutputRedaction:
         assert getattr(record, "to", None) == "+4***3456"
 
 
-class TestPIISafetyFilter:
-    """Tests for the safety-net logging filter that catches unmask'd PII."""
+class TestFormatterSafetyNet:
+    """Tests that formatters scrub PII from final output, including exception text."""
 
-    def test_scrubs_phone_in_message(self) -> None:
-        base = logging.getLogger("tac.test.safety_phone_msg")
-        with _FilteredCaplogContext(base) as records:
-            base.warning("Caller is +15559876543, please help")
+    def test_json_formatter_scrubs_phone_in_message(self) -> None:
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            "tac.test", logging.INFO, "", 0, "Calling +15559876543 now", (), None
+        )
+        output = formatter.format(record)
+        assert "+15559876543" not in output
+        assert "***" in output
 
-        assert len(records) == 1
-        msg = records[0].getMessage()
-        assert "+15559876543" not in msg
-        assert "***" in msg
+    def test_json_formatter_scrubs_email_in_message(self) -> None:
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            "tac.test", logging.INFO, "", 0, "Contact alice@example.com", (), None
+        )
+        output = formatter.format(record)
+        assert "alice@example.com" not in output
+        assert "***" in output
 
-    def test_scrubs_email_in_message(self) -> None:
-        base = logging.getLogger("tac.test.safety_email_msg")
-        with _FilteredCaplogContext(base) as records:
-            base.info("Contact alice@example.com for details")
+    def test_json_formatter_scrubs_phone_in_extra(self) -> None:
+        formatter = JSONFormatter()
+        record = logging.LogRecord("tac.test", logging.INFO, "", 0, "Outbound call", (), None)
+        record.to = "+447911123456"  # type: ignore[attr-defined]
+        output = formatter.format(record)
+        assert "+447911123456" not in output
+        assert "***" in output
 
-        assert len(records) == 1
-        msg = records[0].getMessage()
-        assert "alice@example.com" not in msg
-        assert "***" in msg
+    def test_json_formatter_scrubs_exception_text(self) -> None:
+        formatter = JSONFormatter()
+        try:
+            raise ValueError("No profile found for +15559876543")
+        except ValueError:
+            import sys
 
-    def test_scrubs_phone_in_extra_field(self) -> None:
-        base = logging.getLogger("tac.test.safety_phone_extra")
-        with _FilteredCaplogContext(base) as records:
-            base.info("Outbound call", extra={"to": "+447911123456"})
+            exc_info = sys.exc_info()
+        record = logging.LogRecord(
+            "tac.test", logging.ERROR, "", 0, "Profile lookup failed", (), exc_info
+        )
+        output = formatter.format(record)
+        assert "+15559876543" not in output
+        assert "***" in output
 
-        assert len(records) == 1
-        assert getattr(records[0], "to", None) == "***"
+    def test_console_formatter_scrubs_phone_in_message(self) -> None:
+        formatter = ConsoleFormatter(fmt="%(message)s")
+        record = logging.LogRecord(
+            "tac.test", logging.INFO, "", 0, "Calling +15559876543 now", (), None
+        )
+        output = formatter.format(record)
+        assert "+15559876543" not in output
+        assert "***" in output
 
-    def test_scrubs_email_in_extra_field(self) -> None:
-        base = logging.getLogger("tac.test.safety_email_extra")
-        with _FilteredCaplogContext(base) as records:
-            base.info("Sending message", extra={"address": "bob@corp.io"})
+    def test_console_formatter_scrubs_phone_in_extra(self) -> None:
+        formatter = ConsoleFormatter(fmt="%(message)s")
+        record = logging.LogRecord("tac.test", logging.INFO, "", 0, "Outbound call", (), None)
+        record.to = "+447911123456"  # type: ignore[attr-defined]
+        output = formatter.format(record)
+        assert "+447911123456" not in output
+        assert "***" in output
 
-        assert len(records) == 1
-        assert getattr(records[0], "address", None) == "***"
-
-    def test_passes_clean_messages_through(self) -> None:
-        base = logging.getLogger("tac.test.safety_clean")
-        with _FilteredCaplogContext(base) as records:
-            base.info("Conversation started", extra={"conversation_id": "conv_abc123"})
-
-        assert len(records) == 1
-        assert records[0].getMessage() == "Conversation started"
-        assert getattr(records[0], "conversation_id", None) == "conv_abc123"
-
-    def test_scrubs_phone_in_format_args(self) -> None:
-        base = logging.getLogger("tac.test.safety_phone_args")
-        with _FilteredCaplogContext(base) as records:
-            base.info("Calling %s now", "+15559876543")
-
-        assert len(records) == 1
-        assert "+15559876543" not in records[0].getMessage()
+    def test_formatters_pass_clean_messages_through(self) -> None:
+        for formatter in [JSONFormatter(), ConsoleFormatter(fmt="%(message)s")]:
+            record = logging.LogRecord(
+                "tac.test", logging.INFO, "", 0, "Conversation started", (), None
+            )
+            record.conversation_id = "conv_abc123"  # type: ignore[attr-defined]
+            output = formatter.format(record)
+            assert "Conversation started" in output
+            assert "conv_abc123" in output
 
 
-class _FilteredCaplogContext:
-    """Context manager that captures log records through a PIISafetyFilter."""
+class _RecordCapture:
+    """Context manager that captures LogRecords from a logger."""
 
     def __init__(self, logger: logging.Logger) -> None:
-        self._logger = logger
-        self._handler = logging.Handler()
-        self._filter = PIISafetyFilter()
-        self.records: list[logging.LogRecord] = []
-        self._handler.emit = self.records.append  # type: ignore[assignment]
-        self._handler.addFilter(self._filter)
-
-    def __enter__(self) -> list[logging.LogRecord]:
-        self._logger.addHandler(self._handler)
-        self._logger.setLevel(logging.DEBUG)
-        return self.records
-
-    def __exit__(self, *args: object) -> None:
-        self._logger.removeHandler(self._handler)
-
-
-class _CaplogContext:
-    """Minimal context manager that captures LogRecords from a specific logger."""
-
-    def __init__(self, logger: logging.Logger, _caplog: object) -> None:
         self._logger = logger
         self._handler = logging.Handler()
         self.records: list[logging.LogRecord] = []

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -177,6 +177,24 @@ class TestFormatterSafetyNet:
         assert "+447911123456" not in output
         assert "***" in output
 
+    def test_json_formatter_scrubs_domestic_phone(self) -> None:
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            "tac.test", logging.INFO, "", 0, "Calling 5551234567 now", (), None
+        )
+        output = formatter.format(record)
+        assert "5551234567" not in output
+        assert "***" in output
+
+    def test_json_formatter_scrubs_formatted_phone(self) -> None:
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            "tac.test", logging.INFO, "", 0, "Calling (555) 123-4567 now", (), None
+        )
+        output = formatter.format(record)
+        assert "(555) 123-4567" not in output
+        assert "***" in output
+
     def test_formatters_pass_clean_messages_through(self) -> None:
         for formatter in [JSONFormatter(), ConsoleFormatter(fmt="%(message)s")]:
             record = logging.LogRecord(
@@ -194,13 +212,16 @@ class _RecordCapture:
     def __init__(self, logger: logging.Logger) -> None:
         self._logger = logger
         self._handler = logging.Handler()
+        self._prev_level: int = logging.WARNING
         self.records: list[logging.LogRecord] = []
         self._handler.emit = self.records.append  # type: ignore[assignment]
 
     def __enter__(self) -> list[logging.LogRecord]:
+        self._prev_level = self._logger.level
         self._logger.addHandler(self._handler)
         self._logger.setLevel(logging.DEBUG)
         return self.records
 
     def __exit__(self, *args: object) -> None:
         self._logger.removeHandler(self._handler)
+        self._logger.setLevel(self._prev_level)

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,207 @@
+"""Tests for PII redaction utilities."""
+
+import logging
+
+from tac.core.logging import ContextLogger, PIISafetyFilter
+from tac.utils.redaction import mask_address, mask_email, mask_phone
+
+
+class TestMaskPhone:
+    def test_us_number(self) -> None:
+        assert mask_phone("+15551234567") == "+1***4567"
+
+    def test_international_number(self) -> None:
+        assert mask_phone("+447911123456") == "+4***3456"
+
+    def test_no_plus_prefix(self) -> None:
+        assert mask_phone("5551234567") == "55***4567"
+
+    def test_short_number(self) -> None:
+        assert mask_phone("+1234") == "***"
+
+    def test_empty(self) -> None:
+        assert mask_phone("") == "***"
+
+    def test_whitespace(self) -> None:
+        assert mask_phone("   ") == "***"
+
+    def test_seven_chars(self) -> None:
+        assert mask_phone("1234567") == "12***4567"
+
+
+class TestMaskEmail:
+    def test_basic(self) -> None:
+        assert mask_email("user@example.com") == "u***@example.com"
+
+    def test_single_char_local(self) -> None:
+        assert mask_email("a@b.com") == "a***@b.com"
+
+    def test_long_local(self) -> None:
+        assert mask_email("longuser@domain.co.uk") == "l***@domain.co.uk"
+
+    def test_empty(self) -> None:
+        assert mask_email("") == "***"
+
+    def test_no_at_sign(self) -> None:
+        assert mask_email("not-an-email") == "***"
+
+    def test_at_start(self) -> None:
+        assert mask_email("@example.com") == "***"
+
+
+class TestMaskAddress:
+    def test_detects_phone(self) -> None:
+        assert mask_address("+15551234567") == "+1***4567"
+
+    def test_detects_email(self) -> None:
+        assert mask_address("user@example.com") == "u***@example.com"
+
+    def test_phone_no_plus(self) -> None:
+        assert mask_address("5551234567") == "55***4567"
+
+    def test_empty(self) -> None:
+        assert mask_address("") == "***"
+
+    def test_whitespace(self) -> None:
+        assert mask_address("   ") == "***"
+
+
+class TestLogOutputRedaction:
+    """Integration tests: verify PII is masked in actual log output."""
+
+    def _capture_log(self, logger: ContextLogger, caplog: logging.Handler) -> None:
+        """Helper to attach caplog handler to the underlying logger."""
+        logger.logger.addHandler(caplog.handler)  # type: ignore[attr-defined]
+        logger.logger.setLevel(logging.DEBUG)
+
+    def test_phone_masked_in_log_message(self, caplog: object) -> None:
+        raw_phone = "+15551234567"
+        base = logging.getLogger("tac.test.redaction_phone")
+        ctx_logger = ContextLogger(base)
+
+        with _CaplogContext(base, caplog) as records:
+            ctx_logger.debug(f"No profile found for address {mask_address(raw_phone)}")
+
+        assert len(records) == 1
+        assert raw_phone not in records[0].getMessage()
+        assert "+1***4567" in records[0].getMessage()
+
+    def test_email_masked_in_log_message(self, caplog: object) -> None:
+        raw_email = "alice@example.com"
+        base = logging.getLogger("tac.test.redaction_email")
+        ctx_logger = ContextLogger(base)
+
+        with _CaplogContext(base, caplog) as records:
+            ctx_logger.info(f"Outbound conversation initiated to {mask_address(raw_email)}")
+
+        assert len(records) == 1
+        assert raw_email not in records[0].getMessage()
+        assert "a***@example.com" in records[0].getMessage()
+
+    def test_phone_masked_in_structured_extra(self, caplog: object) -> None:
+        raw_phone = "+447911123456"
+        base = logging.getLogger("tac.test.redaction_extra")
+        ctx_logger = ContextLogger(base)
+
+        with _CaplogContext(base, caplog) as records:
+            ctx_logger.info("Outbound voice call placed", to=mask_phone(raw_phone))
+
+        assert len(records) == 1
+        record = records[0]
+        assert raw_phone not in record.getMessage()
+        assert getattr(record, "to", None) == "+4***3456"
+
+
+class TestPIISafetyFilter:
+    """Tests for the safety-net logging filter that catches unmask'd PII."""
+
+    def test_scrubs_phone_in_message(self) -> None:
+        base = logging.getLogger("tac.test.safety_phone_msg")
+        with _FilteredCaplogContext(base) as records:
+            base.warning("Caller is +15559876543, please help")
+
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "+15559876543" not in msg
+        assert "***" in msg
+
+    def test_scrubs_email_in_message(self) -> None:
+        base = logging.getLogger("tac.test.safety_email_msg")
+        with _FilteredCaplogContext(base) as records:
+            base.info("Contact alice@example.com for details")
+
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "alice@example.com" not in msg
+        assert "***" in msg
+
+    def test_scrubs_phone_in_extra_field(self) -> None:
+        base = logging.getLogger("tac.test.safety_phone_extra")
+        with _FilteredCaplogContext(base) as records:
+            base.info("Outbound call", extra={"to": "+447911123456"})
+
+        assert len(records) == 1
+        assert getattr(records[0], "to", None) == "***"
+
+    def test_scrubs_email_in_extra_field(self) -> None:
+        base = logging.getLogger("tac.test.safety_email_extra")
+        with _FilteredCaplogContext(base) as records:
+            base.info("Sending message", extra={"address": "bob@corp.io"})
+
+        assert len(records) == 1
+        assert getattr(records[0], "address", None) == "***"
+
+    def test_passes_clean_messages_through(self) -> None:
+        base = logging.getLogger("tac.test.safety_clean")
+        with _FilteredCaplogContext(base) as records:
+            base.info("Conversation started", extra={"conversation_id": "conv_abc123"})
+
+        assert len(records) == 1
+        assert records[0].getMessage() == "Conversation started"
+        assert getattr(records[0], "conversation_id", None) == "conv_abc123"
+
+    def test_scrubs_phone_in_format_args(self) -> None:
+        base = logging.getLogger("tac.test.safety_phone_args")
+        with _FilteredCaplogContext(base) as records:
+            base.info("Calling %s now", "+15559876543")
+
+        assert len(records) == 1
+        assert "+15559876543" not in records[0].getMessage()
+
+
+class _FilteredCaplogContext:
+    """Context manager that captures log records through a PIISafetyFilter."""
+
+    def __init__(self, logger: logging.Logger) -> None:
+        self._logger = logger
+        self._handler = logging.Handler()
+        self._filter = PIISafetyFilter()
+        self.records: list[logging.LogRecord] = []
+        self._handler.emit = self.records.append  # type: ignore[assignment]
+        self._handler.addFilter(self._filter)
+
+    def __enter__(self) -> list[logging.LogRecord]:
+        self._logger.addHandler(self._handler)
+        self._logger.setLevel(logging.DEBUG)
+        return self.records
+
+    def __exit__(self, *args: object) -> None:
+        self._logger.removeHandler(self._handler)
+
+
+class _CaplogContext:
+    """Minimal context manager that captures LogRecords from a specific logger."""
+
+    def __init__(self, logger: logging.Logger, _caplog: object) -> None:
+        self._logger = logger
+        self._handler = logging.Handler()
+        self.records: list[logging.LogRecord] = []
+        self._handler.emit = self.records.append  # type: ignore[assignment]
+
+    def __enter__(self) -> list[logging.LogRecord]:
+        self._logger.addHandler(self._handler)
+        self._logger.setLevel(logging.DEBUG)
+        return self.records
+
+    def __exit__(self, *args: object) -> None:
+        self._logger.removeHandler(self._handler)


### PR DESCRIPTION
## Summary

Add PII redaction to SDK logging to prevent phone numbers and email addresses from appearing in plain text in log output.

**Two layers of defense:**
1. **Per-callsite `mask_phone` / `mask_email` / `mask_address`** utilities applied at 8 log statements that previously emitted raw PII. Produces a partial-reveal format for debugging context (e.g. `+1***4567`, `u***@example.com`).
2. **Formatter-level safety net** — `JSONFormatter` and `ConsoleFormatter` scrub any remaining phone/email patterns from the final output string. This catches PII a developer forgets to wrap in a `mask_*` call, without mutating the shared `LogRecord` (consumer-added handlers with their own formatters see the raw record).

Masking functions are exported from `tac` for SDK consumers to use in their own logging.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [x] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created:

🤖 Generated with [Claude Code](https://claude.com/claude-code)