### PR TITLE
feat: Relay-only mode (ConversationRelay voice without Conversation Orchestrator)

### DIFF
--- a/getting_started/examples/features/relay_only.py
+++ b/getting_started/examples/features/relay_only.py
@@ -11,7 +11,7 @@ Use this when you want TAC's voice plumbing (TwiML, WebSocket, callbacks) but
 are bringing your own memory/state layer.
 
 Env vars required:
-- TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN
+- TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_API_KEY, TWILIO_API_SECRET
 - TWILIO_PHONE_NUMBER
 - TWILIO_VOICE_PUBLIC_DOMAIN (ngrok or similar)
 - OPENAI_API_KEY

--- a/getting_started/examples/features/relay_only.py
+++ b/getting_started/examples/features/relay_only.py
@@ -1,0 +1,88 @@
+"""
+Example: Relay-only mode — pure ConversationRelay without Conversation Orchestrator.
+
+When `conversation_configuration_id` is omitted from TACConfig, TAC runs in
+ConversationRelay-only mode:
+- VoiceChannel works with ConversationRelay only (no CO session, no Memory).
+- Messaging channels (SMS, Chat, ...) fail at construction.
+- TAC.retrieve_memory returns an empty TACMemoryResponse.
+
+Use this when you want TAC's voice plumbing (TwiML, WebSocket, callbacks) but
+are bringing your own memory/state layer.
+
+Env vars required:
+- TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN
+- TWILIO_PHONE_NUMBER
+- TWILIO_VOICE_PUBLIC_DOMAIN (ngrok or similar)
+- OPENAI_API_KEY
+
+Env vars that should NOT be set for relay-only mode:
+- TWILIO_CONVERSATION_CONFIGURATION_ID
+"""
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from agents import Agent, Runner, set_tracing_disabled
+from dotenv import load_dotenv
+
+from tac import TAC, TACConfig
+from tac.channels.voice import VoiceChannel
+from tac.models.session import ConversationSession
+from tac.models.tac import TACMemoryResponse
+from tac.server import TACFastAPIServer
+
+load_dotenv()
+set_tracing_disabled(True)
+
+# No conversation_configuration_id — TAC runs in relay-only mode.
+tac = TAC(config=TACConfig.from_env())
+assert not tac.is_orchestrator_enabled(), (
+    "This example expects relay-only mode — unset TWILIO_CONVERSATION_CONFIGURATION_ID."
+)
+
+voice_channel = VoiceChannel(tac)
+
+SYSTEM_INSTRUCTIONS = (
+    "You are a voice assistant speaking with a user over the phone. "
+    "Keep responses short and conversational — a sentence or two. "
+    "Do not use markdown, asterisks, bullets, or emojis; your words will be "
+    "spoken aloud."
+)
+
+agent = Agent(name="Voice Assistant", instructions=SYSTEM_INSTRUCTIONS)
+
+conversation_history: dict[str, list[Any]] = {}
+
+
+async def handle_message_ready(
+    user_message: str,
+    context: ConversationSession,
+    memory_response: TACMemoryResponse | None,
+) -> None:
+    """Stream voice responses through the OpenAI Agents SDK.
+
+    Returns None and manually calls send_response() with an async generator
+    so tokens are sent to the caller as they arrive from the LLM.
+    """
+    conv_id = context.conversation_id
+
+    history = conversation_history.get(conv_id, [])
+    agent_input = history + [{"role": "user", "content": user_message}]
+
+    async def stream_tokens() -> AsyncGenerator[str, None]:
+        result = Runner.run_streamed(agent, agent_input)
+        async for event in result.stream_events():
+            if event.type == "raw_response_event" and hasattr(event.data, "delta"):
+                yield event.data.delta
+        conversation_history[conv_id] = result.to_input_list()
+
+    await voice_channel.send_response(conv_id, stream_tokens())
+
+
+tac.on_message_ready(handle_message_ready)
+
+
+if __name__ == "__main__":
+    server = TACFastAPIServer(tac=tac, voice_channel=voice_channel)
+    server.start()

--- a/getting_started/examples/features/relay_only.py
+++ b/getting_started/examples/features/relay_only.py
@@ -83,6 +83,13 @@ async def handle_message_ready(
 tac.on_message_ready(handle_message_ready)
 
 
+async def handle_conversation_ended(context: ConversationSession) -> None:
+    conversation_history.pop(context.conversation_id, None)
+
+
+tac.on_conversation_ended(handle_conversation_ended)
+
+
 if __name__ == "__main__":
     server = TACFastAPIServer(tac=tac, voice_channel=voice_channel)
     server.start()

--- a/src/tac/channels/chat.py
+++ b/src/tac/channels/chat.py
@@ -117,7 +117,7 @@ class ChatChannel(MessagingChannel):
             )
 
         try:
-            participants = await self.tac.conversation_orchestrator_client.list_participants(
+            participants = await self.conversation_orchestrator_client.list_participants(
                 conversation_id
             )
         except Exception as e:
@@ -175,7 +175,7 @@ class ChatChannel(MessagingChannel):
                 ),
             )
 
-            await self.tac.conversation_orchestrator_client.create_action(
+            await self.conversation_orchestrator_client.create_action(
                 conversation_id, action_request
             )
 

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from tac import TAC
 from tac.channels.base import BaseChannel
+from tac.context.conversation import ConversationClient
 from tac.models.conversation import (
     ActionChannelSettings,
     ActionParticipantRef,
@@ -66,6 +67,14 @@ class MessagingChannel(BaseChannel):
         dedup_capacity: int = 10000,
         auto_retrieve_memory: bool = False,
     ):
+        if tac.conversation_orchestrator_client is None:
+            raise ValueError(
+                f"{type(self).__name__} requires Conversation Orchestrator to be configured. "
+                "Set `conversation_configuration_id` on TACConfig to enable messaging channels."
+            )
+        self.conversation_orchestrator_client: ConversationClient = (
+            tac.conversation_orchestrator_client
+        )
         super().__init__(
             tac, auto_retrieve_memory=auto_retrieve_memory, dedup_capacity=dedup_capacity
         )
@@ -111,7 +120,7 @@ class MessagingChannel(BaseChannel):
 
         if author_participant_id:
             try:
-                participants = await self.tac.conversation_orchestrator_client.list_participants(
+                participants = await self.conversation_orchestrator_client.list_participants(
                     conversation_id
                 )
                 author_p = next((p for p in participants if p.id == author_participant_id), None)
@@ -311,7 +320,7 @@ class MessagingChannel(BaseChannel):
             (
                 conversation_id,
                 reused,
-            ) = await self.tac.conversation_orchestrator_client.create_or_reuse_conversation(
+            ) = await self.conversation_orchestrator_client.create_or_reuse_conversation(
                 participants=[
                     ParticipantRequest(
                         type="CUSTOMER",
@@ -336,7 +345,7 @@ class MessagingChannel(BaseChannel):
                 ]
             )
 
-            participants = await self.tac.conversation_orchestrator_client.list_participants(
+            participants = await self.conversation_orchestrator_client.list_participants(
                 conversation_id
             )
 
@@ -395,7 +404,7 @@ class MessagingChannel(BaseChannel):
                     channel_settings=channel_settings,
                 ),
             )
-            await self.tac.conversation_orchestrator_client.create_action(
+            await self.conversation_orchestrator_client.create_action(
                 conversation_id, action_request
             )
 
@@ -411,7 +420,7 @@ class MessagingChannel(BaseChannel):
                 self._conversations.pop(conversation_id, None)
             if conversation_id and not reused:
                 try:
-                    await self.tac.conversation_orchestrator_client.update_conversation(
+                    await self.conversation_orchestrator_client.update_conversation(
                         conversation_id, "CLOSED"
                     )
                 except Exception as close_err:
@@ -456,7 +465,7 @@ class MessagingChannel(BaseChannel):
             address=agent_address.address,
         )
         try:
-            agent = await self.tac.conversation_orchestrator_client.add_participant(
+            agent = await self.conversation_orchestrator_client.add_participant(
                 conversation_id,
                 addresses=[agent_address],
                 participant_type="AI_AGENT",
@@ -478,9 +487,7 @@ class MessagingChannel(BaseChannel):
             )
 
         try:
-            retried = await self.tac.conversation_orchestrator_client.list_participants(
-                conversation_id
-            )
+            retried = await self.conversation_orchestrator_client.list_participants(conversation_id)
         except Exception as e:
             self.logger.error(
                 "Failed to retry listing participants",

--- a/src/tac/channels/sms.py
+++ b/src/tac/channels/sms.py
@@ -93,7 +93,7 @@ class SMSChannel(MessagingChannel):
             raise TypeError("SMS channel only supports string responses")
 
         try:
-            participants = await self.tac.conversation_orchestrator_client.list_participants(
+            participants = await self.conversation_orchestrator_client.list_participants(
                 conversation_id
             )
         except Exception as e:
@@ -167,7 +167,7 @@ class SMSChannel(MessagingChannel):
                 ),
             )
 
-            await self.tac.conversation_orchestrator_client.create_action(
+            await self.conversation_orchestrator_client.create_action(
                 conversation_id, action_request
             )
 

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -161,6 +161,14 @@ class VoiceChannel(BaseChannel):
             )
             return
 
+        if payload.account_sid != self.tac.config.account_sid:
+            self.logger.warning(
+                "ConversationRelay callback account_sid mismatch, ignoring",
+                expected=self.tac.config.account_sid,
+                received=payload.account_sid,
+            )
+            return
+
         self.logger.info(
             "ConversationRelay callback received",
             call_sid=payload.call_sid,

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -87,8 +87,6 @@ class VoiceChannel(BaseChannel):
         if self._twilio_client is None:
             from twilio.rest import Client
 
-            if not self.tac.config.api_key or not self.tac.config.api_secret:
-                raise RuntimeError("Outbound calls require api_key and api_secret in TACConfig.")
             self._twilio_client = Client(
                 self.tac.config.api_key,
                 self.tac.config.api_secret,

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -15,6 +15,7 @@ from tac.core.tac import TAC
 from tac.models.outbound import InitiateVoiceConversationOptions, InitiateVoiceConversationResult
 from tac.models.session import AuthorInfo
 from tac.models.voice import (
+    ConversationRelayCallbackPayload,
     InterruptMessage,
     PromptMessage,
     SetupMessage,
@@ -77,6 +78,8 @@ class VoiceChannel(BaseChannel):
         if self._twilio_client is None:
             from twilio.rest import Client
 
+            if not self.tac.config.api_key or not self.tac.config.api_secret:
+                raise RuntimeError("Outbound calls require api_key and api_secret in TACConfig.")
             self._twilio_client = Client(
                 self.tac.config.api_key,
                 self.tac.config.api_secret,
@@ -133,6 +136,31 @@ class VoiceChannel(BaseChannel):
             )
         )
 
+    async def handle_conversation_relay_callback(
+        self,
+        payload_dict: dict[str, str],
+    ) -> None:
+        """Handle ConversationRelay callback webhook from Twilio.
+
+        In relay-only mode, this is the primary mechanism for cleaning up
+        conversation state when a call ends. In orchestrated mode, conversation
+        lifecycle is managed by CO webhooks, so this is a no-op.
+
+        Args:
+            payload_dict: Raw form data dict from the webhook request.
+        """
+        payload = ConversationRelayCallbackPayload(**payload_dict)
+
+        self.logger.info(
+            "ConversationRelay callback received",
+            call_sid=payload.call_sid,
+            call_status=payload.call_status,
+        )
+
+        if payload.call_status == "completed" and not self.tac.is_orchestrator_enabled():
+            if payload.call_sid in self._conversations:
+                await self._end_conversation(payload.call_sid)
+
     async def _initialize_conversation(
         self,
         call_sid: str,
@@ -141,9 +169,13 @@ class VoiceChannel(BaseChannel):
     ) -> tuple[str, SessionState | None]:
         """Poll CO for the conversation created by ConversationRelay, resolve
         the customer participant, and initialize the local session."""
+        co_client = self.tac.conversation_orchestrator_client
+        if co_client is None:
+            raise RuntimeError("_initialize_conversation called without Conversation Orchestrator")
+
         conversations: list[Any] = []
         for attempt in range(_POLL_ATTEMPTS):
-            conversations = await self.tac.conversation_orchestrator_client.list_conversations(
+            conversations = await co_client.list_conversations(
                 channel_id=call_sid,
                 status=["ACTIVE"],
             )
@@ -169,7 +201,7 @@ class VoiceChannel(BaseChannel):
         conversation = conversations[0]
         conv_id = conversation.id
 
-        participants = await self.tac.conversation_orchestrator_client.list_participants(conv_id)
+        participants = await co_client.list_participants(conv_id)
 
         customer_participant = next(
             (p for p in participants if p.type == "CUSTOMER"),
@@ -239,9 +271,30 @@ class VoiceChannel(BaseChannel):
 
                     if msg_type == "prompt":
                         if not conv_id and call_sid:
-                            conv_id, session_state = await self._initialize_conversation(
-                                call_sid, setup_msg, websocket
-                            )
+                            if self.tac.is_orchestrator_enabled():
+                                conv_id, session_state = await self._initialize_conversation(
+                                    call_sid, setup_msg, websocket
+                                )
+                            else:
+                                conv_id = call_sid
+                                self._websocket_manager.add_websocket(conv_id, websocket)
+                                self._start_conversation(conv_id, profile_id=None)
+
+                                from_number = (
+                                    setup_msg.to_number
+                                    if setup_msg.direction
+                                    and setup_msg.direction.upper() == "OUTBOUND"
+                                    else setup_msg.from_number
+                                )
+                                if from_number:
+                                    self._conversations[conv_id].author_info = AuthorInfo(
+                                        address=from_number,
+                                    )
+
+                                if self.session_manager is not None:
+                                    session_state = self.session_manager.get_or_create_session(
+                                        conv_id
+                                    )
 
                         if conv_id:
                             await self._handle_prompt_async(conv_id, data, session_state)

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -142,14 +142,24 @@ class VoiceChannel(BaseChannel):
     ) -> None:
         """Handle ConversationRelay callback webhook from Twilio.
 
-        In relay-only mode, this is the primary mechanism for cleaning up
-        conversation state when a call ends. In orchestrated mode, conversation
-        lifecycle is managed by CO webhooks, so this is a no-op.
+        In relay-only mode, this is a secondary mechanism for cleaning up
+        conversation state when a call ends (the primary mechanism is websocket
+        disconnect). In orchestrated mode, conversation lifecycle is managed by
+        CO webhooks, so this is a no-op.
 
         Args:
             payload_dict: Raw form data dict from the webhook request.
         """
-        payload = ConversationRelayCallbackPayload(**payload_dict)
+        from pydantic import ValidationError
+
+        try:
+            payload = ConversationRelayCallbackPayload(**payload_dict)
+        except ValidationError:
+            self.logger.warning(
+                "Invalid ConversationRelay callback payload, ignoring",
+                payload_keys=list(payload_dict.keys()),
+            )
+            return
 
         self.logger.info(
             "ConversationRelay callback received",
@@ -169,13 +179,13 @@ class VoiceChannel(BaseChannel):
     ) -> tuple[str, SessionState | None]:
         """Poll CO for the conversation created by ConversationRelay, resolve
         the customer participant, and initialize the local session."""
-        co_client = self.tac.conversation_orchestrator_client
-        if co_client is None:
+        conversation_orchestrator_client = self.tac.conversation_orchestrator_client
+        if conversation_orchestrator_client is None:
             raise RuntimeError("_initialize_conversation called without Conversation Orchestrator")
 
         conversations: list[Any] = []
         for attempt in range(_POLL_ATTEMPTS):
-            conversations = await co_client.list_conversations(
+            conversations = await conversation_orchestrator_client.list_conversations(
                 channel_id=call_sid,
                 status=["ACTIVE"],
             )
@@ -201,7 +211,7 @@ class VoiceChannel(BaseChannel):
         conversation = conversations[0]
         conv_id = conversation.id
 
-        participants = await co_client.list_participants(conv_id)
+        participants = await conversation_orchestrator_client.list_participants(conv_id)
 
         customer_participant = next(
             (p for p in participants if p.type == "CUSTOMER"),
@@ -684,9 +694,10 @@ class VoiceChannel(BaseChannel):
         """
         Clean up WebSocket and session resources when connection closes.
 
-        Note: Does NOT clean up conversation state. The conversation remains tracked
-        in self._conversations until we receive CONVERSATION_UPDATED webhook with
-        CLOSED status from Maestro.
+        In orchestrated mode, the conversation remains tracked in
+        self._conversations until the CONVERSATION_UPDATED/CLOSED webhook
+        arrives from Maestro. In relay-only mode there is no such webhook,
+        so we also end the conversation here.
 
         Args:
             conv_id: Conversation ID
@@ -701,6 +712,9 @@ class VoiceChannel(BaseChannel):
             # Cancel any running task (user hung up, no point continuing)
             await session_state.cancel_stream_task()
             self.session_manager.remove_session(conv_id)
+
+        if not self.tac.is_orchestrator_enabled() and conv_id in self._conversations:
+            await self._end_conversation(conv_id)
 
         self.logger.debug(
             "Cleaned up WebSocket and session resources",

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from twilio.rest import Client
 
+from pydantic import ValidationError
+
 from tac.channels.base import BaseChannel
 from tac.channels.websocket_manager import WebSocketManager
 from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
@@ -150,8 +152,6 @@ class VoiceChannel(BaseChannel):
         Args:
             payload_dict: Raw form data dict from the webhook request.
         """
-        from pydantic import ValidationError
-
         try:
             payload = ConversationRelayCallbackPayload(**payload_dict)
         except ValidationError:

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -76,6 +76,13 @@ class VoiceChannel(BaseChannel):
         self._websocket_manager = WebSocketManager()
         self._twilio_client: Client | None = None
 
+    @staticmethod
+    def _caller_address(setup_msg: SetupMessage) -> str | None:
+        """Return the phone number of the remote caller/callee from the setup message."""
+        if setup_msg.direction and setup_msg.direction.upper() == "OUTBOUND":
+            return setup_msg.to_number
+        return setup_msg.from_number
+
     def _get_twilio_client(self) -> Client:
         if self._twilio_client is None:
             from twilio.rest import Client
@@ -169,7 +176,7 @@ class VoiceChannel(BaseChannel):
             )
             return
 
-        self.logger.info(
+        self.logger.debug(
             "ConversationRelay callback received",
             call_sid=payload.call_sid,
             call_status=payload.call_status,
@@ -233,12 +240,7 @@ class VoiceChannel(BaseChannel):
             if customer_participant and customer_participant.addresses
             else None
         )
-        fallback_address = (
-            setup_msg.to_number
-            if setup_msg.direction and setup_msg.direction.upper() == "OUTBOUND"
-            else setup_msg.from_number
-        )
-        profile_lookup_address = customer_address or fallback_address
+        profile_lookup_address = customer_address or self._caller_address(setup_msg)
         profile_id = customer_participant.profile_id if customer_participant else None
 
         self._websocket_manager.add_websocket(conv_id, websocket)
@@ -298,15 +300,10 @@ class VoiceChannel(BaseChannel):
                                 self._websocket_manager.add_websocket(conv_id, websocket)
                                 self._start_conversation(conv_id, profile_id=None)
 
-                                from_number = (
-                                    setup_msg.to_number
-                                    if setup_msg.direction
-                                    and setup_msg.direction.upper() == "OUTBOUND"
-                                    else setup_msg.from_number
-                                )
-                                if from_number:
+                                caller = self._caller_address(setup_msg)
+                                if caller:
                                     self._conversations[conv_id].author_info = AuthorInfo(
-                                        address=from_number,
+                                        address=caller,
                                     )
 
                                 if self.session_manager is not None:

--- a/src/tac/core/config.py
+++ b/src/tac/core/config.py
@@ -196,14 +196,8 @@ class TACConfig(BaseModel):
 
     account_sid: str = Field(description="Twilio Account SID")
     auth_token: str = Field(description="Twilio Auth Token")
-    api_key: str | None = Field(
-        default=None,
-        description="Twilio API Key SID (starts with SK)",
-    )
-    api_secret: str | None = Field(
-        default=None,
-        description="Twilio API Key Secret",
-    )
+    api_key: str = Field(description="Twilio API Key SID (starts with SK)")
+    api_secret: str = Field(description="Twilio API Key Secret")
 
     region: str | None = Field(
         default=None,
@@ -288,13 +282,13 @@ class TACConfig(BaseModel):
         Required:
         - TWILIO_ACCOUNT_SID: Twilio Account SID
         - TWILIO_AUTH_TOKEN: Twilio Auth Token for API authentication
+        - TWILIO_API_KEY: Twilio API Key SID (starts with SK)
+        - TWILIO_API_SECRET: Twilio API Secret for API Key authentication
         - TWILIO_PHONE_NUMBER: Phone number for voice and SMS channels
 
         Required for Conversation Orchestrator / Memory / Knowledge:
         - TWILIO_CONVERSATION_CONFIGURATION_ID: Conversation Orchestrator configuration ID
           (when omitted, TAC runs in ConversationRelay-only mode)
-        - TWILIO_API_KEY: Twilio API Key SID (starts with SK)
-        - TWILIO_API_SECRET: Twilio API Secret for API Key authentication
 
         Optional:
         - TWILIO_KNOWLEDGE_BASE_ID: Knowledge Base ID for RAG search functionality
@@ -331,8 +325,8 @@ class TACConfig(BaseModel):
             conversation_configuration_id=os.environ.get("TWILIO_CONVERSATION_CONFIGURATION_ID"),
             account_sid=os.environ["TWILIO_ACCOUNT_SID"],
             auth_token=os.environ["TWILIO_AUTH_TOKEN"],
-            api_key=os.environ.get("TWILIO_API_KEY"),
-            api_secret=os.environ.get("TWILIO_API_SECRET"),
+            api_key=os.environ["TWILIO_API_KEY"],
+            api_secret=os.environ["TWILIO_API_SECRET"],
             phone_number=os.environ["TWILIO_PHONE_NUMBER"],
             knowledge_base_id=os.environ.get("TWILIO_KNOWLEDGE_BASE_ID"),
             log_level=os.environ.get("TWILIO_LOG_LEVEL", "INFO"),

--- a/src/tac/core/config.py
+++ b/src/tac/core/config.py
@@ -177,7 +177,15 @@ class TwilioMemoryConfig(BaseModel):
 class TACConfig(BaseModel):
     """Configuration model for Twilio Agent Connect settings."""
 
-    conversation_configuration_id: str = Field(description="Twilio Conversation Configuration ID")
+    conversation_configuration_id: str | None = Field(
+        default=None,
+        description=(
+            "Twilio Conversation Configuration ID. When omitted, TAC runs in "
+            "ConversationRelay-only mode: only the Voice channel is usable, "
+            "messaging channels cannot be constructed, and "
+            "TAC.retrieve_memory() returns an empty TACMemoryResponse."
+        ),
+    )
 
     memory_config: TwilioMemoryConfig = Field(
         default_factory=TwilioMemoryConfig,
@@ -188,8 +196,14 @@ class TACConfig(BaseModel):
 
     account_sid: str = Field(description="Twilio Account SID")
     auth_token: str = Field(description="Twilio Auth Token")
-    api_key: str = Field(description="Twilio API Key SID (starts with SK)")
-    api_secret: str = Field(description="Twilio API Key Secret")
+    api_key: str | None = Field(
+        default=None,
+        description="Twilio API Key SID (starts with SK)",
+    )
+    api_secret: str | None = Field(
+        default=None,
+        description="Twilio API Key Secret",
+    )
 
     region: str | None = Field(
         default=None,
@@ -272,12 +286,15 @@ class TACConfig(BaseModel):
         Create TACConfig from environment variables.
 
         Required:
-        - TWILIO_CONVERSATION_CONFIGURATION_ID: Conversation Orchestrator configuration ID
         - TWILIO_ACCOUNT_SID: Twilio Account SID
         - TWILIO_AUTH_TOKEN: Twilio Auth Token for API authentication
+        - TWILIO_PHONE_NUMBER: Phone number for voice and SMS channels
+
+        Required for Conversation Orchestrator / Memory / Knowledge:
+        - TWILIO_CONVERSATION_CONFIGURATION_ID: Conversation Orchestrator configuration ID
+          (when omitted, TAC runs in ConversationRelay-only mode)
         - TWILIO_API_KEY: Twilio API Key SID (starts with SK)
         - TWILIO_API_SECRET: Twilio API Secret for API Key authentication
-        - TWILIO_PHONE_NUMBER: Phone number for voice and SMS channels
 
         Optional:
         - TWILIO_KNOWLEDGE_BASE_ID: Knowledge Base ID for RAG search functionality
@@ -311,11 +328,11 @@ class TACConfig(BaseModel):
         conversation_intelligence_config = ConversationIntelligenceConfig.from_env()
 
         return cls(
-            conversation_configuration_id=os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"],
+            conversation_configuration_id=os.environ.get("TWILIO_CONVERSATION_CONFIGURATION_ID"),
             account_sid=os.environ["TWILIO_ACCOUNT_SID"],
             auth_token=os.environ["TWILIO_AUTH_TOKEN"],
-            api_key=os.environ["TWILIO_API_KEY"],
-            api_secret=os.environ["TWILIO_API_SECRET"],
+            api_key=os.environ.get("TWILIO_API_KEY"),
+            api_secret=os.environ.get("TWILIO_API_SECRET"),
             phone_number=os.environ["TWILIO_PHONE_NUMBER"],
             knowledge_base_id=os.environ.get("TWILIO_KNOWLEDGE_BASE_ID"),
             log_level=os.environ.get("TWILIO_LOG_LEVEL", "INFO"),

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -44,48 +44,73 @@ class TAC:
         setup_logging(log_level=self.config.log_level, log_format="console")
         self.logger = get_logger(__name__)
 
-        self.conversation_orchestrator_client = ConversationClient(
-            api_key=self.config.api_key,
-            api_secret=self.config.api_secret,
-            configuration_id=self.config.conversation_configuration_id,
-            region=self.config.region,
-        )
+        self.conversation_orchestrator_client: ConversationClient | None = None
+        self.conversation_memory_client: MemoryClient | None = None
+        self.conversations_v1_service_sid: str | None = None
 
-        try:
-            configuration = self.conversation_orchestrator_client.get_configuration(
-                self.config.conversation_configuration_id
+        if self.config.conversation_configuration_id:
+            if not self.config.api_key or not self.config.api_secret:
+                raise ValueError(
+                    "api_key and api_secret are required when conversation_configuration_id "
+                    "is set. Omit conversation_configuration_id for ConversationRelay-only mode."
+                )
+
+            self.conversation_orchestrator_client = ConversationClient(
+                api_key=self.config.api_key,
+                api_secret=self.config.api_secret,
+                configuration_id=self.config.conversation_configuration_id,
+                region=self.config.region,
             )
-        except Exception as e:
-            raise ValueError(
-                f"Failed to fetch Conversation Orchestrator configuration: {e}. "
-                "TAC initialization requires a valid Conversation Orchestrator configuration. "
-                "Please check your conversation_configuration_id and credentials."
-            ) from e
 
-        # TODO(maestro): Remove once the Actions API resolves the V1 Chat service SID
-        # server-side. Maestro team confirmed this should not be required client-side;
-        # until they ship the fix, CHAT sends fail with
-        #   "chatService attribute is required for CHAT channel"
-        # unless we pass it on channelSettings.chatService. We source it from the
-        # Configuration's conversationsV1Bridge since the inbound webhook's serviceId
-        # is the literal "unused" for CHAT. When the server-side fix lands, drop this
-        # attribute plus ActionChannelSettings.chat_service and the chat channel's
-        # chat_service_sid plumbing.
-        self.conversations_v1_service_sid: str | None = (
-            configuration.conversations_v1_bridge.service_id
-            if configuration.conversations_v1_bridge
-            else None
-        )
+            try:
+                configuration = self.conversation_orchestrator_client.get_configuration(
+                    self.config.conversation_configuration_id
+                )
+            except Exception as e:
+                raise ValueError(
+                    f"Failed to fetch Conversation Orchestrator configuration: {e}. "
+                    "Please check your conversation_configuration_id and credentials, or "
+                    "omit conversation_configuration_id to run in ConversationRelay-only mode."
+                ) from e
 
-        self.conversation_memory_client = MemoryClient(
-            store_id=configuration.memory_store_id,
-            api_key=self.config.api_key,
-            api_secret=self.config.api_secret,
-            region=self.config.region,
-        )
+            # TODO(maestro): Remove once the Actions API resolves the V1 Chat service SID
+            # server-side. Maestro team confirmed this should not be required client-side;
+            # until they ship the fix, CHAT sends fail with
+            #   "chatService attribute is required for CHAT channel"
+            # unless we pass it on channelSettings.chatService. We source it from the
+            # Configuration's conversationsV1Bridge since the inbound webhook's serviceId
+            # is the literal "unused" for CHAT. When the server-side fix lands, drop this
+            # attribute plus ActionChannelSettings.chat_service and the chat channel's
+            # chat_service_sid plumbing.
+            self.conversations_v1_service_sid = (
+                configuration.conversations_v1_bridge.service_id
+                if configuration.conversations_v1_bridge
+                else None
+            )
+
+            self.conversation_memory_client = MemoryClient(
+                store_id=configuration.memory_store_id,
+                api_key=self.config.api_key,
+                api_secret=self.config.api_secret,
+                region=self.config.region,
+            )
+            self.logger.info(
+                "TAC initialized with Conversation Orchestrator and Memory",
+                configuration_id=self.config.conversation_configuration_id,
+            )
+        else:
+            self.logger.info(
+                "TAC initialized in ConversationRelay-only mode "
+                "(no conversation_configuration_id). Only the Voice channel is usable; "
+                "messaging and Memory features are disabled."
+            )
 
         self.knowledge_client: KnowledgeClient | None = None
         if self.config.knowledge_base_id:
+            if not self.config.api_key or not self.config.api_secret:
+                raise ValueError(
+                    "api_key and api_secret are required when knowledge_base_id is set."
+                )
             self.knowledge_client = KnowledgeClient(
                 api_key=self.config.api_key,
                 api_secret=self.config.api_secret,
@@ -94,6 +119,12 @@ class TAC:
 
         self.ci_processor: OperatorResultProcessor | None = None
         if self.config.conversation_intelligence_config:
+            if self.conversation_memory_client is None:
+                raise ValueError(
+                    "conversation_intelligence_config requires Conversation Orchestrator to be "
+                    "configured (set conversation_configuration_id). CI observations/summaries "
+                    "are written via the Memory API."
+                )
             self.ci_processor = OperatorResultProcessor(
                 conversation_memory_client=self.conversation_memory_client,
                 config=self.config.conversation_intelligence_config,
@@ -118,12 +149,21 @@ class TAC:
             | None
         ) = None
 
+    def is_orchestrator_enabled(self) -> bool:
+        """True if TAC is configured with Conversation Orchestrator (not relay-only mode)."""
+        return self.conversation_orchestrator_client is not None
+
     async def retrieve_memory(
         self,
         conversation_context: ConversationSession,
         query: str | None = None,
     ) -> TACMemoryResponse:
         """Retrieve memories from Memory Store with fallback to Conversation Orchestrator.
+
+        Three-tier resolution:
+        1. Memory API (when conversation_memory_client is configured).
+        2. Conversation Orchestrator list_communications fallback (when CO is configured).
+        3. Empty TACMemoryResponse (relay-only mode).
 
         Args:
             conversation_context: Session containing conversation and profile information.
@@ -132,6 +172,15 @@ class TAC:
         Returns:
             Memory response containing conversation history and profile data.
         """
+        if self.conversation_memory_client is None:
+            if self.conversation_orchestrator_client is not None:
+                communications = await self.conversation_orchestrator_client.list_communications(
+                    conversation_id=conversation_context.conversation_id
+                )
+                return TACMemoryResponse(communications)
+            self.logger.debug("Memory retrieval skipped (relay-only mode)")
+            return TACMemoryResponse([])
+
         try:
             if not conversation_context.profile_id:
                 self.logger.debug(
@@ -190,6 +239,12 @@ class TAC:
             return TACMemoryResponse(memory_response)
 
         except Exception as e:
+            if self.conversation_orchestrator_client is None:
+                self.logger.warning(
+                    f"Memory retrieval failed: {e}. No Conversation Orchestrator fallback "
+                    "available; returning empty memory."
+                )
+                return TACMemoryResponse([])
             self.logger.warning(
                 f"Memory retrieval failed: {e}. "
                 "Falling back to Conversation Orchestrator Communications API."

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -49,12 +49,6 @@ class TAC:
         self.conversations_v1_service_sid: str | None = None
 
         if self.config.conversation_configuration_id:
-            if not self.config.api_key or not self.config.api_secret:
-                raise ValueError(
-                    "api_key and api_secret are required when conversation_configuration_id "
-                    "is set. Omit conversation_configuration_id for ConversationRelay-only mode."
-                )
-
             self.conversation_orchestrator_client = ConversationClient(
                 api_key=self.config.api_key,
                 api_secret=self.config.api_secret,
@@ -107,10 +101,6 @@ class TAC:
 
         self.knowledge_client: KnowledgeClient | None = None
         if self.config.knowledge_base_id:
-            if not self.config.api_key or not self.config.api_secret:
-                raise ValueError(
-                    "api_key and api_secret are required when knowledge_base_id is set."
-                )
             self.knowledge_client = KnowledgeClient(
                 api_key=self.config.api_key,
                 api_secret=self.config.api_secret,

--- a/src/tac/models/voice.py
+++ b/src/tac/models/voice.py
@@ -118,3 +118,24 @@ class TwiMLOptions(BaseModel):
     )
 
     model_config = {"populate_by_name": True}
+
+
+class ConversationRelayCallbackPayload(BaseModel):
+    """Payload received from Twilio ConversationRelay callback webhook.
+
+    Sent via the <Connect action="..."> URL when a call ends or transitions state.
+    Used in relay-only mode to signal conversation completion.
+    """
+
+    account_sid: str = Field(..., alias="AccountSid")
+    call_sid: str = Field(..., alias="CallSid")
+    call_status: str = Field(..., alias="CallStatus")
+    from_number: str = Field(..., alias="From")
+    to_number: str = Field(..., alias="To")
+    direction: str = Field(..., alias="Direction")
+    application_sid: str | None = Field(None, alias="ApplicationSid")
+    session_id: str | None = Field(None, alias="SessionId")
+    session_status: str | None = Field(None, alias="SessionStatus")
+    session_duration: str | None = Field(None, alias="SessionDuration")
+
+    model_config = {"populate_by_name": True}

--- a/src/tac/server/config.py
+++ b/src/tac/server/config.py
@@ -27,6 +27,10 @@ class TACServerConfig(BaseModel):
     )
     twiml_path: str = Field(default="/twiml", description="Path for TwiML generation endpoint")
     websocket_path: str = Field(default="/ws", description="Path for voice WebSocket endpoint")
+    conversation_relay_callback_path: str = Field(
+        default="/conversation-relay-callback",
+        description="Path for ConversationRelay action callback endpoint",
+    )
     cintel_webhook_path: str | None = Field(
         default=None,
         description="Path for Conversation Intelligence webhook endpoint. "

--- a/src/tac/server/fastapi_server.py
+++ b/src/tac/server/fastapi_server.py
@@ -189,6 +189,10 @@ class TACFastAPIServer:
                         self.tac.config.account_sid,
                         self.tac.config.studio_handoff_flow_sid,
                     )
+                elif not self.tac.is_orchestrator_enabled():
+                    action_url = (
+                        f"https://{config.public_domain}{config.conversation_relay_callback_path}"
+                    )
                 else:
                     action_url = None
 
@@ -206,6 +210,14 @@ class TACFastAPIServer:
                 """Handle voice WebSocket connections."""
                 adapter = FastAPIWebSocketAdapter(websocket)
                 await vc.handle_websocket(adapter)
+
+            @app.post(config.conversation_relay_callback_path)
+            async def conversation_relay_callback(request: Request) -> Response:
+                """Handle ConversationRelay action callback (call ended)."""
+                form_data = await request.form()
+                payload_dict = {k: str(v) for k, v in form_data.items()}
+                await vc.handle_conversation_relay_callback(payload_dict)
+                return Response(content="", media_type="text/plain", status_code=200)
 
         if config.cintel_webhook_path is not None:
             tac = self.tac

--- a/src/tac/server/fastapi_server.py
+++ b/src/tac/server/fastapi_server.py
@@ -214,9 +214,13 @@ class TACFastAPIServer:
             @app.post(config.conversation_relay_callback_path)
             async def conversation_relay_callback(request: Request) -> Response:
                 """Handle ConversationRelay action callback (call ended)."""
-                form_data = await request.form()
-                payload_dict = {k: str(v) for k, v in form_data.items()}
-                await vc.handle_conversation_relay_callback(payload_dict)
+                try:
+                    form_data = await request.form()
+                    payload_dict = {k: str(v) for k, v in form_data.items()}
+                    await vc.handle_conversation_relay_callback(payload_dict)
+                except Exception:
+                    logger.error("Failed to process ConversationRelay callback", exc_info=True)
+                    return Response(content="", media_type="text/plain", status_code=400)
                 return Response(content="", media_type="text/plain", status_code=200)
 
         if config.cintel_webhook_path is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,12 +116,12 @@ class TestTACConfig:
         assert "phone_number" in schema["properties"]
         assert "log_level" in schema["properties"]
 
-        # Check required fields (conversation_configuration_id, api_key, api_secret
-        # are optional to support ConversationRelay-only mode).
+        # Check required fields (conversation_configuration_id is optional
+        # to support ConversationRelay-only mode).
         assert "required" in schema
         required_fields = schema["required"]
-        assert "api_key" not in required_fields
-        assert "api_secret" not in required_fields
+        assert "api_key" in required_fields
+        assert "api_secret" in required_fields
         assert "conversation_configuration_id" not in required_fields
         assert "phone_number" in required_fields
         assert "auth_token" in required_fields
@@ -155,18 +155,20 @@ class TestTACConfig:
         error = exc_info.value
         assert "auth_token" in str(error)
         assert "account_sid" in str(error)
+        assert "api_key" in str(error)
+        assert "api_secret" in str(error)
         assert "phone_number" in str(error)
 
     def test_minimal_relay_only_config(self):
-        """Test that only phone_number + account creds are needed for relay-only mode."""
+        """Test that relay-only mode only requires conversation_configuration_id to be omitted."""
         config = TACConfig(
             account_sid="ACtest123",
             auth_token="test_token_123",
+            api_key="SK123",
+            api_secret="test_api_secret",
             phone_number="+15551234567",
         )
         assert config.phone_number == "+15551234567"
-        assert config.api_key is None
-        assert config.api_secret is None
         assert config.conversation_configuration_id is None
 
     def test_config_with_region(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,12 +116,13 @@ class TestTACConfig:
         assert "phone_number" in schema["properties"]
         assert "log_level" in schema["properties"]
 
-        # Check required fields
+        # Check required fields (conversation_configuration_id, api_key, api_secret
+        # are optional to support ConversationRelay-only mode).
         assert "required" in schema
         required_fields = schema["required"]
-        assert "api_key" in required_fields
-        assert "api_secret" in required_fields
-        assert "conversation_configuration_id" in required_fields
+        assert "api_key" not in required_fields
+        assert "api_secret" not in required_fields
+        assert "conversation_configuration_id" not in required_fields
         assert "phone_number" in required_fields
         assert "auth_token" in required_fields
         assert "account_sid" in required_fields
@@ -152,15 +153,21 @@ class TestTACConfig:
             TACConfig()
 
         error = exc_info.value
-        assert "api_key" in str(error)
-        assert "api_secret" in str(error)
         assert "auth_token" in str(error)
         assert "account_sid" in str(error)
+        assert "phone_number" in str(error)
 
-    def test_partial_config_fails(self):
-        """Test that partial config raises validation error."""
-        with pytest.raises(ValidationError):
-            TACConfig(api_key="SK123")  # Missing other required fields
+    def test_minimal_relay_only_config(self):
+        """Test that only phone_number + account creds are needed for relay-only mode."""
+        config = TACConfig(
+            account_sid="ACtest123",
+            auth_token="test_token_123",
+            phone_number="+15551234567",
+        )
+        assert config.phone_number == "+15551234567"
+        assert config.api_key is None
+        assert config.api_secret is None
+        assert config.conversation_configuration_id is None
 
     def test_config_with_region(self):
         config = TACConfig(

--- a/tests/test_config_from_env.py
+++ b/tests/test_config_from_env.py
@@ -247,23 +247,21 @@ class TestTACConfigFromEnv:
         with pytest.raises(KeyError, match="TWILIO_PHONE_NUMBER"):
             TACConfig.from_env()
 
-    def test_from_env_missing_api_key_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test from_env() returns api_key=None when TWILIO_API_KEY is missing."""
+    def test_from_env_missing_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test from_env() raises KeyError when TWILIO_API_KEY is missing."""
         self._set_all_env_vars(monkeypatch)
         monkeypatch.delenv("TWILIO_API_KEY", raising=False)
 
-        config = TACConfig.from_env()
-        assert config.api_key is None
+        with pytest.raises(KeyError, match="TWILIO_API_KEY"):
+            TACConfig.from_env()
 
-    def test_from_env_missing_api_secret_returns_none(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test from_env() returns api_secret=None when TWILIO_API_SECRET is missing."""
+    def test_from_env_missing_api_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test from_env() raises KeyError when TWILIO_API_SECRET is missing."""
         self._set_all_env_vars(monkeypatch)
         monkeypatch.delenv("TWILIO_API_SECRET", raising=False)
 
-        config = TACConfig.from_env()
-        assert config.api_secret is None
+        with pytest.raises(KeyError, match="TWILIO_API_SECRET"):
+            TACConfig.from_env()
 
     def test_from_env_missing_multiple_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test from_env() raises KeyError when environment variables are missing."""

--- a/tests/test_config_from_env.py
+++ b/tests/test_config_from_env.py
@@ -214,13 +214,14 @@ class TestTACConfigFromEnv:
     def test_from_env_missing_conversation_configuration_id(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test from_env() raises KeyError when
-        TWILIO_CONVERSATION_CONFIGURATION_ID is missing."""
+        """Test from_env() succeeds with conversation_configuration_id=None when
+        TWILIO_CONVERSATION_CONFIGURATION_ID is missing (ConversationRelay-only mode)."""
         self._set_all_env_vars(monkeypatch)
         monkeypatch.delenv("TWILIO_CONVERSATION_CONFIGURATION_ID", raising=False)
 
-        with pytest.raises(KeyError, match="TWILIO_CONVERSATION_CONFIGURATION_ID"):
-            TACConfig.from_env()
+        config = TACConfig.from_env()
+
+        assert config.conversation_configuration_id is None
 
     def test_from_env_missing_account_sid(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test from_env() raises KeyError when TWILIO_ACCOUNT_SID is missing."""
@@ -246,21 +247,23 @@ class TestTACConfigFromEnv:
         with pytest.raises(KeyError, match="TWILIO_PHONE_NUMBER"):
             TACConfig.from_env()
 
-    def test_from_env_missing_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test from_env() raises KeyError when TWILIO_API_KEY is missing."""
+    def test_from_env_missing_api_key_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test from_env() returns api_key=None when TWILIO_API_KEY is missing."""
         self._set_all_env_vars(monkeypatch)
         monkeypatch.delenv("TWILIO_API_KEY", raising=False)
 
-        with pytest.raises(KeyError, match="TWILIO_API_KEY"):
-            TACConfig.from_env()
+        config = TACConfig.from_env()
+        assert config.api_key is None
 
-    def test_from_env_missing_api_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test from_env() raises KeyError when TWILIO_API_SECRET is missing."""
+    def test_from_env_missing_api_secret_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test from_env() returns api_secret=None when TWILIO_API_SECRET is missing."""
         self._set_all_env_vars(monkeypatch)
         monkeypatch.delenv("TWILIO_API_SECRET", raising=False)
 
-        with pytest.raises(KeyError, match="TWILIO_API_SECRET"):
-            TACConfig.from_env()
+        config = TACConfig.from_env()
+        assert config.api_secret is None
 
     def test_from_env_missing_multiple_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test from_env() raises KeyError when environment variables are missing."""

--- a/tests/test_relay_only_mode.py
+++ b/tests/test_relay_only_mode.py
@@ -28,6 +28,8 @@ def relay_only_config() -> dict:
     return {
         "account_sid": "AC123",
         "auth_token": "test_token_123",
+        "api_key": "SK123",
+        "api_secret": "test_api_secret",
         "phone_number": "+15551234567",
     }
 
@@ -44,17 +46,6 @@ def orchestrated_config() -> dict:
 
 class TestRelayOnlyMode:
     """Tests for TAC relay-only mode."""
-
-    @pytest.mark.no_auto_mock
-    def test_tac_init_raises_without_api_credentials(self) -> None:
-        """TAC raises when conversation_configuration_id set without api credentials."""
-        config = {
-            **relay_only_config(),
-            "conversation_configuration_id": "conv_configuration_test123",
-        }
-
-        with pytest.raises(ValueError, match="api_key and api_secret are required"):
-            TAC(config)
 
     @pytest.mark.no_auto_mock
     def test_tac_init_without_config_succeeds(self) -> None:

--- a/tests/test_relay_only_mode.py
+++ b/tests/test_relay_only_mode.py
@@ -179,6 +179,28 @@ class TestRelayOnlyMode:
 
     @pytest.mark.no_auto_mock
     @pytest.mark.asyncio
+    async def test_callback_ignores_mismatched_account_sid(self) -> None:
+        """Callback with wrong account_sid is silently ignored."""
+        tac = TAC(relay_only_config())
+        channel = VoiceChannel(tac)
+        channel._start_conversation("CA_relay_mismatch", None)
+
+        payload = ConversationRelayCallbackPayload(
+            CallSid="CA_relay_mismatch",
+            CallStatus="completed",
+            AccountSid="AC_WRONG",
+            From="+15551230000",
+            To="+15551234567",
+            Direction="inbound",
+        ).model_dump(by_alias=True, exclude_none=True)
+        payload = {k: str(v) for k, v in payload.items()}
+
+        await channel.handle_conversation_relay_callback(payload)
+
+        assert "CA_relay_mismatch" in channel._conversations
+
+    @pytest.mark.no_auto_mock
+    @pytest.mark.asyncio
     async def test_interrupt_callback_fires_in_relay_only(self) -> None:
         """on_interrupt callback fires in relay-only mode with session for call_sid."""
         tac = TAC(relay_only_config())

--- a/tests/test_relay_only_mode.py
+++ b/tests/test_relay_only_mode.py
@@ -1,0 +1,223 @@
+"""Tests for relay-only mode (TAC without Conversation Orchestrator).
+
+Relay-only mode is active when TACConfig.conversation_configuration_id is not set.
+In this mode:
+- VoiceChannel works with pure ConversationRelay (no CO, no Memory).
+- SMSChannel and ChatChannel raise at construction.
+- TAC.retrieve_memory returns an empty TACMemoryResponse.
+- The ConversationRelay callback for "completed" ends the local session without CO.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tac import TAC
+from tac.channels.chat import ChatChannel
+from tac.channels.sms import SMSChannel
+from tac.channels.voice import VoiceChannel
+from tac.models.session import ConversationSession
+from tac.models.voice import (
+    ConversationRelayCallbackPayload,
+    TwiMLOptions,
+)
+
+
+def relay_only_config() -> dict:
+    """Config without conversation_configuration_id — triggers relay-only mode."""
+    return {
+        "account_sid": "AC123",
+        "auth_token": "test_token_123",
+        "phone_number": "+15551234567",
+    }
+
+
+def orchestrated_config() -> dict:
+    """Config with conversation_configuration_id — triggers orchestrated mode."""
+    return {
+        **relay_only_config(),
+        "api_key": "SK123",
+        "api_secret": "test_api_token",
+        "conversation_configuration_id": "conv_configuration_test123",
+    }
+
+
+class TestRelayOnlyMode:
+    """Tests for TAC relay-only mode."""
+
+    @pytest.mark.no_auto_mock
+    def test_tac_init_raises_without_api_credentials(self) -> None:
+        """TAC raises when conversation_configuration_id set without api credentials."""
+        config = {
+            **relay_only_config(),
+            "conversation_configuration_id": "conv_configuration_test123",
+        }
+
+        with pytest.raises(ValueError, match="api_key and api_secret are required"):
+            TAC(config)
+
+    @pytest.mark.no_auto_mock
+    def test_tac_init_without_config_succeeds(self) -> None:
+        """TAC initializes without conversation_configuration_id and reports relay-only."""
+        tac = TAC(relay_only_config())
+
+        assert tac.is_orchestrator_enabled() is False
+        assert tac.conversation_orchestrator_client is None
+        assert tac.conversation_memory_client is None
+
+    def test_tac_init_with_config_succeeds(self) -> None:
+        """TAC with conversation_configuration_id reports orchestrator enabled.
+
+        Uses the autouse mock_conversation_configuration fixture.
+        """
+        tac = TAC(orchestrated_config())
+
+        assert tac.is_orchestrator_enabled() is True
+        assert tac.conversation_orchestrator_client is not None
+        assert tac.conversation_memory_client is not None
+
+    @pytest.mark.no_auto_mock
+    @pytest.mark.asyncio
+    async def test_retrieve_memory_returns_empty_in_relay_only(self) -> None:
+        """retrieve_memory returns empty TACMemoryResponse in relay-only mode."""
+        tac = TAC(relay_only_config())
+
+        session = ConversationSession(
+            conversation_id="CA_relay_only",
+            profile_id=None,
+            channel="voice",
+        )
+
+        response = await tac.retrieve_memory(session)
+
+        assert response.has_memory_features is False
+        assert response.observations == []
+        assert response.summaries == []
+        assert response.communications == []
+
+    @pytest.mark.no_auto_mock
+    @pytest.mark.asyncio
+    async def test_handle_incoming_call_twiml_omits_conversation_configuration(self) -> None:
+        """TwiML does not include conversationConfiguration in relay-only mode."""
+        tac = TAC(relay_only_config())
+        channel = VoiceChannel(tac)
+
+        twiml = await channel.handle_incoming_call(
+            TwiMLOptions(
+                websocket_url="wss://example.com/ws",
+                welcome_greeting="Hello",
+            )
+        )
+
+        assert "conversationConfiguration" not in twiml
+
+    @pytest.mark.no_auto_mock
+    @pytest.mark.asyncio
+    async def test_handle_websocket_first_prompt_uses_call_sid(self) -> None:
+        """First prompt in relay-only mode uses call_sid as conv_id without CO calls."""
+        tac = TAC(relay_only_config())
+        channel = VoiceChannel(tac)
+
+        mock_ws = AsyncMock()
+        mock_ws.receive_json.side_effect = [
+            {"type": "setup", "callSid": "CA_relay_abc", "from": "+15551230000"},
+            {
+                "type": "prompt",
+                "voicePrompt": "Hello there",
+                "final": True,
+            },
+            Exception("stop-iteration"),
+        ]
+
+        callback_seen: dict = {}
+
+        def on_message(user_message, session, memory):
+            callback_seen["user_message"] = user_message
+            callback_seen["session"] = session
+            callback_seen["memory"] = memory
+            return None
+
+        tac.on_message_ready(on_message)
+
+        await channel.handle_websocket(mock_ws)
+
+        assert callback_seen["user_message"] == "Hello there"
+        assert callback_seen["session"].conversation_id == "CA_relay_abc"
+        assert callback_seen["session"].profile_id is None
+
+    @pytest.mark.no_auto_mock
+    @pytest.mark.asyncio
+    async def test_call_completed_ends_local_session_without_co(self) -> None:
+        """On call completed, relay-only mode ends local session without CO calls."""
+        tac = TAC(relay_only_config())
+        channel = VoiceChannel(tac)
+
+        channel._start_conversation("CA_relay_xyz", None)
+        assert "CA_relay_xyz" in channel._conversations
+
+        ended: list[str] = []
+
+        async def on_ended(session):
+            ended.append(session.conversation_id)
+
+        tac.on_conversation_ended(on_ended)
+
+        payload = ConversationRelayCallbackPayload(
+            CallSid="CA_relay_xyz",
+            CallStatus="completed",
+            AccountSid="AC123",
+            From="+15551230000",
+            To="+15551234567",
+            Direction="inbound",
+        ).model_dump(by_alias=True, exclude_none=True)
+        payload = {k: str(v) for k, v in payload.items()}
+
+        await channel.handle_conversation_relay_callback(payload)
+
+        assert "CA_relay_xyz" not in channel._conversations
+        assert ended == ["CA_relay_xyz"]
+
+    @pytest.mark.no_auto_mock
+    @pytest.mark.asyncio
+    async def test_interrupt_callback_fires_in_relay_only(self) -> None:
+        """on_interrupt callback fires in relay-only mode with session for call_sid."""
+        tac = TAC(relay_only_config())
+        channel = VoiceChannel(tac)
+
+        channel._start_conversation("CA_relay_int", None)
+
+        seen: list = []
+
+        def on_interrupt(session, interrupt_data):
+            seen.append((session.conversation_id, session.profile_id))
+
+        tac.on_interrupt(on_interrupt)
+
+        from tac.models.voice import InterruptMessage
+
+        channel._handle_interrupt(
+            "CA_relay_int",
+            InterruptMessage(
+                type="interrupt",
+                utteranceUntilInterrupt="Hello, I was saying...",
+                durationUntilInterruptMs=1500,
+            ),
+        )
+
+        assert seen == [("CA_relay_int", None)]
+
+    @pytest.mark.no_auto_mock
+    def test_sms_channel_raises_in_relay_only(self) -> None:
+        """SMSChannel construction fails in relay-only mode."""
+        tac = TAC(relay_only_config())
+
+        with pytest.raises(ValueError, match="Conversation Orchestrator"):
+            SMSChannel(tac)
+
+    @pytest.mark.no_auto_mock
+    def test_chat_channel_raises_in_relay_only(self) -> None:
+        """ChatChannel construction fails in relay-only mode."""
+        tac = TAC(relay_only_config())
+
+        with pytest.raises(ValueError, match="Conversation Orchestrator"):
+            ChatChannel(tac)


### PR DESCRIPTION
## Summary

Adds ConversationRelay-only mode — TAC can now run with just the Voice channel (ConversationRelay) without requiring Conversation Orchestrator, Memory, or Knowledge.

When `conversation_configuration_id` is omitted from `TACConfig`, TAC operates in relay-only mode:
- **VoiceChannel** works with ConversationRelay only (no CO session, no Memory)
- **Messaging channels** (SMS, Chat) raise `ValueError` at construction
- **`TAC.retrieve_memory()`** returns an empty `TACMemoryResponse`
- **`api_key` and `api_secret`** are now optional on `TACConfig` — only `account_sid`, `auth_token`, and `phone_number` are required for relay-only mode

### Key changes

- `TACConfig.conversation_configuration_id` is `Optional[str]` (default `None`)
- `TACConfig.api_key` and `TACConfig.api_secret` are `Optional[str]` (default `None`), validated at point-of-use when CO or Knowledge is configured
- `TAC.is_orchestrator_enabled()` helper for conditional client access
- `VoiceChannel` handles call lifecycle (setup, prompts, callbacks) without CO when in relay-only mode
- `MessagingChannel` base class raises early if CO is not available
- `handle_conversation_relay_callback` re-added with actual cleanup logic for relay-only session lifecycle
- `TACFastAPIServer` auto-wires the callback route and `action_url` in relay-only mode
- New example `getting_started/examples/features/relay_only.py` using OpenAI Agents SDK with streaming

## Type of Change

- [x] New feature

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

> **Tip:** Use the `/sync-to-ts-sdk` skill in Claude Code to automatically generate and create a TypeScript SDK PR from your changes.

- [ ] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->