### PR TITLE
docs: Document ConversationRelay-only mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Tests are in `tests/` — one test file per module (e.g., `test_tac.py`, `test_s
 - **Auth**: All API clients use HTTP Basic Auth (API Key as username, API Token as password)
 - **BaseAPIClient**: All API clients (ConversationClient, MemoryClient, KnowledgeClient) inherit from `BaseAPIClient`, which provides shared HTTP client configuration, authentication, and User-Agent header management following Twilio SDK conventions
 - **Horizontal scaling limitation**: Channels track active conversations in instance-local memory (`self._conversations`). Works perfectly for single-instance deployments. In multi-instance deployments behind a load balancer, webhooks may route to a different instance than the one that handled the connection/message, preventing proper conversation cleanup and causing memory leaks. Recommended solutions: sticky sessions (route by conversation_id) or shared state store (Redis/database).
+- **ConversationRelay-only mode**: When `conversation_configuration_id` is omitted from TACConfig, TAC runs without Conversation Orchestrator. Only the Voice channel is usable (messaging channels raise at construction), `TAC.retrieve_memory()` returns an empty `TACMemoryResponse`, and the ConversationRelay callback handles session cleanup. Use `tac.is_orchestrator_enabled()` to check mode at runtime.
 
 ## OpenAI Adapter
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Tests are in `tests/` — one test file per module (e.g., `test_tac.py`, `test_s
 - **Auth**: All API clients use HTTP Basic Auth (API Key as username, API Token as password)
 - **BaseAPIClient**: All API clients (ConversationClient, MemoryClient, KnowledgeClient) inherit from `BaseAPIClient`, which provides shared HTTP client configuration, authentication, and User-Agent header management following Twilio SDK conventions
 - **Horizontal scaling limitation**: Channels track active conversations in instance-local memory (`self._conversations`). Works perfectly for single-instance deployments. In multi-instance deployments behind a load balancer, webhooks may route to a different instance than the one that handled the connection/message, preventing proper conversation cleanup and causing memory leaks. Recommended solutions: sticky sessions (route by conversation_id) or shared state store (Redis/database).
-- **ConversationRelay-only mode**: When `conversation_configuration_id` is omitted from TACConfig, TAC runs without Conversation Orchestrator. Only the Voice channel is usable (messaging channels raise at construction), `TAC.retrieve_memory()` returns an empty `TACMemoryResponse`, and the ConversationRelay callback handles session cleanup. Use `tac.is_orchestrator_enabled()` to check mode at runtime.
+- **ConversationRelay-only mode**: When `conversation_configuration_id` is omitted from TACConfig, TAC runs with just the Voice channel (messaging channels raise at construction), `TAC.retrieve_memory()` returns an empty `TACMemoryResponse`, and the ConversationRelay callback handles session cleanup. Use `tac.is_orchestrator_enabled()` to check mode at runtime.
 
 ## OpenAI Adapter
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   </p>
 </div>
 
-Seamlessly integrate with Twilio's Memory Store and Conversation Orchestrator to build LLM-powered agents with persistent memory and conversation context — or run in ConversationRelay-only mode for voice without Conversation Orchestrator.
+Seamlessly integrate with Twilio's Memory Store and Conversation Orchestrator to build LLM-powered agents with persistent memory and conversation context.
 
 ---
 
@@ -34,7 +34,7 @@ Seamlessly integrate with Twilio's Memory Store and Conversation Orchestrator to
 
 - **SMS Channel Support**: Built-in webhook handling for Twilio SMS conversations
 - **Voice Channel Support**: WebSocket protocol handling for Twilio Voice with ConversationRelay
-- **ConversationRelay-Only Mode**: Use TAC's voice plumbing (TwiML, WebSocket, callbacks) without Conversation Orchestrator
+- **ConversationRelay-Only Mode**: Get started quickly with TAC's voice plumbing (TwiML, WebSocket, callbacks) before adding Conversation Orchestrator
 - **Memory Management**: Automatic integration with Twilio Memory for persistent user context
 - **Conversation Lifecycle**: Automatic tracking of conversation sessions and state
 - **Type-Safe**: Full type hints and Pydantic models throughout

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   </p>
 </div>
 
-Seamlessly integrate with Twilio's Memory Store and Conversation Orchestrator to build LLM-powered agents with persistent memory and conversation context.
+Seamlessly integrate with Twilio's Memory Store and Conversation Orchestrator to build LLM-powered agents with persistent memory and conversation context — or run in ConversationRelay-only mode for voice without Conversation Orchestrator.
 
 ---
 
@@ -34,6 +34,7 @@ Seamlessly integrate with Twilio's Memory Store and Conversation Orchestrator to
 
 - **SMS Channel Support**: Built-in webhook handling for Twilio SMS conversations
 - **Voice Channel Support**: WebSocket protocol handling for Twilio Voice with ConversationRelay
+- **ConversationRelay-Only Mode**: Use TAC's voice plumbing (TwiML, WebSocket, callbacks) without Conversation Orchestrator
 - **Memory Management**: Automatic integration with Twilio Memory for persistent user context
 - **Conversation Lifecycle**: Automatic tracking of conversation sessions and state
 - **Type-Safe**: Full type hints and Pydantic models throughout
@@ -180,6 +181,7 @@ For detailed architecture and advanced usage, see [CLAUDE.md](CLAUDE.md).
 **Examples & Guides:**
 - **[Getting Started Guide](getting_started/)** - Setup wizard, examples, and comprehensive documentation
 - **[Partner SDK Examples](getting_started/examples/partners/)** - OpenAI Chat Completions and Responses API examples
+- **[ConversationRelay-Only Mode](getting_started/examples/features/relay_only.py)** - Voice-only without Conversation Orchestrator
 - More examples coming soon
 
 **Documentation:**

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ For detailed architecture and advanced usage, see [CLAUDE.md](CLAUDE.md).
 **Examples & Guides:**
 - **[Getting Started Guide](getting_started/)** - Setup wizard, examples, and comprehensive documentation
 - **[Partner SDK Examples](getting_started/examples/partners/)** - OpenAI Chat Completions and Responses API examples
-- **[ConversationRelay-Only Mode](getting_started/examples/features/relay_only.py)** - Voice-only without Conversation Orchestrator
+- **[ConversationRelay-Only Mode](getting_started/examples/features/relay_only.py)** - Get started with voice using just ConversationRelay
 - More examples coming soon
 
 **Documentation:**

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -81,6 +81,7 @@ uv run getting_started/examples/partners/openai_chat_completions.py
 uv run getting_started/examples/partners/openai_responses_api.py
 uv run getting_started/examples/features/voice_streaming.py
 uv run getting_started/examples/features/handoff.py
+uv run getting_started/examples/features/relay_only.py
 ```
 
 ### Expose Your Server

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -54,7 +54,7 @@ Production-ready examples using partner SDK adapters:
 
 - **`voice_streaming.py`**: Stream LLM responses token-by-token for ~40-50% faster time-to-first-audio
 - **`handoff.py`**: Hand the conversation off to a human agent via a Twilio Studio Flow (works on voice and SMS)
-- **`relay_only.py`**: ConversationRelay-only mode — voice-only without Conversation Orchestrator
+- **`relay_only.py`**: ConversationRelay-only mode — get started with voice using just ConversationRelay
 
 ## Step 3: Run an Example
 
@@ -109,7 +109,7 @@ See `examples/.env.example` for all available configuration options. Key variabl
 - `TWILIO_PHONE_NUMBER`: Your Twilio phone number
 
 ### Required for Orchestrator Mode (omit for ConversationRelay-only)
-- `TWILIO_CONVERSATION_CONFIGURATION_ID`: Conversation Configuration ID (enables Memory, messaging channels, and Conversation Orchestrator)
+- `TWILIO_CONVERSATION_CONFIGURATION_ID`: Conversation Configuration ID
 
 ### Optional (Voice Channel)
 - `TWILIO_VOICE_PUBLIC_DOMAIN`: Your ngrok domain (required for voice)

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -54,6 +54,7 @@ Production-ready examples using partner SDK adapters:
 
 - **`voice_streaming.py`**: Stream LLM responses token-by-token for ~40-50% faster time-to-first-audio
 - **`handoff.py`**: Hand the conversation off to a human agent via a Twilio Studio Flow (works on voice and SMS)
+- **`relay_only.py`**: ConversationRelay-only mode — voice-only without Conversation Orchestrator
 
 ## Step 3: Run an Example
 
@@ -105,7 +106,9 @@ See `examples/.env.example` for all available configuration options. Key variabl
 - `TWILIO_API_KEY`: Twilio API key SID (starts with SK)
 - `TWILIO_API_SECRET`: Twilio API key secret
 - `TWILIO_PHONE_NUMBER`: Your Twilio phone number
-- `TWILIO_CONVERSATION_CONFIGURATION_ID`: Conversation Configuration ID
+
+### Required for Orchestrator Mode (omit for ConversationRelay-only)
+- `TWILIO_CONVERSATION_CONFIGURATION_ID`: Conversation Configuration ID (enables Memory, messaging channels, and Conversation Orchestrator)
 
 ### Optional (Voice Channel)
 - `TWILIO_VOICE_PUBLIC_DOMAIN`: Your ngrok domain (required for voice)

--- a/getting_started/examples/.env.example
+++ b/getting_started/examples/.env.example
@@ -7,6 +7,9 @@ TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_API_KEY=SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_API_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_PHONE_NUMBER=+1xxxxxxxxxx
+
+# Required for Orchestrator mode (enables Memory, messaging channels, Conversation Orchestrator).
+# Omit for ConversationRelay-only mode (voice-only).
 TWILIO_CONVERSATION_CONFIGURATION_ID=conv_configuration_xxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Optional - Twilio log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/getting_started/examples/.env.example
+++ b/getting_started/examples/.env.example
@@ -8,7 +8,6 @@ TWILIO_API_KEY=SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_API_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_PHONE_NUMBER=+1xxxxxxxxxx
 
-# Required for Orchestrator mode (enables Memory, messaging channels, Conversation Orchestrator).
 # Omit for ConversationRelay-only mode (voice-only).
 TWILIO_CONVERSATION_CONFIGURATION_ID=conv_configuration_xxxxxxxxxxxxxxxxxxxxxxxxxx
 


### PR DESCRIPTION
## Summary

- Update README, getting_started/README, .env.example, and CLAUDE.md to document that `conversation_configuration_id` is now optional
- Clarify that TAC can run in ConversationRelay-only mode for voice without Conversation Orchestrator
- Add relay_only.py example to feature listings

## Type of Change

- [x] Documentation update

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)