### PR TITLE
feat: Fail-fast guards for handoff tool in relay-only mode

### DIFF
--- a/src/tac/tools/handoff.py
+++ b/src/tac/tools/handoff.py
@@ -249,6 +249,14 @@ def create_studio_handoff_tool(
     The tool also sets the conversation to INACTIVE and clears status callbacks
     to prevent further webhook events from being routed to TAC.
 
+    **Not available in ConversationRelay-only mode.** This tool requires
+    Conversation Orchestrator for conversation state management (setting
+    INACTIVE status, clearing callbacks) and Conversation Memory for the
+    handoff payload's ``storeId``. In relay-only mode, implement a custom
+    handoff by setting ``session.pending_handoff_data`` directly — the voice
+    channel will send the WebSocket ``end`` message with your payload, and
+    your ``<Connect action>`` URL handler can route the call accordingly.
+
     Args:
         tac: TAC instance for building payload and posting to Studio
         session: Current conversation session
@@ -273,14 +281,29 @@ def create_studio_handoff_tool(
         ... )
 
     Raises:
-        ValueError: If ``tac.config.studio_handoff_flow_sid`` is unset. The
-            factory is Studio-specific; a missing SID is misconfiguration,
-            not a soft fallback.
+        ValueError: If ``tac.config.studio_handoff_flow_sid`` is unset,
+            if Conversation Orchestrator is not configured (relay-only mode),
+            or if no memory store ID is available.
     """
     if not tac.config.studio_handoff_flow_sid:
         raise ValueError(
             "create_studio_handoff_tool requires tac.config.studio_handoff_flow_sid "
             "(set TWILIO_STUDIO_HANDOFF_FLOW_SID in your environment)."
+        )
+
+    if not tac.is_orchestrator_enabled():
+        raise ValueError(
+            "create_studio_handoff_tool requires Conversation Orchestrator "
+            "(not available in ConversationRelay-only mode). Set "
+            "conversation_configuration_id in TACConfig, or implement a custom "
+            "handoff by setting session.pending_handoff_data directly."
+        )
+
+    if tac.conversation_memory_client is None or not tac.conversation_memory_client.store_id:
+        raise ValueError(
+            "create_studio_handoff_tool requires a memory store ID "
+            "(resolved from conversation_configuration_id at startup). Ensure "
+            "your Conversation Orchestrator configuration has an associated memory store."
         )
 
     handoff_tool = function_tool(name=name, description=description)(_handoff_impl)

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -285,6 +285,15 @@ class TestHandoffExecution:
         with pytest.raises(ValueError, match="Conversation Orchestrator"):
             create_studio_handoff_tool(tac, session)
 
+    def test_factory_raises_without_memory_store_id(self) -> None:
+        """Factory rejects TAC with orchestrator but no memory store."""
+        tac = TAC(get_test_config())
+        tac.conversation_memory_client = None
+        session = ConversationSession(conversation_id="conv_123", channel="voice")
+
+        with pytest.raises(ValueError, match="memory store ID"):
+            create_studio_handoff_tool(tac, session)
+
     @pytest.mark.asyncio
     async def test_handoff_digital_delivery_failure_reports_handoff_failed(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -277,6 +277,14 @@ class TestHandoffExecution:
         with pytest.raises(ValueError, match="studio_handoff_flow_sid"):
             create_studio_handoff_tool(tac, session)
 
+    def test_factory_raises_in_relay_only_mode(self) -> None:
+        """Factory rejects relay-only TAC — orchestrator and memory are required."""
+        tac = TAC(get_test_config(conversation_configuration_id=None))
+        session = ConversationSession(conversation_id="conv_123", channel="voice")
+
+        with pytest.raises(ValueError, match="Conversation Orchestrator"):
+            create_studio_handoff_tool(tac, session)
+
     @pytest.mark.asyncio
     async def test_handoff_digital_delivery_failure_reports_handoff_failed(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- `create_studio_handoff_tool()` now validates at **creation time** that Conversation Orchestrator and a memory store ID are available, raising `ValueError` with actionable messages instead of crashing with `AttributeError` at execution time
- Docstring updated to document relay-only mode incompatibility and the alternative (`session.pending_handoff_data`)
- Aligns with TypeScript SDK PR: https://github.com/twilio/twilio-agent-connect-typescript/pull/17

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [ ] Change is Python-specific (no TypeScript update needed)
- [x] TypeScript SDK PR created: https://github.com/twilio/twilio-agent-connect-typescript/pull/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)