### PR TITLE
docs: Use public product names (Conversation Memory / Orchestrator)

### DIFF
--- a/getting_started/examples/features/dashboard/dashboard.py
+++ b/getting_started/examples/features/dashboard/dashboard.py
@@ -3,7 +3,7 @@ TAC Dashboard — Lightweight observation dashboard for TAC examples.
 
 Provides two views:
 - **Active Sessions** — live conversations with message viewer and profile memory hover
-- **Conversation History** — closed conversations fetched from Maestro
+- **Conversation History** — closed conversations fetched from Conversation Orchestrator
 
 Mount onto any FastAPI app with ``create_dashboard_router()``.
 """
@@ -90,11 +90,11 @@ def create_dashboard_router(
 
     @router.get("/api/sessions")
     async def list_sessions() -> JSONResponse:
-        """List active conversations (only those with ACTIVE status in Maestro)."""
+        """List ACTIVE conversations (status=ACTIVE in Conversation Orchestrator)."""
         results: list[dict[str, Any]] = []
         sessions = _all_sessions()
 
-        # Get ACTIVE + INACTIVE conversations from Maestro (skip CLOSED)
+        # Get ACTIVE + INACTIVE conversations from Conversation Orchestrator (skip CLOSED)
         live_status: dict[str, str] | None = None
         if conversation_client:
             try:
@@ -103,10 +103,10 @@ def create_dashboard_router(
                 )
                 live_status = {c.id: c.status or "ACTIVE" for c in live_convs}
             except Exception as e:
-                logger.warning(f"Failed to fetch conversations from Maestro: {e}")
+                logger.warning(f"Failed to fetch conversations from Conversation Orchestrator: {e}")
 
         for conv_id, session in sessions.items():
-            # Skip sessions that Maestro reports as CLOSED
+            # Skip sessions that Conversation Orchestrator reports as CLOSED
             if live_status is not None and conv_id not in live_status:
                 continue
 
@@ -204,7 +204,7 @@ def create_dashboard_router(
             "ci_events": [],
         }
 
-        # Fetch communications from Maestro
+        # Fetch communications from Conversation Orchestrator
         if conversation_client:
             try:
                 twilio_phone = os.environ.get("TWILIO_PHONE_NUMBER", "")
@@ -249,7 +249,7 @@ def create_dashboard_router(
 
     @router.get("/api/history")
     async def list_history() -> JSONResponse:
-        """List closed conversations from Maestro."""
+        """List closed conversations from Conversation Orchestrator."""
         if not conversation_client:
             return JSONResponse(
                 content={"error": "Conversation client not available"}, status_code=404
@@ -325,7 +325,8 @@ def mount_dashboard(
 
     Args:
         app: FastAPI application instance.
-        tac: TAC instance (used for ``memora_client`` and ``maestro_client``).
+        tac: TAC instance. Uses ``conversation_memory_client`` and
+            ``conversation_orchestrator_client`` for data fetches.
         channels: Channel instances (SMSChannel, VoiceChannel, ChatChannel, etc.).
             Sessions are read from each channel's ``_conversations`` dict.
         messages: Conversation message history ``{conv_id: [{role, content}, ...]}``.

--- a/src/tac/channels/chat.py
+++ b/src/tac/channels/chat.py
@@ -136,9 +136,9 @@ class ChatChannel(MessagingChannel):
                 "session.metadata['channel_id'] explicitly in advanced usage."
             )
 
-        # TODO(maestro): Drop `chat_service` here once the Actions API resolves the
-        # V1 Chat service SID server-side. Maestro team confirmed this should not be
-        # required client-side; keep the workaround until the server-side fix ships.
+        # TODO(conv-orch): Drop `chat_service` here once the Actions API resolves the
+        # V1 Chat service SID server-side. Conversation Orchestrator team confirmed this
+        # should not be required client-side; keep the workaround until the server-side fix ships.
         # `channel_id` stays — it's a permanent per-conversation requirement.
         chat_service_sid = self.tac.conversations_v1_service_sid
         channel_settings = ActionChannelSettings(

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -28,10 +28,10 @@ from tac.models.session import AuthorInfo
 from tac.utils.redaction import mask_address
 
 # Participant types that represent TAC itself at TAC's (channel, address).
-# `AI_AGENT` is the canonical type; `AGENT` is the legacy Maestro form. A
-# participant typed either way at TAC's address is recognized as TAC and not
-# overwritten; anything else (HUMAN_AGENT, CUSTOMER, …) is someone else's
-# assignment.
+# `AI_AGENT` is the canonical type; `AGENT` is the legacy Conversation
+# Orchestrator form. A participant typed either way at TAC's address is
+# recognized as TAC and not overwritten; anything else (HUMAN_AGENT,
+# CUSTOMER, …) is someone else's assignment.
 AGENT_TYPES: frozenset[str] = frozenset({"AGENT", "AI_AGENT"})
 
 
@@ -248,14 +248,14 @@ class MessagingChannel(BaseChannel):
             session.metadata["channel_id"] = communication_data.channel_id
 
         # Reconcile participant types pre-LLM so v1-bridge's UNKNOWN gets
-        # promoted to CUSTOMER (with a Memora profile attached when possible)
+        # promoted to CUSTOMER (with a Conversation Memory profile attached when possible)
         # and to stash both participant ids on the session for send_response.
         # If reconciliation can't identify both sides, any eventual reply would
         # fail too — skip the callback so the LLM doesn't waste a turn on an
         # un-replyable conversation.
         #
         # Skip reconcile entirely when both sides are already stashed from a
-        # prior turn — Maestro's state was written by us and doesn't drift.
+        # prior turn — Conversation Orchestrator's state was written by us and doesn't drift.
         if session.ai_agent_info is None or session.author_info is None:
             resolved = await self._reconcile_participants(conv_id)
             if resolved is None:
@@ -447,7 +447,7 @@ class MessagingChannel(BaseChannel):
         self,
         conversation_id: str,
     ) -> tuple[ParticipantResponse, ParticipantResponse | None] | None:
-        """Reconcile Maestro's participants to the types TAC needs for sending.
+        """Reconcile Conversation Orchestrator's participants to the types TAC needs for sending.
 
         v1-bridge capture can leave TAC's agent participant as `UNKNOWN` (wrong
         type at our address), or omit it entirely (customer-only conversation).
@@ -528,7 +528,7 @@ class MessagingChannel(BaseChannel):
         elif agent_candidate.type not in AGENT_TYPES:
             self.logger.error(
                 "Participant at TAC's address has a conflicting type; refusing to "
-                "overwrite. Check Maestro participant state — a non-agent "
+                "overwrite. Check Conversation Orchestrator participant state — a non-agent "
                 "participant is holding TAC's (channel, address).",
                 conversation_id=conversation_id,
                 participant_id=agent_candidate.id,
@@ -581,7 +581,7 @@ class MessagingChannel(BaseChannel):
         customer: ParticipantResponse,
         channel: str,
     ) -> str | None:
-        """Find or mint a Memora profile for a customer being promoted from UNKNOWN.
+        """Find or mint a Conversation Memory profile for a customer being promoted from UNKNOWN.
 
         Only resolves for phone-based channels (SMS, VOICE). Looks up by phone
         identifier first; on miss, creates a new profile using the configured
@@ -641,14 +641,15 @@ class MessagingChannel(BaseChannel):
     ) -> ParticipantResponse | None:
         """PUT a participant to `new_type`.
 
-        Maestro's PUT is a full-resource replacement, so we pass the existing
-        `name` and `addresses` back unchanged to avoid wiping them. `profile_id`
-        defaults to the participant's current value; pass a non-None override
-        to attach a newly resolved profile during CUSTOMER reconciliation.
+        Conversation Orchestrator's PUT is a full-resource replacement, so we
+        pass the existing `name` and `addresses` back unchanged to avoid wiping
+        them. `profile_id` defaults to the participant's current value; pass a
+        non-None override to attach a newly resolved profile during CUSTOMER
+        reconciliation.
 
-        Returns None on any error (including 409). A 409 from Maestro here
-        means the promotion is structurally blocked — stop and surface it;
-        don't retry.
+        Returns None on any error (including 409). A 409 from Conversation
+        Orchestrator here means the promotion is structurally blocked — stop
+        and surface it; don't retry.
         """
         effective_profile_id = profile_id if profile_id is not None else participant.profile_id
         try:
@@ -671,9 +672,9 @@ class MessagingChannel(BaseChannel):
         except httpx.HTTPStatusError as e:
             if e.response is not None and e.response.status_code == 409:
                 self.logger.warning(
-                    "Maestro returned 409 on participant promotion; skipping — "
-                    "likely a conflicting conversation or grouping constraint. "
-                    "Check Maestro for duplicate active conversations.",
+                    "Conversation Orchestrator returned 409 on participant promotion; "
+                    "skipping — likely a conflicting conversation or grouping constraint. "
+                    "Check Conversation Orchestrator for duplicate active conversations.",
                     conversation_id=conversation_id,
                     participant_id=participant.id,
                     target_type=new_type,
@@ -724,9 +725,9 @@ class MessagingChannel(BaseChannel):
         except httpx.HTTPStatusError as e:
             if e.response is not None and e.response.status_code == 409:
                 self.logger.warning(
-                    "Maestro returned 409 on AI_AGENT participant add; skipping — "
-                    "address is already owned or the conversation can't accept a "
-                    "new AI_AGENT. Check Maestro participant state.",
+                    "Conversation Orchestrator returned 409 on AI_AGENT participant add; "
+                    "skipping — address is already owned or the conversation can't accept "
+                    "a new AI_AGENT. Check Conversation Orchestrator participant state.",
                     conversation_id=conversation_id,
                     conflicting_resource_id=e.response.headers.get("X-Conflicting-Resource-Id"),
                 )

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -700,7 +700,7 @@ class VoiceChannel(BaseChannel):
 
         In orchestrated mode, the conversation remains tracked in
         self._conversations until the CONVERSATION_UPDATED/CLOSED webhook
-        arrives from Maestro. In relay-only mode there is no such webhook,
+        arrives from Conversation Orchestrator. In relay-only mode there is no such webhook,
         so we also end the conversation here.
 
         Args:

--- a/src/tac/context/conversation.py
+++ b/src/tac/context/conversation.py
@@ -113,7 +113,7 @@ class ConversationClient(BaseAPIClient):
         """
         Add a new participant to a conversation.
 
-        Used by `_reconcile_participants` when Maestro's v1-bridge emits only
+        Used by `_reconcile_participants` when Conversation Orchestrator's v1-bridge emits only
         the customer participant on an inbound SMS/chat — TAC adds itself as
         `AI_AGENT` before replying.
 
@@ -165,7 +165,7 @@ class ConversationClient(BaseAPIClient):
         """
         Replace an existing participant.
 
-        PUT is a full resource replacement per the Maestro spec — any field
+        PUT is a full resource replacement per the Conversation Orchestrator spec — any field
         omitted from the body is cleared on the server. Callers must pass the
         current `addresses` (and `name` if set) to preserve them; pass a new
         `profile_id` to attach a profile during reconciliation.
@@ -176,7 +176,7 @@ class ConversationClient(BaseAPIClient):
             participant_type: New participant type
             addresses: Current participant addresses (required to avoid wiping)
             name: Current participant display name (optional)
-            profile_id: Memora profile ID to attach (optional)
+            profile_id: Conversation Memory profile ID to attach (optional)
 
         Returns:
             ParticipantResponse reflecting the updated participant.

--- a/src/tac/context/memory.py
+++ b/src/tac/context/memory.py
@@ -232,7 +232,7 @@ class MemoryClient(BaseAPIClient):
         """
         Create a profile via identity resolution (upsert).
 
-        Memora runs identity resolution on the submitted traits: if an
+        Conversation Memory runs identity resolution on the submitted traits: if an
         identifier match is found the existing canonical profile ID is
         returned, otherwise a new profile is minted. The body must contain
         at least one trait promoted-to-identifier per the store's identity

--- a/src/tac/core/config.py
+++ b/src/tac/core/config.py
@@ -100,7 +100,7 @@ class TwilioMemoryConfig(BaseModel):
     phone_trait_group: str = Field(
         default="Contact",
         description="Trait group name that holds the phone identifier on newly created profiles. "
-        "Must match the promoted-to-identifier configuration of the Memora store.",
+        "Must match the promoted-to-identifier configuration of the Conversation Memory store.",
     )
     phone_trait_field: str = Field(
         default="phone",

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -68,8 +68,9 @@ class TAC:
                     "omit conversation_configuration_id to run in ConversationRelay-only mode."
                 ) from e
 
-            # TODO(maestro): Remove once the Actions API resolves the V1 Chat service SID
-            # server-side. Maestro team confirmed this should not be required client-side;
+            # TODO(conv-orch): Remove once the Actions API resolves the V1 Chat service SID
+            # server-side. Conversation Orchestrator team confirmed this should not be
+            # required client-side;
             # until they ship the fix, CHAT sends fail with
             #   "chatService attribute is required for CHAT channel"
             # unless we pass it on channelSettings.chatService. We source it from the

--- a/src/tac/models/conversation.py
+++ b/src/tac/models/conversation.py
@@ -93,10 +93,10 @@ class ParticipantAddress(BaseModel):
     model_config = {"populate_by_name": True}
 
 
-# TODO(maestro): Remove this class once the Actions API resolves the V1 Chat
+# TODO(conv-orch): Remove this class once the Actions API resolves the V1 Chat
 # service SID server-side. Currently used to extract `conversationsV1Bridge.serviceId`
 # from the Configuration so the chat channel can forward it as
-# channelSettings.chatService — drop together with the other TODO(maestro) sites.
+# channelSettings.chatService — drop together with the other TODO(conv-orch) sites.
 class ConversationsV1Bridge(BaseModel):
     """Conversations V1 bridge settings on a ConversationConfiguration."""
 
@@ -171,7 +171,7 @@ class ConversationConfiguration(BaseModel):
         max_length=5,
         description="List of Intelligence Configuration IDs for this configuration",
     )
-    # TODO(maestro): Drop this field once the Actions API resolves the V1 Chat
+    # TODO(conv-orch): Drop this field once the Actions API resolves the V1 Chat
     # service SID server-side — see ConversationsV1Bridge above.
     conversations_v1_bridge: ConversationsV1Bridge | None = Field(
         None,
@@ -450,7 +450,8 @@ class ActionParticipantRef(BaseModel):
     """Participant reference for the Actions API (`from`/`to` entries).
 
     Either `participant_id` or `address` must be supplied; `channel` is always required.
-    When both are provided, Maestro uses `participant_id` and `channel` disambiguates
+    When both are provided, Conversation Orchestrator uses `participant_id` and
+    `channel` disambiguates
     which of the participant's addresses to use.
     """
 
@@ -494,9 +495,9 @@ class ActionChannelSettings(BaseModel):
         alias="channelId",
         description="Backend-specific channel identifier (e.g. V1 Chat channel SID)",
     )
-    # TODO(maestro): Drop `chat_service` once the Actions API resolves the V1 Chat
-    # service SID server-side. Maestro team confirmed this should not be required
-    # client-side; keep the field until the server-side fix ships.
+    # TODO(conv-orch): Drop `chat_service` once the Actions API resolves the V1 Chat
+    # service SID server-side. Conversation Orchestrator team confirmed this should not be
+    # required client-side; keep the field until the server-side fix ships.
     chat_service: str | None = Field(
         default=None,
         alias="chatService",

--- a/src/tac/models/memory.py
+++ b/src/tac/models/memory.py
@@ -422,5 +422,6 @@ class ProfileLookupResponse(BaseModel):
     @field_validator("profiles", mode="before")
     @classmethod
     def _coerce_null_profiles(cls, v: Any) -> Any:
-        # Memora's Lookup response omits or nulls `profiles` when no match; treat both as [].
+        # Conversation Memory's Lookup response omits or nulls `profiles` when no match;
+        # treat both as [].
         return [] if v is None else v

--- a/tests/test_chat_channel.py
+++ b/tests/test_chat_channel.py
@@ -298,7 +298,7 @@ class TestChatChannel:
         """When TAC.conversations_v1_service_sid is cached, it's forwarded as
         channelSettings.chatService on the Action request.
 
-        TODO(maestro): Drop this test when the chatService workaround is removed.
+        TODO(conv-orch): Drop this test when the chatService workaround is removed.
         """
         tac = TAC(get_test_config())
         tac.conversations_v1_service_sid = "ISabcdef1234567890abcdef1234567890"

--- a/tests/test_memory_models.py
+++ b/tests/test_memory_models.py
@@ -139,7 +139,7 @@ class TestMemoryModels:
 
 
 class TestProfileLookupResponse:
-    """Memora's Lookup endpoint returns `profiles` as optional per its OpenAPI
+    """Conversation Memory's Lookup endpoint returns `profiles` as optional per its OpenAPI
     spec, so null and omitted variants must both parse to an empty list."""
 
     def test_accepts_null_profiles(self):

--- a/tests/test_participant_reconciliation.py
+++ b/tests/test_participant_reconciliation.py
@@ -1,7 +1,7 @@
 """Tests for `_reconcile_participants` in MessagingChannel.
 
 Covers the matrix of participant states that v1-bridge capture can leave us
-with. The resolution rules were agreed with the Maestro team.
+with. The resolution rules were agreed with the Conversation Orchestrator team.
 """
 
 from typing import Any
@@ -278,7 +278,7 @@ async def test_solo_customer_posts_agent() -> None:
 
 @pytest.mark.asyncio
 async def test_add_agent_409_returns_none() -> None:
-    """POST AI_AGENT returns 409 → skip inbound. Maestro is signaling a
+    """POST AI_AGENT returns 409 → skip inbound. Conversation Orchestrator is signaling a
     structural conflict (duplicate conversation, address owned, grouping
     constraint) that TAC can't safely paper over by retrying."""
     tac = _tac()
@@ -311,7 +311,7 @@ async def test_add_agent_409_returns_none() -> None:
 
 @pytest.mark.asyncio
 async def test_promote_409_returns_none() -> None:
-    """PUT returning 409 → skip inbound. Maestro is signaling that the
+    """PUT returning 409 → skip inbound. Conversation Orchestrator is signaling that the
     promotion is structurally blocked (likely a conflicting active
     conversation or grouping constraint); TAC should not retry."""
     tac = _tac()
@@ -345,7 +345,7 @@ async def test_promote_409_returns_none() -> None:
 
 @pytest.mark.asyncio
 async def test_list_participants_failure_returns_none() -> None:
-    """list_participants raising (e.g. Maestro down) skips the webhook."""
+    """list_participants raising (e.g. Conversation Orchestrator down) skips the webhook."""
     tac = _tac()
     channel = SMSChannel(tac)
 
@@ -353,7 +353,7 @@ async def test_list_participants_failure_returns_none() -> None:
         patch.object(
             tac.conversation_orchestrator_client,
             "list_participants",
-            new=AsyncMock(side_effect=httpx.ConnectError("maestro unreachable")),
+            new=AsyncMock(side_effect=httpx.ConnectError("conversation orchestrator unreachable")),
         ),
         patch.object(tac.conversation_orchestrator_client, "update_participant") as mock_update,
     ):
@@ -439,12 +439,12 @@ async def test_customer_promotion_proceeds_without_profile_on_errors() -> None:
         patch.object(
             tac.conversation_memory_client,
             "lookup_profile",
-            new=AsyncMock(side_effect=httpx.ConnectError("memora down")),
+            new=AsyncMock(side_effect=httpx.ConnectError("conversation memory down")),
         ),
         patch.object(
             tac.conversation_memory_client,
             "create_profile",
-            new=AsyncMock(side_effect=httpx.ConnectError("memora down")),
+            new=AsyncMock(side_effect=httpx.ConnectError("conversation memory down")),
         ),
     ):
         result = await channel._reconcile_participants("CH123")
@@ -467,7 +467,7 @@ async def test_reconciliation_lifts_customer_profile_onto_session() -> None:
 
     agent = _participant("PA_A", "AI_AGENT", "+15551234567")
     customer = _participant("PA_C", "CUSTOMER", "+12345678901")
-    # Give the CUSTOMER a profile_id the way a prior reconciliation / Memora
+    # Give the CUSTOMER a profile_id the way a prior reconciliation / Conversation Memory
     # identity-resolution would have.
     customer = customer.model_copy(update={"profile_id": "mem_profile_01abc"})
 


### PR DESCRIPTION
## Summary

Replace internal code-names in comments, docstrings, and log messages:

- **Memora → Conversation Memory** (47 occurrences across 14 files)
- **Maestro → Conversation Orchestrator**
- **`TODO(maestro):` → `TODO(conv-orch):`** (matches the TypeScript SDK's convention)

Also fixes a stale dashboard docstring that referred to `memora_client` / `maestro_client` — those attribute names were renamed to `conversation_memory_client` / `conversation_orchestrator_client` long ago.

No behavior change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist

- [x] Tests added/updated (existing tests still pass: 642 passed)
- [x] Documentation updated (this IS the doc update)
- [x] Tested E2E (N/A — no runtime changes; `make check` clean)

## SDK Parity

The TypeScript SDK already uses the public product names. The matching cleanup on TS was already shipped as part of https://github.com/twilio/twilio-agent-connect-typescript/pull/23 (commit `e5c4fd9`).

- [ ] Change is Python-specific (no TypeScript update needed)
- [x] TypeScript SDK PR created: https://github.com/twilio/twilio-agent-connect-typescript/pull/23