### PR TITLE
build: Exclude dev files from PyPI source distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,22 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/tac"]
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/.github",
+    "/.venv",
+    "/.claude",
+    "/__pycache__",
+    "*.pyc",
+    ".DS_Store",
+    "CLAUDE.md",
+    "/getting_started",
+    "/.pre-commit-config.yaml",
+    "/Makefile",
+    "/logo.svg",
+    "/uv.lock",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"


### PR DESCRIPTION
## Summary

Configures Hatchling to exclude development artifacts from the PyPI source distribution (sdist). The wheel distribution already only includes runtime code via `packages = ["src/tac"]`.

**What gets excluded from sdist:**
- `.github/` - CI workflows and PR templates
- `.claude/` - Claude Code skills
- `getting_started/` - Example code and tutorials
- `.pre-commit-config.yaml`, `Makefile`, `logo.svg`, `uv.lock`, `CLAUDE.md` - Dev tools and internal docs

**Verification:**
- Wheel (63 files): Only `tac/` package code ✅
- SDist: Source code + tests, excludes dev artifacts ✅

## Type of Change

- [x] Refactoring

## Checklist

- [x] Tests added/updated (no tests needed - build config only)
- [x] Documentation updated (not needed)
- [x] Tested E2E (verified with `uv build` + inspected archives)

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)