### PR TITLE
chore: Bump version to 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twilio-agent-connect"
-version = "0.0.3"
+version = "1.0.1"
 description = "A Python framework for building agentic applications with Twilio"
 authors = [{ name = "Twilio Conversation AI", email = "team_conversational-ai@twilio.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2124,7 +2124,7 @@ wheels = [
 
 [[package]]
 name = "twilio-agent-connect"
-version = "0.0.3"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Bump package version from 0.0.3 to 1.0.1 in pyproject.toml and update uv.lock accordingly.

## Test plan

- [ ] Verify version in pyproject.toml is 1.0.1
- [ ] Verify uv.lock reflects the version change
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)