### PR TITLE
build: Optimize sdist to include only essential files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,14 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/tac"]
 
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/README.md",
+    "/LICENSE",
+    "/pyproject.toml",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"


### PR DESCRIPTION
## Summary

Configures hatchling to explicitly include only essential files in the source distribution (sdist), excluding development files like `.github/`, `CLAUDE.md`, `getting_started/`, `tests/`, `Makefile`, etc.

**Before:** 137 files in sdist
**After:** 64 files in sdist (only source code, README, LICENSE, pyproject.toml)

This reduces package size and download time while ensuring all necessary files for installation are included.

## Test plan

- [x] Built sdist with `uv build`
- [x] Verified file count reduced from 137 to 64
- [x] Verified dev files excluded (`.github/`, `CLAUDE.md`, `getting_started/`, `tests/`)
- [x] Verified essential files included (`src/`, `README.md`, `LICENSE`, `pyproject.toml`)
- [x] Installed from sdist tarball successfully
- [x] Installed from wheel successfully
- [x] Verified package imports work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)