### PR TITLE
Add AWS partner examples: Bedrock Agent, AgentCore, and Strands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,5 +160,8 @@ Desktop.ini
 *.swp
 *.swo
 
+# Strands session storage
+getting_started/examples/partners/.strands_sessions/
+
 # Local Makefile overrides
 Makefile.local

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ For detailed architecture and advanced usage, see [CLAUDE.md](https://github.com
 
 **Examples & Guides:**
 - **[Getting Started Guide](https://github.com/twilio/twilio-agent-connect-python/tree/main/getting_started/)** - Setup wizard, examples, and comprehensive documentation
-- **[Partner SDK Examples](https://github.com/twilio/twilio-agent-connect-python/tree/main/getting_started/examples/partners/)** - OpenAI Chat Completions and Responses API examples
+- **[Partner SDK Examples](https://github.com/twilio/twilio-agent-connect-python/tree/main/getting_started/examples/partners/)** - Integration examples for OpenAI, AWS Bedrock Agent, AWS Bedrock AgentCore, and AWS Strands
 - **[ConversationRelay-Only Mode](https://github.com/twilio/twilio-agent-connect-python/blob/main/getting_started/examples/features/relay_only.py)** - Get started with voice using just ConversationRelay
 - More examples coming soon
 

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -44,11 +44,12 @@ Learn the core pattern for manually extracting and injecting TAC memory into **a
 
 ### `partners/` - Partner SDK Examples
 
-Production-ready examples using partner SDK adapters:
-- **`openai_chat_completions.py`**: OpenAI Chat Completions API
-- **`openai_responses_api.py`**: OpenAI Responses API
-- Automatic memory injection with `with_tac_memory()`
-- Less boilerplate, more convention-based
+Production-ready examples integrating TAC with partner SDKs:
+- **`openai_chat_completions.py`**: OpenAI Chat Completions API with automatic memory injection via `with_tac_memory()`
+- **`openai_responses_api.py`**: OpenAI Responses API with automatic memory injection
+- **`aws_bedrock_agent.py`**: AWS Bedrock Agent integration
+- **`aws_bedrock_agentcore.py`**: AWS Bedrock AgentCore integration
+- **`aws_strands.py`**: AWS Strands agents integration
 
 ### `features/` - Feature Examples
 
@@ -84,6 +85,9 @@ walks up from the script's directory, so it'll find
 uv run getting_started/examples/overview.py
 uv run getting_started/examples/partners/openai_chat_completions.py
 uv run getting_started/examples/partners/openai_responses_api.py
+uv run getting_started/examples/partners/aws_bedrock_agent.py
+uv run getting_started/examples/partners/aws_bedrock_agentcore.py
+uv run getting_started/examples/partners/aws_strands.py
 uv run getting_started/examples/features/voice_streaming.py
 uv run getting_started/examples/features/handoff.py
 uv run getting_started/examples/features/relay_only.py

--- a/getting_started/examples/.env.example
+++ b/getting_started/examples/.env.example
@@ -8,28 +8,30 @@ TWILIO_API_KEY=SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_API_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_PHONE_NUMBER=+1xxxxxxxxxx
 
-# Omit for ConversationRelay-only mode (voice-only).
+# Required for all examples except relay_only.py
 TWILIO_CONVERSATION_CONFIGURATION_ID=conv_configuration_xxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Optional - Twilio log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 TWILIO_LOG_LEVEL=INFO
 
-# Optional - Voice Channel (ngrok domain without https://)
-TWILIO_VOICE_PUBLIC_DOMAIN=your-domain.ngrok.app
+# ============================================================================
+# Feature Examples
+# ============================================================================
 
-# Optional - Chat Example
-TWILIO_CONVERSATIONS_SERVICE_SID=ISxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Required for all feature examples (OpenAI Agents SDK)
+OPENAI_API_KEY=sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# Optional - RCS Channel (RCS Sender ID)
-# Required for features/rcs.py example
+# Required for features/handoff.py
+TWILIO_STUDIO_HANDOFF_FLOW_SID=FWxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Required for features/rcs.py
 TWILIO_RCS_SENDER_ID=rcs:your_sender_id
 
-# Optional - WhatsApp Channel (WhatsApp-enabled phone number)
-# Required for features/whatsapp.py example
-TWILIO_WHATSAPP_NUMBER=whatsapp:+1xxxxxxxxxx
+# Required for features/voice_streaming.py
+TWILIO_VOICE_PUBLIC_DOMAIN=your-domain.ngrok.app
 
-# Optional - Handoff Example (Studio Flow SID used by create_studio_handoff_tool)
-TWILIO_STUDIO_HANDOFF_FLOW_SID=FWxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# Required for features/whatsapp.py
+TWILIO_WHATSAPP_NUMBER=whatsapp:+1xxxxxxxxxx
 
 # ============================================================================
 # Partner Examples - OpenAI

--- a/getting_started/examples/.env.example
+++ b/getting_started/examples/.env.example
@@ -52,8 +52,6 @@ BEDROCK_AGENT_ALIAS_ID=your-alias-id
 # Required for partners/aws_bedrock_agentcore.py
 BEDROCK_AGENTCORE_AGENT_ARN=arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/simpleagent-XXX
 
-# Required for partners/aws_strands.py
-# Strands defaults to Amazon Bedrock with Claude Sonnet 4
 # Configure AWS credentials (choose one method):
 #   1. Environment variables (add to this .env file):
 #        AWS_ACCESS_KEY_ID=your-access-key-id

--- a/getting_started/examples/.env.example
+++ b/getting_started/examples/.env.example
@@ -52,6 +52,9 @@ BEDROCK_AGENT_ALIAS_ID=your-alias-id
 # Required for partners/aws_bedrock_agentcore.py
 BEDROCK_AGENTCORE_AGENT_ARN=arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/simpleagent-XXX
 
+# Required for partners/aws_strands.py
+STRANDS_MODEL_ID=us.amazon.nova-pro-v1:0
+
 # Configure AWS credentials (choose one method):
 #   1. Environment variables (add to this .env file):
 #        AWS_ACCESS_KEY_ID=your-access-key-id

--- a/getting_started/examples/.env.example
+++ b/getting_started/examples/.env.example
@@ -28,8 +28,39 @@ TWILIO_RCS_SENDER_ID=rcs:your_sender_id
 # Required for features/whatsapp.py example
 TWILIO_WHATSAPP_NUMBER=whatsapp:+1xxxxxxxxxx
 
-# Optional - OpenAI Examples
-OPENAI_API_KEY=sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
 # Optional - Handoff Example (Studio Flow SID used by create_studio_handoff_tool)
 TWILIO_STUDIO_HANDOFF_FLOW_SID=FWxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# ============================================================================
+# Partner Examples - OpenAI
+# ============================================================================
+
+# Required for partners/openai_*.py examples
+OPENAI_API_KEY=sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# ============================================================================
+# Partner Examples - AWS
+# ============================================================================
+
+# Required: AWS Region
+AWS_REGION=us-east-1
+
+# Required for partners/aws_bedrock_agent.py
+BEDROCK_AGENT_ID=your-agent-id
+BEDROCK_AGENT_ALIAS_ID=your-alias-id
+
+# Required for partners/aws_bedrock_agentcore.py
+BEDROCK_AGENTCORE_AGENT_ARN=arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/simpleagent-XXX
+
+# Required for partners/aws_strands.py
+# Strands defaults to Amazon Bedrock with Claude Sonnet 4
+# Configure AWS credentials (choose one method):
+#   1. Environment variables (add to this .env file):
+#        AWS_ACCESS_KEY_ID=your-access-key-id
+#        AWS_SECRET_ACCESS_KEY=your-secret-access-key
+#        AWS_SESSION_TOKEN=your-session-token (optional)
+#   2. AWS credentials file: Run `aws configure` CLI command
+#   3. IAM roles: If running on AWS services (EC2, ECS, Lambda)
+#   4. Bedrock API keys: Set AWS_BEARER_TOKEN_BEDROCK environment variable
+# Ensure your AWS credentials have permissions to invoke Amazon Bedrock models
+# See: https://strandsagents.com/docs/user-guide/quickstart/python/

--- a/getting_started/examples/features/voice_streaming.py
+++ b/getting_started/examples/features/voice_streaming.py
@@ -1,5 +1,5 @@
 """
-Voice Streaming Example with OpenAI
+Voice Streaming Example with OpenAI Agents SDK
 
 Streaming reduces latency by sending LLM tokens immediately to the caller.
 
@@ -9,12 +9,11 @@ Performance comparison (streaming vs non-streaming):
 - Result: ~40-50% faster time-to-first-audio with streaming
 """
 
-import os
 from collections.abc import AsyncGenerator
+from typing import Any
 
+from agents import Agent, Runner, set_tracing_disabled
 from dotenv import load_dotenv
-from openai import AsyncOpenAI
-from openai.types.chat import ChatCompletionMessageParam
 
 from tac import TAC, TACConfig
 from tac.channels.voice import VoiceChannel
@@ -23,55 +22,42 @@ from tac.models.tac import TACMemoryResponse
 from tac.server import TACFastAPIServer
 
 load_dotenv()
+set_tracing_disabled(True)
 
 tac = TAC(config=TACConfig.from_env())
 voice_channel = VoiceChannel(tac)
-openai_client = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
-conversation_history: dict[str, list[ChatCompletionMessageParam]] = {}
-SYSTEM_MESSAGE: ChatCompletionMessageParam = {
-    "role": "system",
-    "content": (
-        "You are a voice assistant speaking with a user over the phone. "
-        "Keep responses short and conversational — a sentence or two. "
-        "Do not use markdown, asterisks, bullets, or emojis; your words "
-        "will be spoken aloud."
-    ),
-}
+SYSTEM_INSTRUCTIONS = (
+    "You are a voice assistant speaking with a user over the phone. "
+    "Keep responses short and conversational — a sentence or two. "
+    "Do not use markdown, asterisks, bullets, or emojis; your words will be "
+    "spoken aloud."
+)
+
+agent = Agent(name="Voice Assistant", instructions=SYSTEM_INSTRUCTIONS)
+
+conversation_history: dict[str, list[Any]] = {}
 
 
 async def handle_message_ready(
     user_message: str, context: ConversationSession, memory_response: TACMemoryResponse | None
 ) -> None:
-    """Return None and manually call send_response() with an async generator for streaming."""
+    """Stream voice responses through the OpenAI Agents SDK.
+
+    Returns None and manually calls send_response() with an async generator
+    so tokens are sent to the caller as they arrive from the LLM.
+    """
     conv_id = context.conversation_id
 
-    if conv_id not in conversation_history:
-        conversation_history[conv_id] = [SYSTEM_MESSAGE.copy()]
-
-    conversation_history[conv_id].append({"role": "user", "content": user_message})
-
-    # Use conversation history for streaming
-    messages = conversation_history[conv_id][:]  # Copy list
+    history = conversation_history.get(conv_id, [])
+    agent_input = history + [{"role": "user", "content": user_message}]
 
     async def stream_tokens() -> AsyncGenerator[str, None]:
-        response_tokens = []
-
-        # Stream from OpenAI
-        stream = await openai_client.chat.completions.create(
-            model="gpt-4o-mini",
-            messages=messages,
-            stream=True,
-        )
-
-        async for chunk in stream:
-            if chunk.choices and chunk.choices[0].delta.content:
-                token = chunk.choices[0].delta.content
-                response_tokens.append(token)
-                yield token
-
-        full_response = "".join(response_tokens)
-        conversation_history[conv_id].append({"role": "assistant", "content": full_response})
+        result = Runner.run_streamed(agent, agent_input)
+        async for event in result.stream_events():
+            if event.type == "raw_response_event" and hasattr(event.data, "delta"):
+                yield event.data.delta
+        conversation_history[conv_id] = result.to_input_list()
 
     await voice_channel.send_response(conv_id, stream_tokens())
 

--- a/getting_started/examples/partners/aws_bedrock_agent.py
+++ b/getting_started/examples/partners/aws_bedrock_agent.py
@@ -68,10 +68,9 @@ async def handle_message_ready(
     conv_id = context.conversation_id
 
     try:
-        # Compose user message with memory context
+        # Compose user message with memory context (user message first, then memory)
         # Note: Bedrock Agents don't support system prompt at invocation time.
         # The agent's instructions are configured when deploying the agent in AWS Bedrock.
-        # We prepend memory context to the user message in inputText.
         input_text = MemoryPromptBuilder.compose(
             system_prompt=user_message,
             memory_response=memory_response,

--- a/getting_started/examples/partners/aws_bedrock_agent.py
+++ b/getting_started/examples/partners/aws_bedrock_agent.py
@@ -38,7 +38,7 @@ logger = get_logger(__name__)
 tac = TAC(config=TACConfig.from_env())
 
 # Create channel handlers for Voice and SMS
-voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
 sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
 
 # Get Bedrock Agent configuration

--- a/getting_started/examples/partners/aws_bedrock_agent.py
+++ b/getting_started/examples/partners/aws_bedrock_agent.py
@@ -39,16 +39,9 @@ voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"
 sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
 
 # Get Bedrock Agent configuration
-agent_id = os.environ.get("BEDROCK_AGENT_ID")
-agent_alias_id = os.environ.get("BEDROCK_AGENT_ALIAS_ID")
-region = os.environ.get("AWS_REGION")
-
-if not agent_id:
-    raise ValueError("BEDROCK_AGENT_ID environment variable is required")
-if not agent_alias_id:
-    raise ValueError("BEDROCK_AGENT_ALIAS_ID environment variable is required")
-if not region:
-    raise ValueError("AWS_REGION environment variable is required")
+agent_id = os.environ["BEDROCK_AGENT_ID"]
+agent_alias_id = os.environ["BEDROCK_AGENT_ALIAS_ID"]
+region = os.environ["AWS_REGION"]
 
 # Create Bedrock Agent Runtime client
 bedrock_client = boto3.client("bedrock-agent-runtime", region_name=region)

--- a/getting_started/examples/partners/aws_bedrock_agent.py
+++ b/getting_started/examples/partners/aws_bedrock_agent.py
@@ -1,0 +1,125 @@
+"""
+Example: Using AWS Bedrock Agent with TAC
+
+Demonstrates how to connect Twilio Agent Connect with AWS Bedrock Agents
+for voice and SMS channels using boto3 directly.
+
+Prerequisites:
+    pip install boto3
+
+Environment Variables:
+    BEDROCK_AGENT_ID - Your Bedrock Agent ID
+    BEDROCK_AGENT_ALIAS_ID - Agent Alias ID
+    AWS_REGION - AWS Region
+"""
+
+import os
+
+import boto3
+from dotenv import load_dotenv
+
+from tac import TAC, TACConfig
+from tac.adapters import MemoryPromptBuilder
+from tac.channels.sms import SMSChannel, SMSChannelConfig
+from tac.channels.voice import VoiceChannel, VoiceChannelConfig
+from tac.core.logging import get_logger
+from tac.models.session import ConversationSession
+from tac.models.tac import TACMemoryResponse
+from tac.server import TACFastAPIServer
+
+load_dotenv()
+
+logger = get_logger(__name__)
+
+# Initialize TAC with configuration from environment variables
+tac = TAC(config=TACConfig.from_env())
+
+# Create channel handlers for Voice and SMS
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
+sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
+
+# Get Bedrock Agent configuration
+agent_id = os.environ.get("BEDROCK_AGENT_ID")
+agent_alias_id = os.environ.get("BEDROCK_AGENT_ALIAS_ID")
+region = os.environ.get("AWS_REGION")
+
+if not agent_id:
+    raise ValueError("BEDROCK_AGENT_ID environment variable is required")
+if not agent_alias_id:
+    raise ValueError("BEDROCK_AGENT_ALIAS_ID environment variable is required")
+if not region:
+    raise ValueError("AWS_REGION environment variable is required")
+
+# Create Bedrock Agent Runtime client
+bedrock_client = boto3.client("bedrock-agent-runtime", region_name=region)
+
+
+async def handle_message_ready(
+    user_message: str,
+    context: ConversationSession,
+    memory_response: TACMemoryResponse | None,
+) -> str:
+    """
+    Callback invoked when a message is ready to be processed.
+
+    This example calls AWS Bedrock Agent and returns the complete response.
+
+    Args:
+        user_message: The customer's message text
+        context: Session data (conversation_id, channel, profile, etc.)
+        memory_response: Optional retrieved memories (observations, summaries, communications)
+
+    Returns:
+        Response string to send to the channel
+    """
+    conv_id = context.conversation_id
+
+    try:
+        # Compose user message with memory context
+        # Note: Bedrock Agents don't support system prompt at invocation time.
+        # The agent's instructions are configured when deploying the agent in AWS Bedrock.
+        # We prepend memory context to the user message in inputText.
+        input_text = MemoryPromptBuilder.compose(
+            system_prompt=user_message,
+            memory_response=memory_response,
+            context=context,
+        )
+
+        # Invoke Bedrock Agent
+        response = bedrock_client.invoke_agent(
+            agentId=agent_id,
+            agentAliasId=agent_alias_id,
+            sessionId=conv_id,
+            inputText=input_text,
+            enableTrace=False,
+        )
+
+        # Collect all response chunks
+        chunks = []
+        event_stream = response.get("completion", [])
+        for event in event_stream:
+            if "chunk" in event:
+                chunk_data = event["chunk"]
+                if "bytes" in chunk_data:
+                    chunk_text = chunk_data["bytes"].decode("utf-8")
+                    chunks.append(chunk_text)
+
+        return "".join(chunks) if chunks else "No response from agent."
+
+    except Exception as e:
+        logger.error("Error processing message", conversation_id=conv_id, error=str(e))
+        return "Sorry, I encountered an error processing your message."
+
+
+# Register the message handler callback
+tac.on_message_ready(handle_message_ready)
+
+if __name__ == "__main__":
+    # TACFastAPIServer creates a FastAPI app with all required endpoints:
+    # - /twiml: Voice call webhook (returns TwiML with ConversationRelay)
+    # - /ws: WebSocket endpoint for Voice channel
+    # - /webhook: Conversation webhook for all channels
+    server = TACFastAPIServer(
+        tac=tac, voice_channel=voice_channel, messaging_channels=[sms_channel]
+    )
+    server.start()

--- a/getting_started/examples/partners/aws_bedrock_agent.py
+++ b/getting_started/examples/partners/aws_bedrock_agent.py
@@ -7,6 +7,9 @@ for voice and SMS channels using boto3 directly.
 Prerequisites:
     pip install boto3
 
+For an enhanced integration experience with Amazon Bedrock Agents, check out our
+dedicated connector: https://github.com/twilio/twilio-agent-connect-aws
+
 Environment Variables:
     BEDROCK_AGENT_ID - Your Bedrock Agent ID
     BEDROCK_AGENT_ALIAS_ID - Agent Alias ID

--- a/getting_started/examples/partners/aws_bedrock_agentcore.py
+++ b/getting_started/examples/partners/aws_bedrock_agentcore.py
@@ -38,7 +38,7 @@ logger = get_logger(__name__)
 tac = TAC(config=TACConfig.from_env())
 
 # Create channel handlers for Voice and SMS
-voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
 sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
 
 # Get AgentCore configuration

--- a/getting_started/examples/partners/aws_bedrock_agentcore.py
+++ b/getting_started/examples/partners/aws_bedrock_agentcore.py
@@ -7,6 +7,9 @@ for voice and SMS channels.
 Prerequisites:
     pip install boto3
 
+For an enhanced integration experience with Amazon Bedrock AgentCore, check out our
+dedicated connector: https://github.com/twilio/twilio-agent-connect-aws
+
 Environment Variables:
     BEDROCK_AGENTCORE_AGENT_ARN - ARN of deployed AgentCore runtime
     AWS_REGION - AWS Region

--- a/getting_started/examples/partners/aws_bedrock_agentcore.py
+++ b/getting_started/examples/partners/aws_bedrock_agentcore.py
@@ -39,13 +39,8 @@ voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"
 sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
 
 # Get AgentCore configuration
-agent_arn = os.environ.get("BEDROCK_AGENTCORE_AGENT_ARN")
-region = os.environ.get("AWS_REGION")
-
-if not agent_arn:
-    raise ValueError("BEDROCK_AGENTCORE_AGENT_ARN environment variable is required")
-if not region:
-    raise ValueError("AWS_REGION environment variable is required")
+agent_arn = os.environ["BEDROCK_AGENTCORE_AGENT_ARN"]
+region = os.environ["AWS_REGION"]
 
 # Create Bedrock AgentCore client
 agentcore_client = boto3.client("bedrock-agentcore", region_name=region)
@@ -93,22 +88,22 @@ async def handle_message_ready(
         content = []
         if "text/event-stream" in response.get("contentType", ""):
             # Handle streaming response
-            for line in response["response"].iter_lines():
-                if line:
-                    line = line.decode("utf-8")
+            for line_bytes in response["response"].iter_lines():
+                if line_bytes:
+                    line = line_bytes.decode("utf-8")
                     if line.startswith("data: "):
-                        line = line[6:]  # Remove "data: " prefix
-                        if line and line != "[DONE]":
+                        chunk_text = line[6:]  # Remove "data: " prefix
+                        if chunk_text and chunk_text != "[DONE]":
                             # Parse JSON to extract token
                             try:
-                                data = json.loads(line)
+                                data = json.loads(chunk_text)
                                 if isinstance(data, dict) and data.get("type") == "text":
                                     token = data.get("token", "")
                                     if token:
                                         content.append(token)
                             except json.JSONDecodeError:
                                 # If not JSON, use raw text
-                                content.append(line)
+                                content.append(chunk_text)
 
         return "".join(content) if content else "No response from agent."
 

--- a/getting_started/examples/partners/aws_bedrock_agentcore.py
+++ b/getting_started/examples/partners/aws_bedrock_agentcore.py
@@ -1,0 +1,131 @@
+"""
+Example: Using AWS Bedrock AgentCore with TAC
+
+Demonstrates how to connect Twilio Agent Connect with AWS Bedrock AgentCore
+for voice and SMS channels.
+
+Prerequisites:
+    pip install boto3
+
+Environment Variables:
+    BEDROCK_AGENTCORE_AGENT_ARN - ARN of deployed AgentCore runtime
+    AWS_REGION - AWS Region
+"""
+
+import json
+import os
+
+import boto3
+from dotenv import load_dotenv
+
+from tac import TAC, TACConfig
+from tac.adapters import MemoryPromptBuilder
+from tac.channels.sms import SMSChannel, SMSChannelConfig
+from tac.channels.voice import VoiceChannel, VoiceChannelConfig
+from tac.core.logging import get_logger
+from tac.models.session import ConversationSession
+from tac.models.tac import TACMemoryResponse
+from tac.server import TACFastAPIServer
+
+load_dotenv()
+
+logger = get_logger(__name__)
+
+# Initialize TAC with configuration from environment variables
+tac = TAC(config=TACConfig.from_env())
+
+# Create channel handlers for Voice and SMS
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
+sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
+
+# Get AgentCore configuration
+agent_arn = os.environ.get("BEDROCK_AGENTCORE_AGENT_ARN")
+region = os.environ.get("AWS_REGION")
+
+if not agent_arn:
+    raise ValueError("BEDROCK_AGENTCORE_AGENT_ARN environment variable is required")
+if not region:
+    raise ValueError("AWS_REGION environment variable is required")
+
+# Create Bedrock AgentCore client
+agentcore_client = boto3.client("bedrock-agentcore", region_name=region)
+
+
+async def handle_message_ready(
+    user_message: str,
+    context: ConversationSession,
+    memory_response: TACMemoryResponse | None,
+) -> str:
+    """
+    Callback invoked when a message is ready to be processed.
+
+    This example calls AWS Bedrock AgentCore and returns the complete response.
+
+    Args:
+        user_message: The customer's message text
+        context: Session data (conversation_id, channel, profile, etc.)
+        memory_response: Optional retrieved memories (observations, summaries, communications)
+
+    Returns:
+        Response string to send to the channel
+    """
+    conv_id = context.conversation_id
+
+    try:
+        # Compose user message with memory context
+        prompt = MemoryPromptBuilder.compose(
+            system_prompt=user_message,
+            memory_response=memory_response,
+            context=context,
+        )
+
+        # Prepare payload for AgentCore
+        payload = json.dumps({"prompt": prompt}).encode("utf-8")
+
+        # Invoke AgentCore runtime
+        response = agentcore_client.invoke_agent_runtime(
+            agentRuntimeArn=agent_arn,
+            runtimeSessionId=conv_id,
+            payload=payload,
+        )
+
+        # Process streaming response
+        content = []
+        if "text/event-stream" in response.get("contentType", ""):
+            # Handle streaming response
+            for line in response["response"].iter_lines():
+                if line:
+                    line = line.decode("utf-8")
+                    if line.startswith("data: "):
+                        line = line[6:]  # Remove "data: " prefix
+                        if line and line != "[DONE]":
+                            # Parse JSON to extract token
+                            try:
+                                data = json.loads(line)
+                                if isinstance(data, dict) and data.get("type") == "text":
+                                    token = data.get("token", "")
+                                    if token:
+                                        content.append(token)
+                            except json.JSONDecodeError:
+                                # If not JSON, use raw text
+                                content.append(line)
+
+        return "".join(content) if content else "No response from agent."
+
+    except Exception as e:
+        logger.error("Error processing message", conversation_id=conv_id, error=str(e))
+        return "Sorry, I encountered an error processing your message."
+
+
+# Register the message handler callback
+tac.on_message_ready(handle_message_ready)
+
+if __name__ == "__main__":
+    # TACFastAPIServer creates a FastAPI app with all required endpoints:
+    # - /twiml: Voice call webhook (returns TwiML with ConversationRelay)
+    # - /ws: WebSocket endpoint for Voice channel
+    # - /webhook: Conversation webhook for all channels
+    server = TACFastAPIServer(
+        tac=tac, voice_channel=voice_channel, messaging_channels=[sms_channel]
+    )
+    server.start()

--- a/getting_started/examples/partners/aws_bedrock_agentcore.py
+++ b/getting_started/examples/partners/aws_bedrock_agentcore.py
@@ -87,14 +87,12 @@ async def handle_message_ready(
         # Process streaming response
         content = []
         if "text/event-stream" in response.get("contentType", ""):
-            # Handle streaming response
             for line_bytes in response["response"].iter_lines():
                 if line_bytes:
                     line = line_bytes.decode("utf-8")
                     if line.startswith("data: "):
-                        chunk_text = line[6:]  # Remove "data: " prefix
+                        chunk_text = line[6:]
                         if chunk_text and chunk_text != "[DONE]":
-                            # Parse JSON to extract token
                             try:
                                 data = json.loads(chunk_text)
                                 if isinstance(data, dict) and data.get("type") == "text":
@@ -102,7 +100,6 @@ async def handle_message_ready(
                                     if token:
                                         content.append(token)
                             except json.JSONDecodeError:
-                                # If not JSON, use raw text
                                 content.append(chunk_text)
 
         return "".join(content) if content else "No response from agent."

--- a/getting_started/examples/partners/aws_bedrock_agentcore.py
+++ b/getting_started/examples/partners/aws_bedrock_agentcore.py
@@ -67,7 +67,7 @@ async def handle_message_ready(
     conv_id = context.conversation_id
 
     try:
-        # Compose user message with memory context
+        # Compose user message with memory context (user message first, then memory)
         prompt = MemoryPromptBuilder.compose(
             system_prompt=user_message,
             memory_response=memory_response,

--- a/getting_started/examples/partners/aws_strands.py
+++ b/getting_started/examples/partners/aws_strands.py
@@ -53,15 +53,9 @@ tac = TAC(config=TACConfig.from_env())
 voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
 sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
 
-# Get AWS region from environment
-region = os.environ.get("AWS_REGION")
-if not region:
-    raise ValueError("AWS_REGION environment variable is required")
-
-# Get model ID from environment
-model_id = os.environ.get("STRANDS_MODEL_ID")
-if not model_id:
-    raise ValueError("STRANDS_MODEL_ID environment variable is required")
+# Get AWS region and model ID from environment
+region = os.environ["AWS_REGION"]
+model_id = os.environ["STRANDS_MODEL_ID"]
 
 # Store session managers per conversation
 session_managers: dict[str, FileSessionManager] = {}

--- a/getting_started/examples/partners/aws_strands.py
+++ b/getting_started/examples/partners/aws_strands.py
@@ -1,0 +1,132 @@
+"""
+Example: Using AWS Strands with TAC
+
+Demonstrates how to connect Twilio Agent Connect with AWS Strands agents
+for voice and SMS channels.
+
+Prerequisites:
+    pip install strands-agents
+
+    Configure AWS credentials (choose one method):
+    1. Environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN (optional)
+    2. AWS credentials file: Run `aws configure` CLI command
+    3. IAM roles: If running on AWS services (EC2, ECS, Lambda)
+    4. Bedrock API keys: Set AWS_BEARER_TOKEN_BEDROCK environment variable
+
+    Ensure your AWS credentials have permissions to invoke Amazon Bedrock models.
+    By default, Strands uses Amazon Bedrock with Claude Sonnet 4.
+
+    For more details: https://strandsagents.com/docs/user-guide/quickstart/python/
+
+Environment Variables:
+    AWS_REGION - AWS Region
+"""
+
+import os
+
+from dotenv import load_dotenv
+from strands import Agent
+
+from tac import TAC, TACConfig
+from tac.adapters import MemoryPromptBuilder
+from tac.channels.sms import SMSChannel, SMSChannelConfig
+from tac.channels.voice import VoiceChannel, VoiceChannelConfig
+from tac.core.logging import get_logger
+from tac.models.session import ConversationSession
+from tac.models.tac import TACMemoryResponse
+from tac.server import TACFastAPIServer
+
+load_dotenv()
+
+logger = get_logger(__name__)
+
+# Initialize TAC with configuration from environment variables
+tac = TAC(config=TACConfig.from_env())
+
+# Create channel handlers for Voice and SMS
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
+sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
+
+# Verify AWS_REGION is set
+region = os.environ.get("AWS_REGION")
+if not region:
+    raise ValueError("AWS_REGION environment variable is required")
+
+# Store agent instances per conversation
+conversation_agents: dict[str, Agent] = {}
+
+
+async def handle_message_ready(
+    user_message: str,
+    context: ConversationSession,
+    memory_response: TACMemoryResponse | None,
+) -> str:
+    """
+    Callback invoked when a message is ready to be processed.
+
+    This example uses AWS Strands Agent with TAC memory context.
+
+    Args:
+        user_message: The customer's message text
+        context: Session data (conversation_id, channel, profile, etc.)
+        memory_response: Optional retrieved memories (observations, summaries, communications)
+
+    Returns:
+        Response string to send to the channel
+    """
+    conv_id = context.conversation_id
+
+    try:
+        # Create agent for this conversation (only once per conversation)
+        if conv_id not in conversation_agents:
+            # Compose system prompt with memory context
+            system_prompt = MemoryPromptBuilder.compose(
+                system_prompt=(
+                    "You are a customer service agent speaking with a user over voice or SMS. "
+                    "Keep responses short and conversational — a sentence or two. "
+                    "Do not use markdown, asterisks, bullets, or emojis; your words will be "
+                    "spoken aloud or sent as plain text."
+                ),
+                memory_response=memory_response,
+                context=context,
+            )
+
+            conversation_agents[conv_id] = Agent(
+                model="us.amazon.nova-pro-v1:0",  # Use cross-region inference profile
+                system_prompt=system_prompt,
+            )
+
+        agent = conversation_agents[conv_id]
+
+        # Call Strands agent (invoke_async for async compatibility)
+        result = await agent.invoke_async(user_message)
+
+        # Extract response text from result
+        # result.message is a dict: {"role": "assistant", "content": [{"text": "..."}]}
+        response_text = ""
+        if result and hasattr(result, "message") and result.message:
+            if isinstance(result.message, dict):
+                content = result.message.get("content", [])
+                for block in content:
+                    if isinstance(block, dict) and "text" in block:
+                        response_text += block.get("text", "")
+
+        return response_text if response_text else "No response from agent."
+
+    except Exception as e:
+        logger.error("Error processing message", conversation_id=conv_id, error=str(e))
+        return "Sorry, I encountered an error processing your message."
+
+
+# Register the message handler callback
+tac.on_message_ready(handle_message_ready)
+
+if __name__ == "__main__":
+    # TACFastAPIServer creates a FastAPI app with all required endpoints:
+    # - /twiml: Voice call webhook (returns TwiML with ConversationRelay)
+    # - /ws: WebSocket endpoint for Voice channel
+    # - /webhook: Conversation webhook for all channels
+    server = TACFastAPIServer(
+        tac=tac, voice_channel=voice_channel, messaging_channels=[sms_channel]
+    )
+    server.start()

--- a/getting_started/examples/partners/aws_strands.py
+++ b/getting_started/examples/partners/aws_strands.py
@@ -26,6 +26,7 @@ import os
 
 from dotenv import load_dotenv
 from strands import Agent
+from strands.session.file_session_manager import FileSessionManager
 
 from tac import TAC, TACConfig
 from tac.adapters import MemoryPromptBuilder
@@ -52,8 +53,8 @@ region = os.environ.get("AWS_REGION")
 if not region:
     raise ValueError("AWS_REGION environment variable is required")
 
-# Store agent instances per conversation
-conversation_agents: dict[str, Agent] = {}
+# Store session managers per conversation
+session_managers: dict[str, FileSessionManager] = {}
 
 
 async def handle_message_ready(
@@ -77,32 +78,38 @@ async def handle_message_ready(
     conv_id = context.conversation_id
 
     try:
-        # Create agent for this conversation (only once per conversation)
-        if conv_id not in conversation_agents:
-            # Compose system prompt with memory context
-            system_prompt = MemoryPromptBuilder.compose(
-                system_prompt=(
-                    "You are a customer service agent speaking with a user over voice or SMS. "
-                    "Keep responses short and conversational — a sentence or two. "
-                    "Do not use markdown, asterisks, bullets, or emojis; your words will be "
-                    "spoken aloud or sent as plain text."
-                ),
-                memory_response=memory_response,
-                context=context,
+        # Get or create session manager for this conversation
+        if conv_id not in session_managers:
+            session_managers[conv_id] = FileSessionManager(
+                session_id=conv_id,
+                storage_dir=".strands_sessions",
             )
 
-            conversation_agents[conv_id] = Agent(
-                model="us.amazon.nova-pro-v1:0",  # Use cross-region inference profile
-                system_prompt=system_prompt,
-            )
+        session_manager = session_managers[conv_id]
 
-        agent = conversation_agents[conv_id]
+        # Compose system prompt with memory context
+        system_prompt = MemoryPromptBuilder.compose(
+            system_prompt=(
+                "You are a customer service agent speaking with a user over voice or SMS. "
+                "Keep responses short and conversational — a sentence or two. "
+                "Do not use markdown, asterisks, bullets, or emojis; your words will be "
+                "spoken aloud or sent as plain text."
+            ),
+            memory_response=memory_response,
+            context=context,
+        )
 
-        # Call Strands agent (invoke_async for async compatibility)
+        # Create agent with session manager to maintain conversation history
+        agent = Agent(
+            model="us.amazon.nova-pro-v1:0",
+            system_prompt=system_prompt,
+            session_manager=session_manager,
+        )
+
+        # Call Strands agent
         result = await agent.invoke_async(user_message)
 
         # Extract response text from result
-        # result.message is a dict: {"role": "assistant", "content": [{"text": "..."}]}
         response_text = ""
         if result and hasattr(result, "message") and result.message:
             if isinstance(result.message, dict):

--- a/getting_started/examples/partners/aws_strands.py
+++ b/getting_started/examples/partners/aws_strands.py
@@ -19,13 +19,15 @@ Prerequisites:
     For more details: https://strandsagents.com/docs/user-guide/quickstart/python/
 
 Environment Variables:
-    AWS_REGION - AWS Region
+    AWS_REGION - AWS Region (required)
+    STRANDS_MODEL_ID - Bedrock model ID (required, e.g., us.amazon.nova-pro-v1:0)
 """
 
 import os
 
 from dotenv import load_dotenv
 from strands import Agent
+from strands.models import BedrockModel
 from strands.session.file_session_manager import FileSessionManager
 
 from tac import TAC, TACConfig
@@ -41,6 +43,9 @@ load_dotenv()
 
 logger = get_logger(__name__)
 
+# Get the directory where this script is located
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
 # Initialize TAC with configuration from environment variables
 tac = TAC(config=TACConfig.from_env())
 
@@ -48,10 +53,15 @@ tac = TAC(config=TACConfig.from_env())
 voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
 sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
 
-# Verify AWS_REGION is set
+# Get AWS region from environment
 region = os.environ.get("AWS_REGION")
 if not region:
     raise ValueError("AWS_REGION environment variable is required")
+
+# Get model ID from environment
+model_id = os.environ.get("STRANDS_MODEL_ID")
+if not model_id:
+    raise ValueError("STRANDS_MODEL_ID environment variable is required")
 
 # Store session managers per conversation
 session_managers: dict[str, FileSessionManager] = {}
@@ -82,7 +92,7 @@ async def handle_message_ready(
         if conv_id not in session_managers:
             session_managers[conv_id] = FileSessionManager(
                 session_id=conv_id,
-                storage_dir=".strands_sessions",
+                storage_dir=os.path.join(SCRIPT_DIR, ".strands_sessions"),
             )
 
         session_manager = session_managers[conv_id]
@@ -101,7 +111,7 @@ async def handle_message_ready(
 
         # Create agent with session manager to maintain conversation history
         agent = Agent(
-            model="us.amazon.nova-pro-v1:0",
+            model=BedrockModel(model_id=model_id, region_name=region),
             system_prompt=system_prompt,
             session_manager=session_manager,
         )

--- a/getting_started/examples/partners/aws_strands.py
+++ b/getting_started/examples/partners/aws_strands.py
@@ -53,7 +53,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 tac = TAC(config=TACConfig.from_env())
 
 # Create channel handlers for Voice and SMS
-voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
 sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
 
 # Get AWS region and model ID from environment

--- a/getting_started/examples/partners/aws_strands.py
+++ b/getting_started/examples/partners/aws_strands.py
@@ -18,6 +18,9 @@ Prerequisites:
 
     For more details: https://strandsagents.com/docs/user-guide/quickstart/python/
 
+For an enhanced integration experience with AWS Strands, check out our dedicated connector:
+    https://github.com/twilio/twilio-agent-connect-aws
+
 Environment Variables:
     AWS_REGION - AWS Region (required)
     STRANDS_MODEL_ID - Bedrock model ID (required, e.g., us.amazon.nova-pro-v1:0)

--- a/getting_started/examples/partners/openai_chat_completions.py
+++ b/getting_started/examples/partners/openai_chat_completions.py
@@ -33,7 +33,7 @@ logger = get_logger(__name__)
 tac = TAC(config=TACConfig.from_env())
 
 # Create channel handlers for Voice and SMS
-voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
 sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
 
 # Initialize OpenAI client

--- a/getting_started/examples/partners/openai_responses_api.py
+++ b/getting_started/examples/partners/openai_responses_api.py
@@ -29,7 +29,7 @@ tac = TAC(config=TACConfig.from_env())
 
 # Create channel handlers for Voice and SMS
 # Channels process Twilio webhooks and manage conversation lifecycle
-voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="always"))
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
 sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
 
 # Initialize your LLM client (OpenAI in this example)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,13 @@ dev = [
     "mypy>=1.0.0,<2",
 ]
 examples = [
+    # OpenAI examples
     "openai>=2.0.0",
     "openai-agents>=0.6.0",
+    # AWS examples (using AWS SDKs directly)
+    "boto3>=1.34.0",
+    "strands-agents>=1.30.0",
+    # Common
     "python-dotenv>=1.0.0,<2",
     "fastapi>=0.115.0,<1",
     "uvicorn[standard]>=0.32.0,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ examples = [
     "openai-agents>=0.6.0",
     # AWS examples (using AWS SDKs directly)
     "boto3>=1.34.0",
+    "boto3-stubs[bedrock-agent-runtime,bedrock-agentcore]>=1.34.0",
     "strands-agents>=1.30.0",
     # Common
     "python-dotenv>=1.0.0,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -225,6 +225,28 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3-stubs"
+version = "1.43.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/e2/4dd15f98eb2f9194d04e6a3c5914a643d273bb4e63d38a4e8d8110bcd6ab/boto3_stubs-1.43.5.tar.gz", hash = "sha256:6843be7e835963acb6faeb8d717ed1188d6e9f6a395b3bf3cfe70c65050c343e", size = 102678, upload-time = "2026-05-06T20:47:58.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/54/5cf9f4cee8ce1721c391045203c07cfbf545edb0f2c68705931877b529b2/boto3_stubs-1.43.5-py3-none-any.whl", hash = "sha256:89b780f2dab38c4e037e3ac73d065a57242366a2a9f916e14f718cd50f679ea3", size = 70654, upload-time = "2026-05-06T20:47:52.47Z" },
+]
+
+[package.optional-dependencies]
+bedrock-agent-runtime = [
+    { name = "mypy-boto3-bedrock-agent-runtime" },
+]
+bedrock-agentcore = [
+    { name = "mypy-boto3-bedrock-agentcore" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.43.5"
 source = { registry = "https://pypi.org/simple" }
@@ -236,6 +258,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/a2/1285a22bf157f9e97a8fd236daea95d9b14cc8425ae5f8a616badf948408/botocore-1.43.5.tar.gz", hash = "sha256:5c7207816ab5e48382adcb2a64db388fa4abe9ee1d23f72c82ae62c51a0bc84e", size = 15321290, upload-time = "2026-05-06T19:56:35.658Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/d2/99f1741b12e3cdba2e5370f6dafaab743a373c6f83592601ec75ff2cc47f/botocore-1.43.5-py3-none-any.whl", hash = "sha256:a1df6e0c6346735936f42e6b99f3b28f1e9397731c0bc2563c617df7965a0dc0", size = 15002116, upload-time = "2026-05-06T19:56:29.993Z" },
+]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.42.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/a8/a26608ff39e3a5866c6c79eda10133490205cbddd45074190becece3ff2a/botocore_stubs-1.42.41.tar.gz", hash = "sha256:dbeac2f744df6b814ce83ec3f3777b299a015cbea57a2efc41c33b8c38265825", size = 42411, upload-time = "2026-02-03T20:46:14.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/76/cab7af7f16c0b09347f2ebe7ffda7101132f786acb767666dce43055faab/botocore_stubs-1.42.41-py3-none-any.whl", hash = "sha256:9423110fb0e391834bd2ed44ae5f879d8cb370a444703d966d30842ce2bcb5f0", size = 66759, upload-time = "2026-02-03T20:46:13.02Z" },
 ]
 
 [[package]]
@@ -1374,6 +1408,30 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-boto3-bedrock-agent-runtime"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/29/ccd618a5fe8082904ed8cb39490aa79220b8e856a3ba0786eb19332a3ced/mypy_boto3_bedrock_agent_runtime-1.43.0.tar.gz", hash = "sha256:5a0f329442d3b6a2ea5dc44d2a0f027038351d44033f3fe2e11556363978a210", size = 42042, upload-time = "2026-04-29T22:57:47.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/35/8490203bf6d1b43377548450c8c1e19f5d6d4bc441219fd5355c0c4bee21/mypy_boto3_bedrock_agent_runtime-1.43.0-py3-none-any.whl", hash = "sha256:569ccd99648cbd6b162911601b2b1d8085f4f75090e3a2f07ad9a37b23545a2e", size = 51057, upload-time = "2026-04-29T22:57:45.57Z" },
+]
+
+[[package]]
+name = "mypy-boto3-bedrock-agentcore"
+version = "1.43.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/f7/7dd2a911c5e31f64f0fe9ab3f3e3739433472dc065222222270ac3e92dc3/mypy_boto3_bedrock_agentcore-1.43.1.tar.gz", hash = "sha256:c4a90909366bb8604ca27efb6778013a9b7d6503e2aaeb01922e9317261fc295", size = 46486, upload-time = "2026-04-30T21:16:15.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/28/6de7696f28d222871c7d5caf952d90ba9dc19fadec1f5e640c816aa716ee/mypy_boto3_bedrock_agentcore-1.43.1-py3-none-any.whl", hash = "sha256:b45e4b6aca17f812a34598822f894bccadd43668f3b7b718ce572df354de78bd", size = 52432, upload-time = "2026-04-30T21:16:12.908Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2332,6 +2390,7 @@ dev = [
 ]
 examples = [
     { name = "boto3" },
+    { name = "boto3-stubs", extra = ["bedrock-agent-runtime", "bedrock-agentcore"] },
     { name = "fastapi" },
     { name = "openai" },
     { name = "openai-agents" },
@@ -2362,6 +2421,7 @@ dev = [
 ]
 examples = [
     { name = "boto3", specifier = ">=1.34.0" },
+    { name = "boto3-stubs", extras = ["bedrock-agent-runtime", "bedrock-agentcore"], specifier = ">=1.34.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1" },
     { name = "openai", specifier = ">=2.0.0" },
     { name = "openai-agents", specifier = ">=0.6.0" },
@@ -2369,6 +2429,15 @@ examples = [
     { name = "python-multipart", specifier = ">=0.0.12" },
     { name = "strands-agents", specifier = ">=1.30.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0,<1" },
+]
+
+[[package]]
+name = "types-awscrt"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/26/0aa563e229c269c528a3b8c709fc671ac2a5c564732fab0852ac6ee006cf/types_awscrt-0.31.3.tar.gz", hash = "sha256:09d3eaf00231e0f47e101bd9867e430873bc57040050e2a3bd8305cb4fc30865", size = 18178, upload-time = "2026-03-08T02:31:14.569Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/e5/47a573bbbd0a790f8f9fe452f7188ea72b212d21c9be57d5fc0cbc442075/types_awscrt-0.31.3-py3-none-any.whl", hash = "sha256:e5ce65a00a2ab4f35eacc1e3d700d792338d56e4823ee7b4dbe017f94cfc4458", size = 43340, upload-time = "2026-03-08T02:31:13.38Z" },
 ]
 
 [[package]]
@@ -2381,6 +2450,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
+]
+
+[[package]]
+name = "types-s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -211,6 +211,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/b0/90ba01763dd483bb040d0815dc0ba893421e3f5926672ceab9acbb73b23f/boto3-1.43.5.tar.gz", hash = "sha256:414be7868f25c3b6a0232301c8ab40347911b6b191926b61f00a63f89b97b2bc", size = 113150, upload-time = "2026-05-06T19:56:49.629Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bb/347307758c2003783df1d9a9b07596928d05a6ca0e17790cea3b18105244/boto3-1.43.5-py3-none-any.whl", hash = "sha256:aa8a296c8db55d812767b282cfe4c7977f0b0eeaa709abdaeb368b9c738e901f", size = 140502, upload-time = "2026-05-06T19:56:46.626Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/a2/1285a22bf157f9e97a8fd236daea95d9b14cc8425ae5f8a616badf948408/botocore-1.43.5.tar.gz", hash = "sha256:5c7207816ab5e48382adcb2a64db388fa4abe9ee1d23f72c82ae62c51a0bc84e", size = 15321290, upload-time = "2026-05-06T19:56:35.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/d2/99f1741b12e3cdba2e5370f6dafaab743a373c6f83592601ec75ff2cc47f/botocore-1.43.5-py3-none-any.whl", hash = "sha256:a1df6e0c6346735936f42e6b99f3b28f1e9397731c0bc2563c617df7965a0dc0", size = 15002116, upload-time = "2026-05-06T19:56:29.993Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -615,6 +643,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -871,6 +908,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -980,6 +1029,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
     { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
     { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -1363,6 +1421,75 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-threading"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/2d/2537d5990fa341198cbc8ae70b2c3637037061b8ab1196af1d924a275f55/opentelemetry_instrumentation_threading-0.62b1.tar.gz", hash = "sha256:4b3c876907657e3b8b977bfe15d248f2c02db56302c51883724e7ac2f8ce26d2", size = 9180, upload-time = "2026-04-24T13:23:06.15Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/37/a80fb13b76f85b4e433ff44b4ba177615823c36c28dca12e94d2c37de681/opentelemetry_instrumentation_threading-0.62b1-py3-none-any.whl", hash = "sha256:4596e79c47de122eb2e85877c1a8bfed1cd6ab06bd2c29d120ebcf8a708a433a", size = 9335, upload-time = "2026-04-24T13:22:19.419Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1727,6 +1854,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2007,6 +2146,27 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2039,6 +2199,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "strands-agents"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "docstring-parser" },
+    { name = "jsonschema" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation-threading" },
+    { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "typing-extensions" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/89/3e722f4b5bd913531bc32a23bf88aaa77a434774f294bba5bfa88690ec46/strands_agents-1.38.0.tar.gz", hash = "sha256:02a68ec321ad457f9137dfd6a99cf72cf0e86081fee35de85fbe29b9ac0af2b2", size = 858950, upload-time = "2026-04-30T16:57:43.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/06/de8d8ab14a2e92dcb0fa82db0a4cb102418a1eda139412bbe5b5725e28df/strands_agents-1.38.0-py3-none-any.whl", hash = "sha256:9dc3de17e25d70e367d37f9151f2a4c7b3ac8fc9f6237e9e1f34d00bfbfd001b", size = 422354, upload-time = "2026-04-30T16:57:41.094Z" },
 ]
 
 [[package]]
@@ -2148,11 +2331,13 @@ dev = [
     { name = "ruff" },
 ]
 examples = [
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "openai" },
     { name = "openai-agents" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "strands-agents" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -2176,11 +2361,13 @@ dev = [
     { name = "ruff", specifier = ">=0.8.0,<1" },
 ]
 examples = [
+    { name = "boto3", specifier = ">=1.34.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1" },
     { name = "openai", specifier = ">=2.0.0" },
     { name = "openai-agents", specifier = ">=0.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2" },
     { name = "python-multipart", specifier = ">=0.0.12" },
+    { name = "strands-agents", specifier = ">=1.30.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0,<1" },
 ]
 
@@ -2293,6 +2480,38 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]
@@ -2458,6 +2677,92 @@ wheels = [
 ]
 
 [[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/d2/387594fb592d027366645f3d7cc9b4d7ca7be93845fbaba6d835a912ef3c/wrapt-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b7a86d99a14f76facb269dc148590c01aaf47584071809a70da30555228158c", size = 60669, upload-time = "2026-03-06T02:52:40.671Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/18/3f373935bc5509e7ac444c8026a56762e50c1183e7061797437ca96c12ce/wrapt-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a819e39017f95bf7aede768f75915635aa8f671f2993c036991b8d3bfe8dbb6f", size = 61603, upload-time = "2026-03-06T02:54:21.032Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/7a/32758ca2853b07a887a4574b74e28843919103194bb47001a304e24af62f/wrapt-2.1.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5681123e60aed0e64c7d44f72bbf8b4ce45f79d81467e2c4c728629f5baf06eb", size = 113632, upload-time = "2026-03-06T02:53:54.121Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d5/eeaa38f670d462e97d978b3b0d9ce06d5b91e54bebac6fbed867809216e7/wrapt-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8b28e97a44d21836259739ae76284e180b18abbb4dcfdff07a415cf1016c3e", size = 115644, upload-time = "2026-03-06T02:54:53.33Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/09/2a41506cb17affb0bdf9d5e2129c8c19e192b388c4c01d05e1b14db23c00/wrapt-2.1.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cef91c95a50596fcdc31397eb6955476f82ae8a3f5a8eabdc13611b60ee380ba", size = 112016, upload-time = "2026-03-06T02:54:43.274Z" },
+    { url = "https://files.pythonhosted.org/packages/64/15/0e6c3f5e87caadc43db279724ee36979246d5194fa32fed489c73643ba59/wrapt-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dad63212b168de8569b1c512f4eac4b57f2c6934b30df32d6ee9534a79f1493f", size = 114823, upload-time = "2026-03-06T02:54:29.392Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b2/0ad17c8248f4e57bedf44938c26ec3ee194715f812d2dbbd9d7ff4be6c06/wrapt-2.1.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d307aa6888d5efab2c1cde09843d48c843990be13069003184b67d426d145394", size = 111244, upload-time = "2026-03-06T02:54:02.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/04/bcdba98c26f2c6522c7c09a726d5d9229120163493620205b2f76bd13c01/wrapt-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c87cf3f0c85e27b3ac7d9ad95da166bf8739ca215a8b171e8404a2d739897a45", size = 113307, upload-time = "2026-03-06T02:54:12.428Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1b/5e2883c6bc14143924e465a6fc5a92d09eeabe35310842a481fb0581f832/wrapt-2.1.2-cp310-cp310-win32.whl", hash = "sha256:d1c5fea4f9fe3762e2b905fdd67df51e4be7a73b7674957af2d2ade71a5c075d", size = 57986, upload-time = "2026-03-06T02:54:26.823Z" },
+    { url = "https://files.pythonhosted.org/packages/42/5a/4efc997bccadd3af5749c250b49412793bc41e13a83a486b2b54a33e240c/wrapt-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:d8f7740e1af13dff2684e4d56fe604a7e04d6c94e737a60568d8d4238b9a0c71", size = 60336, upload-time = "2026-03-06T02:54:18Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f5/a2bb833e20181b937e87c242645ed5d5aa9c373006b0467bfe1a35c727d0/wrapt-2.1.2-cp310-cp310-win_arm64.whl", hash = "sha256:1c6cc827c00dc839350155f316f1f8b4b0c370f52b6a19e782e2bda89600c7dc", size = 58757, upload-time = "2026-03-06T02:53:51.545Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
 name = "yarl"
 version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2595,4 +2900,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
## Summary

This PR adds three new partner integration examples showing how to use TAC with AWS AI services: Bedrock Agent, Bedrock AgentCore, and AWS Strands.

### New Examples

**1. `aws_bedrock_agent.py` - AWS Bedrock Agent**
- Integrates with deployed AWS Bedrock Agents
- Uses boto3 `bedrock-agent-runtime` client
- Composes user message with memory context (user message first, then memory appended)

**2. `aws_bedrock_agentcore.py` - AWS Bedrock AgentCore**
- Integrates with deployed AWS Bedrock AgentCore runtimes
- Uses boto3 `bedrock-agentcore` client
- Parses SSE streaming responses to extract tokens

**3. `aws_strands.py` - AWS Strands Agents**
- Uses AWS Strands SDK to create agents programmatically
- Explicit model and region configuration via environment variables
- Uses FileSessionManager for persistent conversation history across messages
- Script-relative session storage directory (`.strands_sessions/`)
- Requires AWS credentials with Bedrock model access

### Key Features

All examples follow the TAC partner example pattern:
- ✅ Use TAC + AWS SDKs directly (no `tac_aws` package needed)
- ✅ Use `MemoryPromptBuilder.compose()` for memory injection
- ✅ Support both voice and SMS channels with optimized memory modes (`once` for voice, `always` for SMS)
- ✅ Non-streaming responses (simpler for getting-started examples)
- ✅ Clear prerequisite documentation in docstrings
- ✅ Comprehensive AWS credentials documentation in `.env.example`
- ✅ Proper error handling with clear error messages
- ✅ Explicit configuration via required environment variables
- ✅ Consistent environment variable access pattern (`os.environ["KEY"]`)
- ✅ Added references to `twilio-agent-connect-aws` connector library for enhanced integration

### Documentation & Configuration Updates

- **`.gitignore`**: Added `.strands_sessions/` for local Strands session storage
- **`.env.example`**: 
  - Added comprehensive AWS credentials setup documentation with 4 configuration methods
  - Added `STRANDS_MODEL_ID` for explicit model configuration
  - Reorganized with dedicated Feature Examples section
  - Clarified `TWILIO_CONVERSATION_CONFIGURATION_ID` requirement (all examples except relay_only.py)
  - Reordered feature example env vars to match alphabetical file order
  - Updated comments for clarity
- **`pyproject.toml`**: Added boto3, boto3-stubs, and strands-agents to examples dependencies
- **`getting_started/README.md`**: Documented all 3 AWS examples with run commands
- **`README.md`**: Updated Partner SDK Examples description to include AWS integrations
- **AWS example docstrings**: Added links to `twilio-agent-connect-aws` repo for developers seeking enhanced integration experience
- **`voice_streaming.py`**: Migrated from raw OpenAI API to OpenAI Agents SDK for consistency with other feature examples

### Code Quality

- ✅ All examples pass `make format` (ruff)
- ✅ All examples pass `make lint` (ruff check)
- ✅ All examples pass `make type-check` (mypy strict)
- ✅ Follows Python 3.10+ conventions (built-in generics, union syntax)
- ✅ Clean code with minimal comments (following CLAUDE.md guidelines)
- ✅ Clear memory ordering in prompts (user message first, then memory)
- ✅ Consistent patterns across all examples

### Performance Optimizations

- Voice channels in partner examples use `memory_mode="once"` for better latency (fetches memory once per call, not on every message)
- Feature examples consistently use OpenAI Agents SDK with streaming support where applicable

## Commits

1. **Add AWS partner examples: Bedrock Agent, AgentCore, and Strands** - Initial implementation of all three examples with documentation
2. **Fix mypy type errors in AWS examples** - Corrected type annotations for strict mypy compliance
3. **Improve AWS examples: fix session management and clean up comments** - Updated Strands to use FileSessionManager for conversation history, removed redundant comments
4. **Refine AWS examples: fix region usage, clarify comments, and improve configuration** - Made STRANDS_MODEL_ID required, fixed storage path to be script-relative, clarified memory ordering in comments
5. **Use consistent env var access pattern across AWS examples** - Replaced `os.environ.get()` with `os.environ[]` for required variables to match pattern across all examples
6. **Add AWS connector library references to partner examples** - Added links to twilio-agent-connect-aws repo in all AWS examples to help developers discover the dedicated connector library
7. **Improve examples: update voice_streaming to use Agents SDK, optimize voice memory mode, and reorganize .env.example** - Migrated voice_streaming.py to OpenAI Agents SDK, changed voice memory_mode to "once" in all partner examples, reorganized .env.example with Feature Examples section

## Test Plan

To test these examples:

1. Set up AWS credentials and required services:
   ```bash
   # For Bedrock Agent
   export BEDROCK_AGENT_ID=your-agent-id
   export BEDROCK_AGENT_ALIAS_ID=your-alias-id
   
   # For AgentCore
   export BEDROCK_AGENTCORE_AGENT_ARN=arn:aws:bedrock-agentcore:...
   
   # For Strands
   export STRANDS_MODEL_ID=us.amazon.nova-pro-v1:0
   aws configure  # OR set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
   export AWS_REGION=us-east-1
   ```

2. Install dependencies and run:
   ```bash
   cd getting_started/examples
   cp .env.example .env  # Fill in your credentials
   uv run partners/aws_bedrock_agent.py
   uv run partners/aws_bedrock_agentcore.py
   uv run partners/aws_strands.py
   ```

3. Test via SMS or Voice call to your Twilio number

🤖 Generated with [Claude Code](https://claude.com/claude-code)