### PR TITLE
refactor(chat): remove chatService workaround; migrate chat example to TACFastAPIServer

### DIFF
--- a/getting_started/examples/features/chat/app.py
+++ b/getting_started/examples/features/chat/app.py
@@ -12,14 +12,15 @@ Messages flow through Twilio's infrastructure:
 See README.md in this directory for setup and usage instructions.
 """
 
-import asyncio
 import os
 import sys
 from pathlib import Path
-from typing import Any
 
 import httpx
 from dotenv import load_dotenv
+from fastapi import Request
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 from openai import AsyncOpenAI
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
@@ -27,13 +28,16 @@ from openai.types.chat import (
     ChatCompletionSystemMessageParam,
     ChatCompletionUserMessageParam,
 )
+from twilio.jwt.access_token import AccessToken
+from twilio.jwt.access_token.grants import ChatGrant
 
 from tac import TAC, TACConfig
 from tac.adapters.openai import with_tac_memory
 from tac.channels.chat import ChatChannel
-from tac.core.logging import get_logger, setup_logging
+from tac.core.logging import get_logger
 from tac.models.session import ConversationSession
 from tac.models.tac import TACMemoryResponse
+from tac.server import TACFastAPIServer
 
 load_dotenv()
 
@@ -41,14 +45,9 @@ logger = get_logger(__name__)
 
 CHAT_IDENTITY = "ai-agent"
 
-# Initialize OpenAI client
 openai_client = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
-# Initialize TAC and chat channel
-# Note: TAC.__init__ calls setup_logging with config.log_level, so set it here
-# or use TWILIO_LOG_LEVEL=DEBUG in your .env
 tac = TAC(config=TACConfig.from_env())
-
 
 # Example-level setup check (not required by the SDK): the V1 Chat backend
 # behind this example needs a classic Conversations service — with Chat enabled
@@ -66,11 +65,8 @@ if not (response.json().get("conversationsV1Bridge") or {}).get("serviceId"):
         'Conversation Configuration → Channel traffic → "+ Add messaging & chat traffic".'
     )
 
-# Override logging to DEBUG after TAC init (which resets it to config.log_level)
-setup_logging(log_level="DEBUG", log_format="console")
 chat_channel = ChatChannel(tac, config={"agent_address": CHAT_IDENTITY})
 
-# Store conversation history per conversation
 conversation_history: dict[str, list[ChatCompletionMessageParam]] = {}
 
 SYSTEM_MESSAGE: ChatCompletionSystemMessageParam = {
@@ -129,37 +125,22 @@ tac.on_message_ready(handle_message_ready)
 tac.on_conversation_ended(handle_conversation_ended)
 
 
-def create_app() -> Any:
-    """Create the FastAPI app with chat-specific routes."""
-    try:
-        from fastapi import FastAPI, Request
-        from fastapi.responses import JSONResponse
-        from fastapi.staticfiles import StaticFiles
-        from twilio.jwt.access_token import AccessToken
-        from twilio.jwt.access_token.grants import ChatGrant
-    except ImportError as e:
-        raise ImportError(
-            "Chat example requires: pip install fastapi uvicorn twilio python-multipart"
-        ) from e
+if __name__ == "__main__":
+    server = TACFastAPIServer(tac=tac, messaging_channels=[chat_channel])
 
-    app = FastAPI(title="TAC Chat Server")
-
-    # Serve static files (the chat UI)
+    # Layer the chat UI routes onto the same FastAPI app TAC provides.
     static_dir = Path(__file__).parent / "public"
-    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+    server.app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
-    @app.get("/")
-    async def index() -> Any:
-        from fastapi.responses import FileResponse
-
+    @server.app.get("/")
+    async def index() -> FileResponse:
         return FileResponse(str(static_dir / "index.html"))
 
-    @app.post("/token")
+    @server.app.post("/token")
     async def generate_token(request: Request) -> JSONResponse:
         """Generate a Conversations SDK access token."""
         body = await request.json()
         identity = body.get("identity")
-
         if not identity:
             return JSONResponse({"error": "Identity is required"}, status_code=400)
 
@@ -167,40 +148,14 @@ def create_app() -> Any:
         api_key = os.environ.get("TWILIO_API_KEY")
         api_secret = os.environ.get("TWILIO_API_SECRET")
         service_sid = os.environ.get("TWILIO_CONVERSATIONS_SERVICE_SID")
-
         if not all([account_sid, api_key, api_secret, service_sid]):
-            logger.error("Missing required credentials for token generation")
             return JSONResponse({"error": "Missing Twilio credentials"}, status_code=500)
 
         token = AccessToken(account_sid, api_key, api_secret, identity=identity, ttl=3600)
-        chat_grant = ChatGrant(service_sid=service_sid)
-        token.add_grant(chat_grant)
-
+        token.add_grant(ChatGrant(service_sid=service_sid))
         jwt = token.to_jwt()
         if isinstance(jwt, bytes):
             jwt = jwt.decode("utf-8")
-
         return JSONResponse({"token": jwt})
 
-    @app.post("/webhook")
-    async def conversation_webhook(request: Request) -> JSONResponse:
-        """Handle Conversation Orchestrator webhook events."""
-        try:
-            webhook_data = await request.json()
-            idempotency_token = request.headers.get("i-twilio-idempotency-token")
-            asyncio.create_task(chat_channel.process_webhook(webhook_data, idempotency_token))
-            return JSONResponse({"status": "ok"})
-        except Exception as e:
-            logger.error("Webhook error", error=str(e), exc_info=True)
-            return JSONResponse({"status": "error", "message": str(e)}, status_code=400)
-
-    return app
-
-
-if __name__ == "__main__":
-    import uvicorn
-
-    app = create_app()
-    logger.info("Starting TAC Chat Server on http://0.0.0.0:8000")
-    logger.info("Open http://localhost:8000 in your browser to test chat")
-    uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info", access_log=False)
+    server.start()

--- a/getting_started/examples/features/chat/app.py
+++ b/getting_started/examples/features/chat/app.py
@@ -61,7 +61,7 @@ response.raise_for_status()
 if not (response.json().get("conversationsV1Bridge") or {}).get("serviceId"):
     sys.exit(
         f"Configuration '{configuration_id}' has no classic Conversations service attached. "
-        'Attach one (with Chat enabled) via Console → Conversation Orchestrator → '
+        "Attach one (with Chat enabled) via Console → Conversation Orchestrator → "
         'Conversation Configuration → Channel traffic → "+ Add messaging & chat traffic".'
     )
 

--- a/getting_started/examples/features/chat/app.py
+++ b/getting_started/examples/features/chat/app.py
@@ -50,54 +50,22 @@ openai_client = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 tac = TAC(config=TACConfig.from_env())
 
 
-def _assert_chat_traffic_configured() -> None:
-    """Fail fast if the Conversation Orchestrator configuration has no classic
-    Conversations (V1) service attached.
-
-    This check is example-level setup validation, not part of the chat
-    integration. The TAC SDK does not require this — but the V1 Chat backend
-    this example uses does, and misconfiguration surfaces as cryptic failures
-    on the first inbound message. Enable it in the Twilio Console under
-    Conversation Orchestrator -> Conversation Configuration -> Channel traffic
-    -> "+ Add messaging & chat traffic", which attaches a classic Conversations
-    service to the configuration.
-    """
-    configuration_id = os.environ.get("TWILIO_CONVERSATION_CONFIGURATION_ID")
-    api_key = os.environ.get("TWILIO_API_KEY")
-    api_secret = os.environ.get("TWILIO_API_SECRET")
-    if not (configuration_id and api_key and api_secret):
-        return  # Let TAC's own credential checks surface the error.
-
-    url = (
-        "https://conversations.twilio.com/v2/ControlPlane/Configurations/"
-        f"{configuration_id}"
+# Example-level setup check (not required by the SDK): the V1 Chat backend
+# behind this example needs a classic Conversations service attached to the CO
+# configuration. Enable it in Console → Conversation Orchestrator →
+# Conversation Configuration → Channel traffic → "+ Add messaging & chat traffic".
+configuration_id = os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"]
+response = httpx.get(
+    f"https://conversations.twilio.com/v2/ControlPlane/Configurations/{configuration_id}",
+    auth=(os.environ["TWILIO_API_KEY"], os.environ["TWILIO_API_SECRET"]),
+)
+response.raise_for_status()
+if not (response.json().get("conversationsV1Bridge") or {}).get("serviceId"):
+    sys.exit(
+        f"Configuration '{configuration_id}' has no classic Conversations service attached. "
+        'Enable it in Console → Conversation Orchestrator → Conversation Configuration → '
+        'Channel traffic → "+ Add messaging & chat traffic".'
     )
-    try:
-        response = httpx.get(url, auth=(api_key, api_secret), timeout=10.0)
-        response.raise_for_status()
-        config_json = response.json()
-    except Exception as e:
-        logger.warning(
-            "Could not verify CO configuration has classic Conversations attached; "
-            "skipping chat-traffic check",
-            error=str(e),
-        )
-        return
-
-    v1_bridge = config_json.get("conversationsV1Bridge") or {}
-    if not v1_bridge.get("serviceId"):
-        sys.exit(
-            "\nError: Conversation Orchestrator configuration "
-            f"'{configuration_id}' has no classic Conversations (V1) service "
-            "attached — the chat example requires one.\n\n"
-            "To enable it: Twilio Console -> Conversation Orchestrator -> "
-            "Conversation Configuration -> Channel traffic -> "
-            '"+ Add messaging & chat traffic". Attach a classic Conversations '
-            "service that has Chat enabled.\n"
-        )
-
-
-_assert_chat_traffic_configured()
 
 # Override logging to DEBUG after TAC init (which resets it to config.log_level)
 setup_logging(log_level="DEBUG", log_format="console")

--- a/getting_started/examples/features/chat/app.py
+++ b/getting_started/examples/features/chat/app.py
@@ -14,9 +14,11 @@ See README.md in this directory for setup and usage instructions.
 
 import asyncio
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
+import httpx
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 from openai.types.chat import (
@@ -46,6 +48,56 @@ openai_client = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 # Note: TAC.__init__ calls setup_logging with config.log_level, so set it here
 # or use TWILIO_LOG_LEVEL=DEBUG in your .env
 tac = TAC(config=TACConfig.from_env())
+
+
+def _assert_chat_traffic_configured() -> None:
+    """Fail fast if the Conversation Orchestrator configuration has no classic
+    Conversations (V1) service attached.
+
+    This check is example-level setup validation, not part of the chat
+    integration. The TAC SDK does not require this — but the V1 Chat backend
+    this example uses does, and misconfiguration surfaces as cryptic failures
+    on the first inbound message. Enable it in the Twilio Console under
+    Conversation Orchestrator -> Conversation Configuration -> Channel traffic
+    -> "+ Add messaging & chat traffic", which attaches a classic Conversations
+    service to the configuration.
+    """
+    configuration_id = os.environ.get("TWILIO_CONVERSATION_CONFIGURATION_ID")
+    api_key = os.environ.get("TWILIO_API_KEY")
+    api_secret = os.environ.get("TWILIO_API_SECRET")
+    if not (configuration_id and api_key and api_secret):
+        return  # Let TAC's own credential checks surface the error.
+
+    url = (
+        "https://conversations.twilio.com/v2/ControlPlane/Configurations/"
+        f"{configuration_id}"
+    )
+    try:
+        response = httpx.get(url, auth=(api_key, api_secret), timeout=10.0)
+        response.raise_for_status()
+        config_json = response.json()
+    except Exception as e:
+        logger.warning(
+            "Could not verify CO configuration has classic Conversations attached; "
+            "skipping chat-traffic check",
+            error=str(e),
+        )
+        return
+
+    v1_bridge = config_json.get("conversationsV1Bridge") or {}
+    if not v1_bridge.get("serviceId"):
+        sys.exit(
+            "\nError: Conversation Orchestrator configuration "
+            f"'{configuration_id}' has no classic Conversations (V1) service "
+            "attached — the chat example requires one.\n\n"
+            "To enable it: Twilio Console -> Conversation Orchestrator -> "
+            "Conversation Configuration -> Channel traffic -> "
+            '"+ Add messaging & chat traffic". Attach a classic Conversations '
+            "service that has Chat enabled.\n"
+        )
+
+
+_assert_chat_traffic_configured()
 
 # Override logging to DEBUG after TAC init (which resets it to config.log_level)
 setup_logging(log_level="DEBUG", log_format="console")

--- a/getting_started/examples/features/chat/app.py
+++ b/getting_started/examples/features/chat/app.py
@@ -51,9 +51,8 @@ tac = TAC(config=TACConfig.from_env())
 
 
 # Example-level setup check (not required by the SDK): the V1 Chat backend
-# behind this example needs a classic Conversations service attached to the CO
-# configuration. Enable it in Console → Conversation Orchestrator →
-# Conversation Configuration → Channel traffic → "+ Add messaging & chat traffic".
+# behind this example needs a classic Conversations service — with Chat enabled
+# on it — attached to the CO configuration.
 configuration_id = os.environ["TWILIO_CONVERSATION_CONFIGURATION_ID"]
 response = httpx.get(
     f"https://conversations.twilio.com/v2/ControlPlane/Configurations/{configuration_id}",
@@ -63,8 +62,8 @@ response.raise_for_status()
 if not (response.json().get("conversationsV1Bridge") or {}).get("serviceId"):
     sys.exit(
         f"Configuration '{configuration_id}' has no classic Conversations service attached. "
-        'Enable it in Console → Conversation Orchestrator → Conversation Configuration → '
-        'Channel traffic → "+ Add messaging & chat traffic".'
+        'Attach one (with Chat enabled) via Console → Conversation Orchestrator → '
+        'Conversation Configuration → Channel traffic → "+ Add messaging & chat traffic".'
     )
 
 # Override logging to DEBUG after TAC init (which resets it to config.log_level)

--- a/src/tac/channels/chat.py
+++ b/src/tac/channels/chat.py
@@ -136,15 +136,7 @@ class ChatChannel(MessagingChannel):
                 "session.metadata['channel_id'] explicitly in advanced usage."
             )
 
-        # TODO(conv-orch): Drop `chat_service` here once the Actions API resolves the
-        # V1 Chat service SID server-side. Conversation Orchestrator team confirmed this
-        # should not be required client-side; keep the workaround until the server-side fix ships.
-        # `channel_id` stays — it's a permanent per-conversation requirement.
-        chat_service_sid = self.tac.conversations_v1_service_sid
-        channel_settings = ActionChannelSettings(
-            channel_id=chat_channel_sid,
-            chat_service=chat_service_sid,
-        )
+        channel_settings = ActionChannelSettings(channel_id=chat_channel_sid)
 
         try:
             action_request = SendMessageActionRequest(
@@ -192,21 +184,11 @@ class ChatChannel(MessagingChannel):
         If an active conversation with the same addresses already exists
         (group-by dedup), CO returns 409 and the existing conversation is reused.
         """
-        chat_service_sid = self.tac.conversations_v1_service_sid
-        if not chat_service_sid:
-            raise RuntimeError(
-                "conversations_v1_service_sid is not set — the Conversation Orchestrator "
-                "configuration has no Conversations V1 bridge. Chat outbound requires it."
-            )
-
         return await self._initiate_messaging_conversation(
             options=options,
             from_address=self.agent_address,
             customer_address_kwargs={"channel_id": options.channel_id},
             agent_address_kwargs={"channel_id": options.channel_id},
             extra_metadata={"channel_id": options.channel_id},
-            channel_settings=ActionChannelSettings(
-                channel_id=options.channel_id,
-                chat_service=chat_service_sid,
-            ),
+            channel_settings=ActionChannelSettings(channel_id=options.channel_id),
         )

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -47,7 +47,6 @@ class TAC:
 
         self.conversation_orchestrator_client: ConversationClient | None = None
         self.conversation_memory_client: MemoryClient | None = None
-        self.conversations_v1_service_sid: str | None = None
 
         if self.config.conversation_configuration_id:
             self.conversation_orchestrator_client = ConversationClient(
@@ -67,22 +66,6 @@ class TAC:
                     "Please check your conversation_configuration_id and credentials, or "
                     "omit conversation_configuration_id to run in ConversationRelay-only mode."
                 ) from e
-
-            # TODO(conv-orch): Remove once the Actions API resolves the V1 Chat service SID
-            # server-side. Conversation Orchestrator team confirmed this should not be
-            # required client-side;
-            # until they ship the fix, CHAT sends fail with
-            #   "chatService attribute is required for CHAT channel"
-            # unless we pass it on channelSettings.chatService. We source it from the
-            # Configuration's conversationsV1Bridge since the inbound webhook's serviceId
-            # is the literal "unused" for CHAT. When the server-side fix lands, drop this
-            # attribute plus ActionChannelSettings.chat_service and the chat channel's
-            # chat_service_sid plumbing.
-            self.conversations_v1_service_sid = (
-                configuration.conversations_v1_bridge.service_id
-                if configuration.conversations_v1_bridge
-                else None
-            )
 
             self.conversation_memory_client = MemoryClient(
                 store_id=configuration.memory_store_id,

--- a/src/tac/models/conversation.py
+++ b/src/tac/models/conversation.py
@@ -93,18 +93,6 @@ class ParticipantAddress(BaseModel):
     model_config = {"populate_by_name": True}
 
 
-# TODO(conv-orch): Remove this class once the Actions API resolves the V1 Chat
-# service SID server-side. Currently used to extract `conversationsV1Bridge.serviceId`
-# from the Configuration so the chat channel can forward it as
-# channelSettings.chatService — drop together with the other TODO(conv-orch) sites.
-class ConversationsV1Bridge(BaseModel):
-    """Conversations V1 bridge settings on a ConversationConfiguration."""
-
-    service_id: str = Field(..., alias="serviceId", description="V1 Conversations service SID")
-
-    model_config = {"populate_by_name": True}
-
-
 class ConversationConfiguration(BaseModel):
     """Configuration settings for a conversation response."""
 
@@ -170,13 +158,6 @@ class ConversationConfiguration(BaseModel):
         alias="intelligenceConfigurationIds",
         max_length=5,
         description="List of Intelligence Configuration IDs for this configuration",
-    )
-    # TODO(conv-orch): Drop this field once the Actions API resolves the V1 Chat
-    # service SID server-side — see ConversationsV1Bridge above.
-    conversations_v1_bridge: ConversationsV1Bridge | None = Field(
-        None,
-        alias="conversationsV1Bridge",
-        description="V1 Conversations bridge (carries the V1 service SID)",
     )
     created_at: str | None = Field(
         None, alias="createdAt", description="Timestamp when this configuration was created"
@@ -494,14 +475,6 @@ class ActionChannelSettings(BaseModel):
         default=None,
         alias="channelId",
         description="Backend-specific channel identifier (e.g. V1 Chat channel SID)",
-    )
-    # TODO(conv-orch): Drop `chat_service` once the Actions API resolves the V1 Chat
-    # service SID server-side. Conversation Orchestrator team confirmed this should not be
-    # required client-side; keep the field until the server-side fix ships.
-    chat_service: str | None = Field(
-        default=None,
-        alias="chatService",
-        description="V1 Chat service SID (IS...); required by V1 Chat backend when channel=CHAT",
     )
 
     model_config = {"populate_by_name": True, "extra": "allow"}

--- a/tests/test_chat_channel.py
+++ b/tests/test_chat_channel.py
@@ -294,37 +294,6 @@ class TestChatChannel:
             assert request.payload.channel_settings.channel_id == "CH_CHAT_SID_123"
 
     @pytest.mark.asyncio
-    async def test_send_response_forwards_chat_service_when_set(self) -> None:
-        """When TAC.conversations_v1_service_sid is cached, it's forwarded as
-        channelSettings.chatService on the Action request.
-
-        TODO(conv-orch): Drop this test when the chatService workaround is removed.
-        """
-        tac = TAC(get_test_config())
-        tac.conversations_v1_service_sid = "ISabcdef1234567890abcdef1234567890"
-        channel = ChatChannel(tac)
-
-        channel._conversations["CH123"] = ConversationSession(
-            conversation_id="CH123",
-            channel="chat",
-            author_info=AuthorInfo(address="user@example.com", participant_id="PA_USER"),
-            ai_agent_info=AuthorInfo(address="ai-assistant", participant_id="PA_AGENT"),
-            metadata={"channel_id": "CH_CHAT_SID_123"},
-        )
-
-        with patch.object(tac.conversation_orchestrator_client, "create_action") as mock_send:
-            await channel.send_response("CH123", "Hello!")
-
-            mock_send.assert_called_once()
-            request = mock_send.call_args[0][1]
-            assert request.payload.channel_settings is not None
-            assert (
-                request.payload.channel_settings.chat_service
-                == "ISabcdef1234567890abcdef1234567890"
-            )
-            assert request.payload.channel_settings.channel_id == "CH_CHAT_SID_123"
-
-    @pytest.mark.asyncio
     async def test_send_response_no_session(self) -> None:
         """Missing session → send_response raises (no conversation to reply to)."""
         tac = TAC(get_test_config())

--- a/tests/test_outbound.py
+++ b/tests/test_outbound.py
@@ -310,7 +310,6 @@ def _mock_chat_outbound(
     channel_id: str = "CHSIDabc",
     reused: bool = False,
 ) -> None:
-    tac.conversations_v1_service_sid = "IStestchatservice"
     co = tac.conversation_orchestrator_client
     co.create_or_reuse_conversation = AsyncMock(return_value=(conv_id, reused))
     co.list_participants = AsyncMock(


### PR DESCRIPTION
## Summary

- **SDK:** Removed the `chatService`/`conversationsV1Bridge` workaround — CO now resolves the V1 Chat service SID server-side. Drops `ConversationsV1Bridge`, `ActionChannelSettings.chat_service`, `TAC.conversations_v1_service_sid`, and all call-site plumbing. TAC no longer knows about the V1 bridge.
- **Chat example:** Added a startup check that fails fast with Console guidance when the CO configuration has no classic Conversations service attached (the V1 Chat backend the example uses needs one).
- **Chat example:** Migrated to `TACFastAPIServer`, matching the other messaging examples. ~60 lines of boilerplate dropped.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Checklist

- [x] Tests added/updated — dropped the `chatService` forwarding test; 692 tests pass, `make check` green.
- [ ] Documentation updated — no doc mentions of this workaround existed.
- [x] Tested E2E — inbound chat → agent reply round-tripped against a V1-bridged CO configuration. Chat example migrated to `TACFastAPIServer` also verified live.

## SDK Parity

- [ ] Change is Python-specific (no TypeScript update needed)
- [x] TypeScript SDK PR: twilio/twilio-agent-connect-typescript#40

🤖 Generated with [Claude Code](https://claude.com/claude-code)