### PR TITLE
feat: Add OpenTelemetry observability with metrics and traces

### DIFF
--- a/docs/opentelemetry-proposal.md
+++ b/docs/opentelemetry-proposal.md
@@ -1,0 +1,230 @@
+# Proposal: OpenTelemetry Integration for TAC
+
+## 1. Overview
+
+This proposal suggests adding **OpenTelemetry observability** to TAC with two components:
+
+### 1. Metrics (Monitoring)
+Aggregate numerical data for monitoring system health - message counts, latency, error rates.
+
+**Backend:** Prometheus → Grafana
+
+### 2. Traces (Debugging)
+Individual request lifecycle showing complete execution flow with nested operations.
+
+**Backend:** Jaeger, Langfuse, or any OTLP-compatible system
+
+---
+
+## 2. Background & Motivation
+
+### The Problem
+
+Users deploying TAC in production need visibility into their system's performance and health. Without built-in observability, users cannot:
+
+- **Monitor performance** - Identify latency bottlenecks or degradation
+- **Track errors** - Understand failure rates and error patterns
+- **Measure throughput** - Know how many messages are being processed
+- **Debug issues** - Investigate production problems with data
+- **Set up alerts** - Get notified when SLAs are violated
+
+### Why OpenTelemetry?
+
+**OpenTelemetry (OTel)** is the industry standard for observability instrumentation:
+
+✅ **Universal compatibility** - Works with Grafana, Datadog, New Relic, Prometheus, Langfuse, etc.  
+✅ **Vendor-neutral** - Not locked into any specific platform  
+✅ **Widely adopted** - Used by major projects (Strands SDK, cloud providers, etc.)  
+✅ **Unified protocol** - OTLP (OpenTelemetry Protocol) for metrics and traces  
+✅ **Production-ready** - Mature, stable, and well-documented
+
+By instrumenting TAC with OpenTelemetry, users can plug TAC into their existing observability infrastructure without vendor lock-in.
+
+---
+
+## 3. Metrics
+
+Metrics provide aggregate numerical data about system behavior over time - counts, rates, and latencies. They answer questions like "how many?", "how fast?", and "how often?"
+
+### Category 1: Message Processing
+
+Track message throughput, success rate, and errors per channel.
+
+| Metric | Type | Description | Labels |
+|--------|------|-------------|--------|
+| `tac.message.received` | Counter | Total messages received from Twilio | `channel` (sms, voice, whatsapp, rcs, chat) |
+| `tac.message.sent` | Counter | Total messages successfully sent | `channel` |
+| `tac.message.success` | Counter | Messages processed successfully end-to-end | `channel` |
+| `tac.message.error` | Counter | Message processing errors | `channel`, `error_type` |
+
+**Use case:** Monitor message throughput, calculate success rate per channel, track error patterns.
+
+**Example queries:**
+- Success rate: `rate(tac.message.success) / rate(tac.message.received)`
+- Error rate by channel: `rate(tac.message.error{channel="sms"})`
+- Total throughput: `sum(rate(tac.message.received)) by (channel)`
+
+---
+
+### Category 2: Lifecycle Latency
+
+Measure latency at each stage of the conversation lifecycle.
+
+| Metric | Type | Description | Labels |
+|--------|------|-------------|--------|
+| `tac.conversation.start` | Histogram | Time to start a new conversation (on_conversation_start) | `channel` |
+| `tac.conversation.ready` | Histogram | Time spent in user callback (on_message_ready) | `channel` |
+| `tac.conversation.end` | Histogram | Time to clean up ended conversation (on_conversation_end) | `channel`, `reason` (completed, timeout, error) |
+
+**Use case:** Monitor performance of the three main lifecycle stages: starting conversations, processing messages, and ending conversations.
+
+**Example queries:**
+- P95 callback latency: `histogram_quantile(0.95, rate(tac_conversation_ready_seconds_bucket))`
+- P99 conversation start: `histogram_quantile(0.99, rate(tac_conversation_start_seconds_bucket))`
+- P95 conversation end: `histogram_quantile(0.95, rate(tac_conversation_end_seconds_bucket))`
+
+---
+
+### Category 3: API Requests
+
+Monitor Twilio API performance and reliability.
+
+| Metric | Type | Description | Labels |
+|--------|------|-------------|--------|
+| `tac.api.request` | Counter | Total API requests to Twilio services | `client_type` (conversation, memory, knowledge), `method` (GET, POST, PUT, DELETE) |
+| `tac.api.success` | Counter | Successful API requests (2xx status) | `client_type`, `method` |
+| `tac.api.error` | Counter | Failed API requests | `client_type`, `method`, `error_type`, `status_code` |
+| `tac.api.request_duration` | Histogram | API request latency | `client_type`, `method` |
+
+**Use case:** Detect Twilio service degradation, track API quota usage, calculate success rates per service.
+
+**Example queries:**
+- Orchestrator success rate: `rate(tac.api.success{client_type="conversation"}) / rate(tac.api.request{client_type="conversation"})`
+- Memory API P95 latency: `histogram_quantile(0.95, rate(tac.api.request_duration_bucket{client_type="memory"}))`
+- Knowledge API errors: `sum(rate(tac.api.error{client_type="knowledge"})) by (error_type)`
+
+---
+
+## 4. Traces
+
+Traces would provide visibility into individual request execution, showing the complete lifecycle of a message with nested operations (spans).
+
+### Example Trace Structure
+
+```
+message.processing (1.2s)
+├── conversation.start (0.01s)
+├── memory.retrieve (0.3s)
+├── conversation.ready (0.8s)  ← User callback
+├── message.send (0.09s)
+└── conversation.end (0.01s)
+```
+
+### Trace Attributes
+
+Each span includes:
+- `conversation_id` - Unique conversation identifier
+- `channel` - sms, voice, whatsapp, rcs, chat
+- `service.name` - "tac"
+- `service.version` - TAC version
+- Custom attributes (model name, token usage, etc.)
+
+### Use Cases
+
+- **Debug slow requests** - "Why did this message take 5 seconds?"
+- **Find bottlenecks** - "Is the delay in memory retrieval or LLM calls?"
+- **Visualize flow** - See parent-child relationships in nested operations
+- **Correlate with metrics** - Jump from high P95 latency in Grafana to specific slow traces
+
+### Supported Backends
+
+- **Jaeger** - Open-source distributed tracing platform
+- **Langfuse** - LLM-focused observability with OpenTelemetry support
+- **Datadog APM** - Enterprise monitoring with OTLP support
+- **Any OTLP-compatible system**
+
+---
+
+## 5. Proposed API
+
+### Dependencies
+
+Core SDK is included by default (small footprint, zero overhead when not configured). Exporters are optional to minimize bundle size and let users choose their backend.
+
+**Core (included by default):**
+- `opentelemetry-api>=1.20.0`
+- `opentelemetry-sdk>=1.20.0`
+
+**Optional (install with `pip install tac[telemetry]`):**
+- `opentelemetry-exporter-otlp-proto-http>=1.20.0` - OTLP exporter for production use
+
+### Basic Setup (Metrics Only)
+
+```python
+from tac import TAC, TACConfig
+from tac.telemetry import TACTelemetry
+
+# Enable telemetry with console exporter (development)
+TACTelemetry().setup_meter(enable_console_exporter=True)
+
+# TAC automatically records metrics
+tac = TAC(config=TACConfig.from_env())
+```
+
+### Production Setup (Metrics + Traces)
+
+```python
+import os
+from tac import TAC, TACConfig
+from tac.telemetry import TACTelemetry
+
+# Configure OTLP endpoint
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://otel-collector:4318"
+
+# Enable metrics + traces
+telemetry = TACTelemetry()
+telemetry.setup_meter(enable_otlp_exporter=True)
+telemetry.setup_tracer(enable_otlp_exporter=True)  # Proposed
+
+tac = TAC(config=TACConfig.from_env())
+```
+
+### Proposed Data Flow
+
+```
+TAC Application
+    ↓ (OTLP Protocol)
+OpenTelemetry Collector
+    ↓
+    ├─→ Metrics → Prometheus → Grafana
+    └─→ Traces → Jaeger/Langfuse
+```
+
+---
+
+## 6. Dashboard & Visualization
+
+### Metrics (Grafana)
+
+- **P95/P99 Latency** - Callback execution time by channel
+- **Message Volume** - Messages received/sent per minute
+- **Error Rates** - Errors by channel and type
+- **API Performance** - Twilio API latency and success rates
+
+### Traces (Jaeger/Langfuse)
+
+- **Waterfall View** - Visual timeline of request execution
+- **Nested Spans** - Parent-child relationships showing operation hierarchy
+- **Detailed Attributes** - conversation_id, channel, timing, custom metadata
+- **Debug Tools** - Filter by slow requests, errors, or specific conversations
+
+---
+
+## 7. References
+
+- [OpenTelemetry Python Docs](https://opentelemetry.io/docs/languages/python/)
+- [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/)
+- [Strands SDK Telemetry Implementation](https://github.com/anthropics/anthropic-strands-python)
+- [Prometheus Best Practices](https://prometheus.io/docs/practices/naming/)
+- [Grafana Dashboard Examples](https://grafana.com/grafana/dashboards/)
+

--- a/getting_started/examples/observability-demo/README.md
+++ b/getting_started/examples/observability-demo/README.md
@@ -1,0 +1,146 @@
+# TAC OpenTelemetry Observability Demo
+
+This demo showcases TAC's OpenTelemetry integration:
+- **Metrics** → Prometheus → Grafana (P95 latencies, message counts)
+- **Traces** → Langfuse (nested span visualization for debugging)
+
+## Architecture
+
+```
+TAC Application
+    ↓ (OTLP Protocol)
+OpenTelemetry Collector
+    ↓
+    ├─→ Metrics → Prometheus → Grafana
+    └─→ Traces → Langfuse
+```
+
+## Quick Start
+
+### 1. Start Services
+
+```bash
+cd getting_started/examples/observability-demo
+docker compose up -d
+```
+
+Wait 30-60 seconds for services to be ready.
+
+### 2. Configure Langfuse
+
+1. Open http://localhost:3001
+2. Create an account and project
+3. Go to **Settings → API Keys**
+4. Copy the keys and add to your `.env` file:
+
+```bash
+# In getting_started/examples/.env
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+```
+
+### 3. Run the Example
+
+```bash
+# Set up environment (if not already done)
+cd getting_started/examples
+# Make sure .env has all required credentials (TAC + OpenAI + Langfuse)
+
+# Run the example
+uv run python observability-demo/openai_with_observability.py
+
+# Expose with ngrok
+ngrok http 8000
+```
+
+### 4. Configure Twilio Webhooks
+
+Point Twilio to your ngrok URL:
+- **SMS**: `https://your-ngrok.ngrok.io/channels/sms`
+- **Voice**: `https://your-ngrok.ngrok.io/twiml`
+
+### 5. Send Messages
+
+Send SMS or make a voice call. You'll see:
+
+**Metrics in Grafana** (http://localhost:3000):
+- P95 Callback Latency by Channel
+- Message Volume (received/sent)
+- API Request Duration
+
+**Traces in Langfuse** (http://localhost:3001):
+- Click **Traces** → Select any `message.processing` trace
+- See nested operations:
+  ```
+  message.processing (1.2s)
+  ├── conversation.start (0.01s)
+  ├── memory.retrieve (0.3s)
+  ├── conversation.ready (0.8s)  ← User callback
+  ├── message.send (0.09s)
+  └── conversation.end (0.01s)
+  ```
+
+## Services
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| Grafana | 3000 | Metrics dashboard |
+| Langfuse | 3001 | Trace visualization |
+| Prometheus | 9090 | Metrics storage |
+| OTel Collector | 4318 | OTLP receiver |
+
+## Files
+
+- `openai_with_observability.py` - Example application (SMS + Voice + OpenAI)
+- `docker-compose.yml` - Infrastructure stack
+- `otel-collector-config.yml` - Collector configuration
+- `prometheus.yml` - Prometheus config
+- `grafana-datasource.yml` - Grafana datasource
+- `grafana-dashboard.yml` - Dashboard provisioning
+- `grafana-tac-dashboard.json` - TAC metrics dashboard
+
+## What Gets Measured
+
+### Metrics (Grafana)
+- **Message Counts**: received, sent, errors
+- **Latency**: P50/P95/P99 for conversation lifecycle stages
+- **API Requests**: duration and errors by client type
+
+Labels: `channel` (sms/voice/whatsapp/rcs/chat), `client_type` (conversation/memory/knowledge)
+
+### Traces (Langfuse)
+- Complete request lifecycle with nested spans
+- Timing for each operation
+- Conversation ID and channel metadata
+- Parent-child relationships
+
+## Integration Pattern
+
+Add observability to your TAC application:
+
+```python
+from tac import TAC, TACConfig
+from tac.telemetry import TACTelemetry
+import os
+
+# 1. Configure OTLP endpoint
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
+
+# 2. Setup telemetry BEFORE creating TAC
+telemetry = TACTelemetry()
+telemetry.setup_meter(enable_otlp_exporter=True)   # Metrics
+telemetry.setup_tracer(enable_otlp_exporter=True)  # Traces
+
+# 3. Create TAC - metrics and traces are automatic
+tac = TAC(config=TACConfig.from_env())
+```
+
+## Cleanup
+
+```bash
+# Stop services
+docker compose down
+
+# Remove all data
+docker compose down -v
+```

--- a/getting_started/examples/observability-demo/docker-compose.yml
+++ b/getting_started/examples/observability-demo/docker-compose.yml
@@ -1,0 +1,183 @@
+services:
+  # OpenTelemetry Collector - receives OTLP and exports to Prometheus
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yml"]
+    volumes:
+      - ./otel-collector-config.yml:/etc/otel-collector-config.yml
+    ports:
+      - "4318:4318"   # OTLP HTTP receiver (metrics + traces)
+      - "8889:8889"   # Prometheus metrics exporter
+
+  # Prometheus - stores metrics
+  prometheus:
+    image: prom/prometheus:latest
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    depends_on:
+      - otel-collector
+
+  # Langfuse v3 - trace visualization with OpenTelemetry support
+  langfuse-db:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      TZ: UTC
+      PGTZ: UTC
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    volumes:
+      - langfuse-db:/var/lib/postgresql/data
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    user: "101:101"
+    environment:
+      CLICKHOUSE_DB: default
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 1s
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+      - clickhouse-logs:/var/log/clickhouse-server
+
+  minio:
+    image: cgr.dev/chainguard/minio:latest
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: miniosecret
+    ports:
+      - "9092:9000"  # MinIO API
+      - "9093:9001"  # MinIO Console
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 1s
+      timeout: 5s
+      retries: 5
+      start_period: 1s
+    volumes:
+      - minio-data:/data
+
+  redis:
+    image: redis:7
+    command: >
+      --requirepass myredissecret
+      --maxmemory-policy noeviction
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 10s
+      retries: 10
+    volumes:
+      - redis-data:/data
+
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3
+    depends_on:
+      langfuse-db:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment: &langfuse-env
+      NEXTAUTH_URL: http://localhost:3001
+      DATABASE_URL: postgresql://postgres:postgres@langfuse-db:5432/postgres
+      SALT: mysalt
+      ENCRYPTION_KEY: f7f29ab97d863396e042048a3663407ba48b33bee7169a3167920a2c3eb39957
+      TELEMETRY_ENABLED: "false"
+      LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: "true"
+      CLICKHOUSE_MIGRATION_URL: clickhouse://clickhouse:9000
+      CLICKHOUSE_URL: http://clickhouse:8123
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: miniosecret
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_PREFIX: events/
+      LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse
+      LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+      LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: minio
+      LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: miniosecret
+      LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio:9000
+      LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+      LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      REDIS_AUTH: myredissecret
+
+  langfuse:
+    image: langfuse/langfuse:3
+    depends_on:
+      langfuse-db:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "3001:3000"  # Langfuse UI (different from Grafana)
+    environment:
+      <<: *langfuse-env
+      NEXTAUTH_SECRET: mysecret
+
+  # Grafana - visualizes metrics
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./grafana-datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
+      - ./grafana-dashboard.yml:/etc/grafana/provisioning/dashboards/dashboard.yml
+      - ./grafana-tac-dashboard.json:/var/lib/grafana/dashboards/tac.json
+      - ./grafana-tac-status-dashboard.json:/var/lib/grafana/dashboards/tac-status.json
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+
+volumes:
+  prometheus-data:
+  grafana-data:
+  langfuse-db:
+  clickhouse-data:
+  clickhouse-logs:
+  minio-data:
+  redis-data:

--- a/getting_started/examples/observability-demo/generate_test_data.py
+++ b/getting_started/examples/observability-demo/generate_test_data.py
@@ -6,7 +6,6 @@ This script simulates TAC operations to populate Grafana and Langfuse with test 
 import asyncio
 import os
 import random
-import time
 
 # Setup telemetry BEFORE importing TAC
 os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
@@ -36,51 +35,64 @@ CLIENT_TYPES = ["conversation", "memory", "knowledge"]
 async def simulate_message_processing(channel: str, conversation_id: str):
     """Simulate a complete message processing lifecycle"""
 
-    with tracer.start_span("message.processing", attributes={"channel": channel, "conversation_id": conversation_id}):
+    # Generate sample input/output
+    user_input = f"Hello from {channel} user in {conversation_id}"
+    llm_output = f"Hi! I received your message on {channel}."
+
+    # Generate a profile ID for the user (in real usage, this comes from Conversation Memory)
+    profile_id = f"profile_{hash(conversation_id) % 100:03d}"
+
+    with tracer.start_span(
+        "message.processing",
+        attributes={
+            "channel": channel,
+            "conversation_id": conversation_id,
+            "input": user_input,
+            "output": llm_output,
+            "enduser.id": profile_id,  # User identification for filtering in Langfuse
+        },
+    ):
         # 1. Message received
         metrics.message_received_count.add(1, attributes={"channel": channel})
 
-        # 2. Conversation start (for new conversations)
-        if random.random() < 0.3:  # 30% are new conversations
-            with tracer.start_span("conversation.start", attributes={"channel": channel, "conversation_id": conversation_id}):
-                start_duration = random.uniform(0.01, 0.05)
-                await asyncio.sleep(start_duration)
-                metrics.conversation_start_duration.record(start_duration, attributes={"channel": channel})
-                metrics.conversation_active_count.add(1)
-
-        # 3. Memory retrieval
-        with tracer.start_span("memory.retrieve", attributes={"channel": channel, "conversation_id": conversation_id}):
+        # 2. Memory retrieval
+        with tracer.start_span(
+            "memory.retrieve", attributes={"channel": channel, "conversation_id": conversation_id}
+        ):
             memory_duration = random.uniform(0.05, 0.3)
             await asyncio.sleep(memory_duration)
 
             # Simulate memory API call
             metrics.api_request_count.add(1, attributes={"client_type": "memory", "method": "POST"})
-            metrics.api_request_duration.record(memory_duration, attributes={"client_type": "memory", "method": "POST"})
+            metrics.api_request_duration.record(
+                memory_duration, attributes={"client_type": "memory", "method": "POST"}
+            )
 
-        # 4. User callback (conversation.ready)
-        with tracer.start_span("conversation.ready", attributes={"channel": channel, "conversation_id": conversation_id}):
+        # 3. User callback (conversation.ready)
+        with tracer.start_span(
+            "conversation.ready",
+            attributes={"channel": channel, "conversation_id": conversation_id},
+        ):
             # This is the critical path - includes LLM call
             callback_duration = random.uniform(0.2, 1.5)
             await asyncio.sleep(callback_duration)
-            metrics.conversation_ready_duration.record(callback_duration, attributes={"channel": channel})
+            metrics.conversation_ready_duration.record(
+                callback_duration, attributes={"channel": channel}
+            )
 
-        # 5. Send message
+        # 4. Send message
         if random.random() < 0.95:  # 95% success rate
-            with tracer.start_span("message.send", attributes={"channel": channel, "conversation_id": conversation_id}):
+            with tracer.start_span(
+                "message.send", attributes={"channel": channel, "conversation_id": conversation_id}
+            ):
                 send_duration = random.uniform(0.02, 0.1)
                 await asyncio.sleep(send_duration)
                 metrics.message_sent_count.add(1, attributes={"channel": channel})
         else:
             # 5% error rate
-            metrics.message_error_count.add(1, attributes={"channel": channel, "error_type": "http_5xx"})
-
-        # 6. Conversation end (some conversations)
-        if random.random() < 0.2:  # 20% conversations end
-            with tracer.start_span("conversation.end", attributes={"channel": channel, "conversation_id": conversation_id, "reason": "completed"}):
-                end_duration = random.uniform(0.005, 0.02)
-                await asyncio.sleep(end_duration)
-                metrics.conversation_end_duration.record(end_duration, attributes={"channel": channel, "reason": "completed"})
-                metrics.conversation_active_count.add(-1)
+            metrics.message_error_count.add(
+                1, attributes={"channel": channel, "error_type": "http_5xx"}
+            )
 
 
 async def simulate_api_requests():
@@ -92,20 +104,33 @@ async def simulate_api_requests():
     await asyncio.sleep(duration)
 
     metrics.api_request_count.add(1, attributes={"client_type": client_type, "method": method})
-    metrics.api_request_duration.record(duration, attributes={"client_type": client_type, "method": method})
+    metrics.api_request_duration.record(
+        duration, attributes={"client_type": client_type, "method": method}
+    )
 
     # Simulate occasional errors
     if random.random() < 0.05:  # 5% error rate
         error_type = random.choice(["http_4xx", "http_5xx", "timeout"])
-        metrics.api_error_count.add(1, attributes={"client_type": client_type, "error_type": error_type})
+        metrics.api_error_count.add(
+            1, attributes={"client_type": client_type, "error_type": error_type}
+        )
 
 
 async def main():
     """Generate test data"""
+    # Simulate some conversation starts/ends (metrics only, no spans)
+    for _ in range(5):
+        channel = random.choice(CHANNELS)
+        # Conversation start
+        metrics.conversation_start_duration.record(
+            random.uniform(0.01, 0.05), attributes={"channel": channel}
+        )
+        metrics.conversation_active_count.add(1)
+
     tasks = []
 
     # Generate 30 messages across different channels
-    for i in range(30):
+    for _ in range(30):
         channel = random.choice(CHANNELS)
         conversation_id = f"conv_{random.randint(1, 10):03d}"  # 10 different conversations
         tasks.append(simulate_message_processing(channel, conversation_id))
@@ -118,11 +143,20 @@ async def main():
     print(f"Simulating {len(tasks)} operations...")
     await asyncio.gather(*tasks)
 
-    # Wait for metrics to be exported
-    print("\n⏳ Waiting for metrics to be exported...")
-    await asyncio.sleep(10)
+    # Simulate some conversation ends (metrics only)
+    for _ in range(3):
+        channel = random.choice(CHANNELS)
+        metrics.conversation_end_duration.record(
+            random.uniform(0.005, 0.02), attributes={"channel": channel, "reason": "completed"}
+        )
+        metrics.conversation_active_count.add(-1)
 
-    print("✅ Done! View results:")
+    # Flush telemetry data
+    print("\n⏳ Flushing telemetry data...")
+    telemetry.shutdown()
+    await asyncio.sleep(2)
+
+    print("\n✅ Done! View results:")
     print("   📊 Grafana: http://localhost:3000 (Dashboards → TAC Observability)")
     print("   🔍 Langfuse: http://localhost:3001 (Traces → message.processing)")
     print()

--- a/getting_started/examples/observability-demo/generate_test_data.py
+++ b/getting_started/examples/observability-demo/generate_test_data.py
@@ -1,0 +1,135 @@
+"""Generate test telemetry data to verify metrics and traces
+
+This script simulates TAC operations to populate Grafana and Langfuse with test data.
+"""
+
+import asyncio
+import os
+import random
+import time
+
+# Setup telemetry BEFORE importing TAC
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
+
+from tac.telemetry import TACTelemetry
+
+# Initialize telemetry
+telemetry = TACTelemetry()
+telemetry.setup_meter(enable_otlp_exporter=True)
+telemetry.setup_tracer(enable_otlp_exporter=True)
+
+from tac.telemetry.metrics import MetricsClient
+from tac.telemetry.tracer import TracerClient
+
+print("🚀 Generating test telemetry data...")
+print("📊 Metrics → Prometheus → Grafana (http://localhost:3000)")
+print("🔍 Traces → Langfuse (http://localhost:3001)")
+print()
+
+metrics = MetricsClient()
+tracer = TracerClient()
+
+CHANNELS = ["sms", "whatsapp", "voice"]
+CLIENT_TYPES = ["conversation", "memory", "knowledge"]
+
+
+async def simulate_message_processing(channel: str, conversation_id: str):
+    """Simulate a complete message processing lifecycle"""
+
+    with tracer.start_span("message.processing", attributes={"channel": channel, "conversation_id": conversation_id}):
+        # 1. Message received
+        metrics.message_received_count.add(1, attributes={"channel": channel})
+
+        # 2. Conversation start (for new conversations)
+        if random.random() < 0.3:  # 30% are new conversations
+            with tracer.start_span("conversation.start", attributes={"channel": channel, "conversation_id": conversation_id}):
+                start_duration = random.uniform(0.01, 0.05)
+                await asyncio.sleep(start_duration)
+                metrics.conversation_start_duration.record(start_duration, attributes={"channel": channel})
+                metrics.conversation_active_count.add(1)
+
+        # 3. Memory retrieval
+        with tracer.start_span("memory.retrieve", attributes={"channel": channel, "conversation_id": conversation_id}):
+            memory_duration = random.uniform(0.05, 0.3)
+            await asyncio.sleep(memory_duration)
+
+            # Simulate memory API call
+            metrics.api_request_count.add(1, attributes={"client_type": "memory", "method": "POST"})
+            metrics.api_request_duration.record(memory_duration, attributes={"client_type": "memory", "method": "POST"})
+
+        # 4. User callback (conversation.ready)
+        with tracer.start_span("conversation.ready", attributes={"channel": channel, "conversation_id": conversation_id}):
+            # This is the critical path - includes LLM call
+            callback_duration = random.uniform(0.2, 1.5)
+            await asyncio.sleep(callback_duration)
+            metrics.conversation_ready_duration.record(callback_duration, attributes={"channel": channel})
+
+        # 5. Send message
+        if random.random() < 0.95:  # 95% success rate
+            with tracer.start_span("message.send", attributes={"channel": channel, "conversation_id": conversation_id}):
+                send_duration = random.uniform(0.02, 0.1)
+                await asyncio.sleep(send_duration)
+                metrics.message_sent_count.add(1, attributes={"channel": channel})
+        else:
+            # 5% error rate
+            metrics.message_error_count.add(1, attributes={"channel": channel, "error_type": "http_5xx"})
+
+        # 6. Conversation end (some conversations)
+        if random.random() < 0.2:  # 20% conversations end
+            with tracer.start_span("conversation.end", attributes={"channel": channel, "conversation_id": conversation_id, "reason": "completed"}):
+                end_duration = random.uniform(0.005, 0.02)
+                await asyncio.sleep(end_duration)
+                metrics.conversation_end_duration.record(end_duration, attributes={"channel": channel, "reason": "completed"})
+                metrics.conversation_active_count.add(-1)
+
+
+async def simulate_api_requests():
+    """Simulate API requests to various services"""
+    client_type = random.choice(CLIENT_TYPES)
+    method = random.choice(["GET", "POST"])
+
+    duration = random.uniform(0.05, 0.5)
+    await asyncio.sleep(duration)
+
+    metrics.api_request_count.add(1, attributes={"client_type": client_type, "method": method})
+    metrics.api_request_duration.record(duration, attributes={"client_type": client_type, "method": method})
+
+    # Simulate occasional errors
+    if random.random() < 0.05:  # 5% error rate
+        error_type = random.choice(["http_4xx", "http_5xx", "timeout"])
+        metrics.api_error_count.add(1, attributes={"client_type": client_type, "error_type": error_type})
+
+
+async def main():
+    """Generate test data"""
+    tasks = []
+
+    # Generate 30 messages across different channels
+    for i in range(30):
+        channel = random.choice(CHANNELS)
+        conversation_id = f"conv_{random.randint(1, 10):03d}"  # 10 different conversations
+        tasks.append(simulate_message_processing(channel, conversation_id))
+
+        # Add some API requests
+        if random.random() < 0.3:
+            tasks.append(simulate_api_requests())
+
+    # Run all simulations
+    print(f"Simulating {len(tasks)} operations...")
+    await asyncio.gather(*tasks)
+
+    # Wait for metrics to be exported
+    print("\n⏳ Waiting for metrics to be exported...")
+    await asyncio.sleep(10)
+
+    print("✅ Done! View results:")
+    print("   📊 Grafana: http://localhost:3000 (Dashboards → TAC Observability)")
+    print("   🔍 Langfuse: http://localhost:3001 (Traces → message.processing)")
+    print()
+    print("Note: You'll need to create a Langfuse account and set these env vars:")
+    print("   export LANGFUSE_PUBLIC_KEY='pk-lf-...'")
+    print("   export LANGFUSE_SECRET_KEY='sk-lf-...'")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/getting_started/examples/observability-demo/grafana-dashboard.yml
+++ b/getting_started/examples/observability-demo/grafana-dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'TAC Dashboards'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/getting_started/examples/observability-demo/grafana-datasource.yml
+++ b/getting_started/examples/observability-demo/grafana-datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    uid: prometheus
+    isDefault: true
+    editable: true

--- a/getting_started/examples/observability-demo/grafana-tac-dashboard.json
+++ b/getting_started/examples/observability-demo/grafana-tac-dashboard.json
@@ -1,0 +1,567 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# TAC Observability Dashboard\n\nShowing P95 latency (95% of requests are faster than this) for the selected time range.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.0",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "s",
+          "decimals": 3
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "sms"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "voice"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "blue"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "whatsapp"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "yellow"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 1,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.6,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "always",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xField": "channel",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(increase(tac_conversation_ready_seconds_bucket{channel=\"sms\"}[$__range])) by (le))",
+          "legendFormat": "sms",
+          "refId": "A",
+          "instant": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(increase(tac_conversation_ready_seconds_bucket{channel=\"voice\"}[$__range])) by (le))",
+          "legendFormat": "voice",
+          "refId": "B",
+          "instant": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(increase(tac_conversation_ready_seconds_bucket{channel=\"whatsapp\"}[$__range])) by (le))",
+          "legendFormat": "whatsapp",
+          "refId": "C",
+          "instant": true
+        }
+      ],
+      "title": "Callback Latency P95 by Channel (on_message_ready)",
+      "description": "Time spent in user callback function (95th percentile)",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s",
+          "decimals": 3
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "value_and_name",
+        "text": {
+          "titleSize": 16,
+          "valueSize": 40
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(increase(tac_api_request_duration_seconds_bucket{client_type=\"conversation\"}[$__range])) by (le))",
+          "legendFormat": "Orchestrator",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Orchestrator API P95",
+      "description": "Conversation Orchestrator API latency (95th percentile)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s",
+          "decimals": 3
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "value_and_name",
+        "text": {
+          "titleSize": 16,
+          "valueSize": 40
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(increase(tac_api_request_duration_seconds_bucket{client_type=\"memory\"}[$__range])) by (le))",
+          "legendFormat": "Memory",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Memory API P95",
+      "description": "Conversation Memory API latency (95th percentile)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "value",
+        "text": {
+          "titleSize": 16,
+          "valueSize": 40
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(tac_message_error_total[$__range]))",
+          "legendFormat": "Errors",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Error Count",
+      "description": "Total message processing errors",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 5,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "vertical",
+        "showValue": "always",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(tac_message_received_total[$__range])) by (channel)",
+          "legendFormat": "{{channel}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Messages Received by Channel",
+      "description": "Total messages received per channel",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "vertical",
+        "showValue": "always",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(tac_message_sent_total[$__range])) by (channel)",
+          "legendFormat": "{{channel}}",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Messages Sent by Channel",
+      "description": "Total messages sent per channel",
+      "type": "barchart"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["tac", "observability"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "TAC Observability",
+  "uid": "tac-obs",
+  "version": 1,
+  "weekStart": ""
+}

--- a/getting_started/examples/observability-demo/openai_with_observability.py
+++ b/getting_started/examples/observability-demo/openai_with_observability.py
@@ -1,0 +1,171 @@
+"""
+Example: Using OpenAI Chat Completions API with TAC Memory Injection + OpenTelemetry
+
+This is the same as openai_chat_completions.py, but with OpenTelemetry observability added.
+
+Setup:
+1. Start observability stack: docker compose up -d
+2. Get Langfuse credentials from http://localhost:3001 → Settings → API Keys
+3. Create .env file with:
+   LANGFUSE_PUBLIC_KEY=pk-lf-...
+   LANGFUSE_SECRET_KEY=sk-lf-...
+   CONVERSATION_API_KEY=your-key
+   CONVERSATION_API_TOKEN=your-token
+   CONVERSATION_CONFIGURATION_ID=your-config-id
+   OPENAI_API_KEY=sk-...
+
+4. Run: uv run python openai_with_observability.py
+5. Expose with ngrok: ngrok http 8000
+6. Configure Twilio webhooks and send messages
+7. View data in:
+   - Grafana: http://localhost:3000
+   - Langfuse: http://localhost:3001
+"""
+
+import base64
+import os
+
+from dotenv import load_dotenv
+from openai import AsyncOpenAI
+from openai.types.chat import (
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionMessageParam,
+    ChatCompletionSystemMessageParam,
+    ChatCompletionUserMessageParam,
+)
+
+# ============================================================================
+# OpenTelemetry Setup - ADD THIS BEFORE IMPORTING TAC
+# ============================================================================
+load_dotenv()
+
+PUBLIC_KEY = os.getenv("LANGFUSE_PUBLIC_KEY")
+SECRET_KEY = os.getenv("LANGFUSE_SECRET_KEY")
+
+if PUBLIC_KEY and SECRET_KEY:
+    # Configure OpenTelemetry endpoints
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"  # Metrics → Prometheus
+
+    # Traces → Langfuse
+    auth_string = f"{PUBLIC_KEY}:{SECRET_KEY}"
+    auth_b64 = base64.b64encode(auth_string.encode()).decode()
+    os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "http://localhost:3001/api/public/otel/v1/traces"
+    os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {auth_b64}"
+# ============================================================================
+
+from tac import TAC, TACConfig
+from tac.adapters.openai import with_tac_memory
+from tac.channels.sms import SMSChannel, SMSChannelConfig
+from tac.channels.voice import VoiceChannel, VoiceChannelConfig
+from tac.core.logging import get_logger
+from tac.models.session import ConversationSession
+from tac.models.tac import TACMemoryResponse
+from tac.server import TACFastAPIServer
+
+# ============================================================================
+# OpenTelemetry Setup - ADD THIS AFTER IMPORTING TAC
+# ============================================================================
+if PUBLIC_KEY and SECRET_KEY:
+    from tac.telemetry import TACTelemetry
+
+    telemetry = TACTelemetry()
+    telemetry.setup_meter(enable_otlp_exporter=True)   # Metrics → Grafana
+    telemetry.setup_tracer(enable_otlp_exporter=True)  # Traces → Langfuse
+    print("✅ OpenTelemetry enabled - data will be sent to Grafana and Langfuse")
+else:
+    print("ℹ️  OpenTelemetry disabled - set LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY to enable")
+# ============================================================================
+
+logger = get_logger(__name__)
+
+# Initialize TAC with configuration from environment variables
+tac = TAC(config=TACConfig.from_env())
+
+# Create channel handlers for Voice and SMS
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
+sms_channel = SMSChannel(tac, config=SMSChannelConfig(memory_mode="always"))
+
+# Initialize OpenAI client
+openai_client = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+
+# Store conversation history per conversation
+conversation_history: dict[str, list[ChatCompletionMessageParam]] = {}
+
+SYSTEM_MESSAGE: ChatCompletionSystemMessageParam = {
+    "role": "system",
+    "content": (
+        "You are a customer service agent speaking with a user over voice or SMS. "
+        "Keep responses short and conversational — a sentence or two. "
+        "Do not use markdown, asterisks, bullets, or emojis; your words will be "
+        "spoken aloud or sent as plain text."
+    ),
+}
+
+
+async def handle_message_ready(
+    user_message: str,
+    context: ConversationSession,
+    memory_response: TACMemoryResponse | None,
+) -> str:
+    """
+    Callback invoked when a message is ready to be processed.
+
+    This example uses the Chat Completions API with automatic memory injection.
+
+    Args:
+        user_message: The customer's message text
+        context: Session data (conversation_id, channel, profile, etc.)
+        memory_response: Optional retrieved memories (observations, summaries, communications)
+
+    Returns:
+        Response string to send to the channel
+    """
+    conv_id = context.conversation_id
+
+    try:
+        # Initialize conversation history for new conversations
+        if conv_id not in conversation_history:
+            conversation_history[conv_id] = [SYSTEM_MESSAGE]
+
+        # Add user message to conversation history
+        user_msg: ChatCompletionUserMessageParam = {"role": "user", "content": user_message}
+        conversation_history[conv_id].append(user_msg)
+
+        # Wrap OpenAI client with TAC adapter for automatic memory injection
+        # The adapter injects memory as a system message at the start of the messages array
+        client = with_tac_memory(openai_client, memory_response, context)
+
+        # Call OpenAI Chat Completions API - memory is automatically injected
+        response = await client.chat.completions.create(
+            model="gpt-5.4-mini",
+            messages=conversation_history[conv_id],
+        )
+
+        llm_response = response.choices[0].message.content or ""
+
+        # Save assistant response to conversation history
+        assistant_msg: ChatCompletionAssistantMessageParam = {
+            "role": "assistant",
+            "content": llm_response,
+        }
+        conversation_history[conv_id].append(assistant_msg)
+
+        return llm_response
+
+    except Exception as e:
+        logger.error("Error processing message", conversation_id=conv_id, error=str(e))
+        return "Sorry, I encountered an error processing your message."
+
+
+# Register the message handler callback
+tac.on_message_ready(handle_message_ready)
+
+if __name__ == "__main__":
+    # TACFastAPIServer creates a FastAPI app with all required endpoints:
+    # - /twiml: Voice call webhook (returns TwiML with ConversationRelay)
+    # - /ws: WebSocket endpoint for Voice channel
+    # - /webhook: Conversation webhook for all channels
+    server = TACFastAPIServer(
+        tac=tac, voice_channel=voice_channel, messaging_channels=[sms_channel]
+    )
+    server.start()

--- a/getting_started/examples/observability-demo/openai_with_observability.py
+++ b/getting_started/examples/observability-demo/openai_with_observability.py
@@ -49,8 +49,18 @@ if PUBLIC_KEY and SECRET_KEY:
     # Traces → Langfuse
     auth_string = f"{PUBLIC_KEY}:{SECRET_KEY}"
     auth_b64 = base64.b64encode(auth_string.encode()).decode()
-    os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = "http://localhost:3001/api/public/otel/v1/traces"
+    os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = (
+        "http://localhost:3001/api/public/otel/v1/traces"
+    )
     os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {auth_b64}"
+
+    # PRIVACY: Include message content (input/output) in traces?
+    # WARNING: This sends user messages and LLM responses to your observability backend.
+    # Only enable if you have proper data handling agreements and comply with privacy regulations.
+    # Default: false (disabled for privacy)
+    os.environ["TAC_TELEMETRY_INCLUDE_MESSAGE_CONTENT"] = os.getenv(
+        "TAC_TELEMETRY_INCLUDE_MESSAGE_CONTENT", "false"
+    )
 # ============================================================================
 
 from tac import TAC, TACConfig
@@ -69,7 +79,7 @@ if PUBLIC_KEY and SECRET_KEY:
     from tac.telemetry import TACTelemetry
 
     telemetry = TACTelemetry()
-    telemetry.setup_meter(enable_otlp_exporter=True)   # Metrics → Grafana
+    telemetry.setup_meter(enable_otlp_exporter=True)  # Metrics → Grafana
     telemetry.setup_tracer(enable_otlp_exporter=True)  # Traces → Langfuse
     print("✅ OpenTelemetry enabled - data will be sent to Grafana and Langfuse")
 else:

--- a/getting_started/examples/observability-demo/otel-collector-config.yml
+++ b/getting_started/examples/observability-demo/otel-collector-config.yml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 100
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+    namespace: tac
+    resource_to_telemetry_conversion:
+      enabled: true
+
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, debug]

--- a/getting_started/examples/observability-demo/prometheus.yml
+++ b/getting_started/examples/observability-demo/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: 'tac'
+    static_configs:
+      - targets: ['otel-collector:8889']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,12 @@ server = [
     "uvicorn[standard]>=0.32.0,<1",
     "python-multipart>=0.0.20,<1",
 ]
+telemetry = [
+    "opentelemetry-api>=1.30.0,<2.0.0",
+    "opentelemetry-sdk>=1.30.0,<2.0.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.30.0,<2.0.0",
+    "langfuse>=4.6.1",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,8 @@ select = [
     "N",   # pep8-naming
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"getting_started/examples/**/*.py" = ["E402"]  # Allow module imports after code in examples
 
 [tool.ruff.lint.isort]
 known-first-party = ["tac"]

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -240,7 +240,6 @@ class MessagingChannel(BaseChannel):
 
     async def _handle_communication_created(self, event_data: Any) -> None:
         """Handle COMMUNICATION_CREATED event (incoming message)."""
-        start_time = time.time()
         communication_data = Communication.model_validate(event_data)
         conv_id = communication_data.conversation_id
         message_text = communication_data.content.text
@@ -256,25 +255,45 @@ class MessagingChannel(BaseChannel):
             return
 
         channel_name = self.get_channel_name()
-        span_attributes = {"channel": channel_name, "conversation_id": conv_id}
+        span_attributes = {
+            "channel": channel_name,
+            "conversation_id": conv_id,
+        }
+
+        # Only include message content if explicitly enabled (privacy-safe by default)
+        if self._tracer and self._tracer.include_message_content:
+            span_attributes["input"] = message_text
 
         # Start root span for entire message processing
-        with self._tracer.start_span("message.processing", attributes=span_attributes) if self._tracer else nullcontext():
+        # We need to manually start the span to be able to add attributes later
+        if self._tracer:
+            from opentelemetry import trace
+
+            message_span = self._tracer.tracer.start_span(
+                "message.processing", attributes=span_attributes
+            )
+            span_context = trace.use_span(message_span, end_on_exit=True)
+        else:
+            message_span = None
+            span_context = nullcontext()
+
+        with span_context:
             try:
                 # 📊 Metric: Message received
                 if self._metrics:
-                    self._metrics.message_received_count.add(1, attributes={"channel": channel_name})
+                    self._metrics.message_received_count.add(
+                        1, attributes={"channel": channel_name}
+                    )
 
                 if conv_id not in self._conversations:
-                    # 🔍 Span: Conversation start
-                    with self._tracer.start_span("conversation.start", attributes=span_attributes) if self._tracer else nullcontext():
-                        start_conv_time = time.time()
-                        self._start_conversation(conv_id, profile_id=None)
-                        if self._metrics:
-                            self._metrics.conversation_start_duration.record(
-                                time.time() - start_conv_time, attributes={"channel": channel_name}
-                            )
-                            self._metrics.conversation_active_count.add(1)
+                    # 📊 Metric: Conversation start
+                    start_conv_time = time.time()
+                    self._start_conversation(conv_id, profile_id=None)
+                    if self._metrics:
+                        self._metrics.conversation_start_duration.record(
+                            time.time() - start_conv_time, attributes={"channel": channel_name}
+                        )
+                        self._metrics.conversation_active_count.add(1)
 
                 session = self._conversations[conv_id]
 
@@ -288,14 +307,15 @@ class MessagingChannel(BaseChannel):
                     session.metadata["channel_id"] = communication_data.channel_id
 
                 # Reconcile participant types pre-LLM so v1-bridge's UNKNOWN gets
-                # promoted to CUSTOMER (with a Conversation Memory profile attached when possible)
-                # and to stash both participant ids on the session for send_response.
-                # If reconciliation can't identify both sides, any eventual reply would
-                # fail too — skip the callback so the LLM doesn't waste a turn on an
-                # un-replyable conversation.
+                # promoted to CUSTOMER (with a Conversation Memory profile attached
+                # when possible) and to stash both participant ids on the session
+                # for send_response. If reconciliation can't identify both sides,
+                # any eventual reply would fail too — skip the callback so the LLM
+                # doesn't waste a turn on an un-replyable conversation.
                 #
-                # Skip reconcile entirely when both sides are already stashed from a
-                # prior turn — Conversation Orchestrator's state was written by us and doesn't drift.
+                # Skip reconcile entirely when both sides are already stashed from
+                # a prior turn — Conversation Orchestrator's state was written by
+                # us and doesn't drift.
                 if session.ai_agent_info is None or session.author_info is None:
                     resolved = await self._reconcile_participants(conv_id)
                     if resolved is None:
@@ -319,14 +339,30 @@ class MessagingChannel(BaseChannel):
                         if customer_participant.profile_id and not session.profile_id:
                             session.profile_id = customer_participant.profile_id
 
+                # Add user ID to span if profile_id is available
+                if message_span and session.profile_id:
+                    message_span.set_attribute("enduser.id", session.profile_id)
+
                 # 🔍 Span: Memory retrieval
-                with self._tracer.start_span("memory.retrieve", attributes=span_attributes) if self._tracer else nullcontext():
-                    memory_response = await self._retrieve_memory_if_enabled(session, message_text, conv_id)
+                with (
+                    self._tracer.start_span("memory.retrieve", attributes=span_attributes)
+                    if self._tracer
+                    else nullcontext()
+                ):
+                    memory_response = await self._retrieve_memory_if_enabled(
+                        session, message_text, conv_id
+                    )
 
                 # 🔍 Span: User callback execution
-                with self._tracer.start_span("conversation.ready", attributes=span_attributes) if self._tracer else nullcontext():
+                with (
+                    self._tracer.start_span("conversation.ready", attributes=span_attributes)
+                    if self._tracer
+                    else nullcontext()
+                ):
                     callback_start = time.time()
-                    response = await self.tac.trigger_message_ready(message_text, session, memory_response)
+                    response = await self.tac.trigger_message_ready(
+                        message_text, session, memory_response
+                    )
                     callback_duration = time.time() - callback_start
 
                     if self._metrics:
@@ -336,13 +372,23 @@ class MessagingChannel(BaseChannel):
 
                 # Auto-send if callback returned a string (None = manual send_response flow)
                 if response is not None:
+                    # Add output to the message.processing span (only if message content is enabled)
+                    if message_span and self._tracer.include_message_content:
+                        message_span.set_attribute("output", response)
+
                     # 🔍 Span: Send response
-                    with self._tracer.start_span("message.send", attributes=span_attributes) if self._tracer else nullcontext():
+                    with (
+                        self._tracer.start_span("message.send", attributes=span_attributes)
+                        if self._tracer
+                        else nullcontext()
+                    ):
                         await self.send_response(conv_id, response, role="assistant")
 
                         # 📊 Metric: Message sent
                         if self._metrics:
-                            self._metrics.message_sent_count.add(1, attributes={"channel": channel_name})
+                            self._metrics.message_sent_count.add(
+                                1, attributes={"channel": channel_name}
+                            )
 
             except Exception as e:
                 # 📊 Metric: Message error
@@ -381,21 +427,20 @@ class MessagingChannel(BaseChannel):
             return
 
         if status == "CLOSED":
-            # 🔍 Span: Conversation end
+            # 📊 Metric: Conversation end
             channel_name = self.get_channel_name()
-            span_attributes = {"channel": channel_name, "conversation_id": conv_id, "reason": "completed"}
-            with self._tracer.start_span("conversation.end", attributes=span_attributes) if self._tracer else nullcontext():
-                end_start_time = time.time()
+            end_start_time = time.time()
 
-                if self._metrics:
-                    self._metrics.conversation_active_count.add(-1)
+            if self._metrics:
+                self._metrics.conversation_active_count.add(-1)
 
-                await self._end_conversation(conv_id)
+            await self._end_conversation(conv_id)
 
-                if self._metrics:
-                    self._metrics.conversation_end_duration.record(
-                        time.time() - end_start_time, attributes={"channel": channel_name, "reason": "completed"}
-                    )
+            if self._metrics:
+                self._metrics.conversation_end_duration.record(
+                    time.time() - end_start_time,
+                    attributes={"channel": channel_name, "reason": "completed"},
+                )
         elif status == "INACTIVE" and self.memory_mode == "once":
             # Invalidate cached memory when conversation becomes inactive
             # Memory is updated by Conversation Orchestrator on INACTIVE transition

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -1,7 +1,9 @@
 """MessagingChannel base class for messaging channels (SMS, RCS, WhatsApp, Chat)."""
 
+import time
 from abc import abstractmethod
 from collections.abc import AsyncGenerator
+from contextlib import nullcontext
 from typing import Any
 
 import httpx
@@ -25,6 +27,7 @@ from tac.models.conversation import (
 from tac.models.memory import MemoryMode
 from tac.models.outbound import InitiateConversationResult, InitiateMessagingConversationOptions
 from tac.models.session import AuthorInfo
+from tac.telemetry.tracer import TracerClient
 from tac.utils.redaction import mask_address
 
 # Participant types that represent TAC itself at TAC's (channel, address).
@@ -100,6 +103,19 @@ class MessagingChannel(BaseChannel):
             tac.conversation_orchestrator_client
         )
         super().__init__(tac, memory_mode=memory_mode, dedup_capacity=dedup_capacity)
+
+        # Initialize telemetry clients
+        try:
+            from tac.telemetry.metrics import MetricsClient
+
+            self._metrics = MetricsClient()
+        except ImportError:
+            self._metrics = None
+
+        try:
+            self._tracer = TracerClient()
+        except ImportError:
+            self._tracer = None
 
     @abstractmethod
     def is_default_agent_address(self, author_address: str) -> bool:
@@ -224,6 +240,7 @@ class MessagingChannel(BaseChannel):
 
     async def _handle_communication_created(self, event_data: Any) -> None:
         """Handle COMMUNICATION_CREATED event (incoming message)."""
+        start_time = time.time()
         communication_data = Communication.model_validate(event_data)
         conv_id = communication_data.conversation_id
         message_text = communication_data.content.text
@@ -238,66 +255,113 @@ class MessagingChannel(BaseChannel):
         ):
             return
 
-        if conv_id not in self._conversations:
-            self._start_conversation(conv_id, profile_id=None)
+        channel_name = self.get_channel_name()
+        span_attributes = {"channel": channel_name, "conversation_id": conv_id}
 
-        session = self._conversations[conv_id]
+        # Start root span for entire message processing
+        with self._tracer.start_span("message.processing", attributes=span_attributes) if self._tracer else nullcontext():
+            try:
+                # 📊 Metric: Message received
+                if self._metrics:
+                    self._metrics.message_received_count.add(1, attributes={"channel": channel_name})
 
-        session.author_info = AuthorInfo(
-            address=communication_data.author.address,
-            participant_id=communication_data.author.participant_id,
-        )
+                if conv_id not in self._conversations:
+                    # 🔍 Span: Conversation start
+                    with self._tracer.start_span("conversation.start", attributes=span_attributes) if self._tracer else nullcontext():
+                        start_conv_time = time.time()
+                        self._start_conversation(conv_id, profile_id=None)
+                        if self._metrics:
+                            self._metrics.conversation_start_duration.record(
+                                time.time() - start_conv_time, attributes={"channel": channel_name}
+                            )
+                            self._metrics.conversation_active_count.add(1)
 
-        # Store channelId in session metadata for outbound reply channelSettings
-        if communication_data.channel_id:
-            session.metadata["channel_id"] = communication_data.channel_id
+                session = self._conversations[conv_id]
 
-        # Reconcile participant types pre-LLM so v1-bridge's UNKNOWN gets
-        # promoted to CUSTOMER (with a Conversation Memory profile attached when possible)
-        # and to stash both participant ids on the session for send_response.
-        # If reconciliation can't identify both sides, any eventual reply would
-        # fail too — skip the callback so the LLM doesn't waste a turn on an
-        # un-replyable conversation.
-        #
-        # Skip reconcile entirely when both sides are already stashed from a
-        # prior turn — Conversation Orchestrator's state was written by us and doesn't drift.
-        if session.ai_agent_info is None or session.author_info is None:
-            resolved = await self._reconcile_participants(conv_id)
-            if resolved is None:
-                self.logger.warning(
-                    "Reconciliation failed; skipping callback for this inbound",
-                    conversation_id=conv_id,
+                session.author_info = AuthorInfo(
+                    address=communication_data.author.address,
+                    participant_id=communication_data.author.participant_id,
                 )
-                return
 
-            agent_participant, customer_participant = resolved
-            session.ai_agent_info = AuthorInfo(
-                address=self.get_agent_address(conv_id).address,
-                participant_id=agent_participant.id,
-            )
-            # When reconcile resolved a customer (SMS path — chat disables
-            # customer reconciliation and uses the author_info captured from
-            # the webhook above), use its authoritative participant id and
-            # lift any resolved profile.
-            if customer_participant is not None and session.author_info is not None:
-                session.author_info.participant_id = customer_participant.id
-                if customer_participant.profile_id and not session.profile_id:
-                    session.profile_id = customer_participant.profile_id
+                # Store channelId in session metadata for outbound reply channelSettings
+                if communication_data.channel_id:
+                    session.metadata["channel_id"] = communication_data.channel_id
 
-        memory_response = await self._retrieve_memory_if_enabled(session, message_text, conv_id)
+                # Reconcile participant types pre-LLM so v1-bridge's UNKNOWN gets
+                # promoted to CUSTOMER (with a Conversation Memory profile attached when possible)
+                # and to stash both participant ids on the session for send_response.
+                # If reconciliation can't identify both sides, any eventual reply would
+                # fail too — skip the callback so the LLM doesn't waste a turn on an
+                # un-replyable conversation.
+                #
+                # Skip reconcile entirely when both sides are already stashed from a
+                # prior turn — Conversation Orchestrator's state was written by us and doesn't drift.
+                if session.ai_agent_info is None or session.author_info is None:
+                    resolved = await self._reconcile_participants(conv_id)
+                    if resolved is None:
+                        self.logger.warning(
+                            "Reconciliation failed; skipping callback for this inbound",
+                            conversation_id=conv_id,
+                        )
+                        return
 
-        try:
-            response = await self.tac.trigger_message_ready(message_text, session, memory_response)
-            # Auto-send if callback returned a string (None = manual send_response flow)
-            if response is not None:
-                await self.send_response(conv_id, response, role="assistant")
-        except Exception as e:
-            self.logger.error(
-                "Error in message ready callback",
-                conversation_id=conv_id,
-                error=str(e),
-                exc_info=True,
-            )
+                    agent_participant, customer_participant = resolved
+                    session.ai_agent_info = AuthorInfo(
+                        address=self.get_agent_address(conv_id).address,
+                        participant_id=agent_participant.id,
+                    )
+                    # When reconcile resolved a customer (SMS path — chat disables
+                    # customer reconciliation and uses the author_info captured from
+                    # the webhook above), use its authoritative participant id and
+                    # lift any resolved profile.
+                    if customer_participant is not None and session.author_info is not None:
+                        session.author_info.participant_id = customer_participant.id
+                        if customer_participant.profile_id and not session.profile_id:
+                            session.profile_id = customer_participant.profile_id
+
+                # 🔍 Span: Memory retrieval
+                with self._tracer.start_span("memory.retrieve", attributes=span_attributes) if self._tracer else nullcontext():
+                    memory_response = await self._retrieve_memory_if_enabled(session, message_text, conv_id)
+
+                # 🔍 Span: User callback execution
+                with self._tracer.start_span("conversation.ready", attributes=span_attributes) if self._tracer else nullcontext():
+                    callback_start = time.time()
+                    response = await self.tac.trigger_message_ready(message_text, session, memory_response)
+                    callback_duration = time.time() - callback_start
+
+                    if self._metrics:
+                        self._metrics.conversation_ready_duration.record(
+                            callback_duration, attributes={"channel": channel_name}
+                        )
+
+                # Auto-send if callback returned a string (None = manual send_response flow)
+                if response is not None:
+                    # 🔍 Span: Send response
+                    with self._tracer.start_span("message.send", attributes=span_attributes) if self._tracer else nullcontext():
+                        await self.send_response(conv_id, response, role="assistant")
+
+                        # 📊 Metric: Message sent
+                        if self._metrics:
+                            self._metrics.message_sent_count.add(1, attributes={"channel": channel_name})
+
+            except Exception as e:
+                # 📊 Metric: Message error
+                if self._metrics:
+                    self._metrics.message_error_count.add(
+                        1,
+                        attributes={
+                            "channel": channel_name,
+                            "error_type": type(e).__name__,
+                        },
+                    )
+
+                self.logger.error(
+                    "Error in message ready callback",
+                    conversation_id=conv_id,
+                    error=str(e),
+                    exc_info=True,
+                )
+                raise
 
     async def _handle_conversation_updated(self, event_data: Any) -> None:
         """Handle CONVERSATION_UPDATED event.
@@ -317,7 +381,21 @@ class MessagingChannel(BaseChannel):
             return
 
         if status == "CLOSED":
-            await self._end_conversation(conv_id)
+            # 🔍 Span: Conversation end
+            channel_name = self.get_channel_name()
+            span_attributes = {"channel": channel_name, "conversation_id": conv_id, "reason": "completed"}
+            with self._tracer.start_span("conversation.end", attributes=span_attributes) if self._tracer else nullcontext():
+                end_start_time = time.time()
+
+                if self._metrics:
+                    self._metrics.conversation_active_count.add(-1)
+
+                await self._end_conversation(conv_id)
+
+                if self._metrics:
+                    self._metrics.conversation_end_duration.record(
+                        time.time() - end_start_time, attributes={"channel": channel_name, "reason": "completed"}
+                    )
         elif status == "INACTIVE" and self.memory_mode == "once":
             # Invalidate cached memory when conversation becomes inactive
             # Memory is updated by Conversation Orchestrator on INACTIVE transition

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -261,17 +261,15 @@ class VoiceChannel(BaseChannel):
 
         self._websocket_manager.add_websocket(conv_id, websocket)
 
-        # 🔍 Span: Conversation start (session initialization)
-        span_attributes = {"channel": "voice", "conversation_id": conv_id}
-        with self._tracer.start_span("conversation.start", attributes=span_attributes) if self._tracer else nullcontext():
-            start_conv_time = time.time()
-            session = self._start_conversation(conv_id, profile_id)
+        # 📊 Metric: Conversation start (session initialization)
+        start_conv_time = time.time()
+        session = self._start_conversation(conv_id, profile_id)
 
-            if self._metrics:
-                self._metrics.conversation_start_duration.record(
-                    time.time() - start_conv_time, attributes={"channel": "voice"}
-                )
-                self._metrics.conversation_active_count.add(1)
+        if self._metrics:
+            self._metrics.conversation_start_duration.record(
+                time.time() - start_conv_time, attributes={"channel": "voice"}
+            )
+            self._metrics.conversation_active_count.add(1)
 
         session_state = None
         if self.session_manager is not None:
@@ -696,8 +694,6 @@ class VoiceChannel(BaseChannel):
             conv_id: Conversation ID
             message: Parsed PromptMessage containing user's transcribed speech
         """
-        start_time = time.time()
-
         if conv_id not in self._conversations:
             self.logger.error(
                 f"Received prompt for unknown conversation {conv_id}. "
@@ -709,23 +705,58 @@ class VoiceChannel(BaseChannel):
         message_body = message.voice_prompt or ""
         session = self._conversations[conv_id]
 
-        span_attributes = {"channel": "voice", "conversation_id": conv_id}
+        span_attributes = {
+            "channel": "voice",
+            "conversation_id": conv_id,
+        }
+
+        # Only include message content if explicitly enabled (privacy-safe by default)
+        if self._tracer and self._tracer.include_message_content:
+            span_attributes["input"] = message_body
 
         # Start root span for entire message processing
-        with self._tracer.start_span("message.processing", attributes=span_attributes) if self._tracer else nullcontext():
+        # We need to manually start the span to be able to add attributes later
+        if self._tracer:
+            from opentelemetry import trace
+
+            message_span = self._tracer.tracer.start_span(
+                "message.processing", attributes=span_attributes
+            )
+            span_context = trace.use_span(message_span, end_on_exit=True)
+        else:
+            message_span = None
+            span_context = nullcontext()
+
+        with span_context:
             try:
+                # Add user ID to span if profile_id is available
+                if message_span and session.profile_id:
+                    message_span.set_attribute("enduser.id", session.profile_id)
+
                 # 📊 Metric: Message received
                 if self._metrics:
                     self._metrics.message_received_count.add(1, attributes={"channel": "voice"})
 
                 # 🔍 Span: Memory retrieval
-                with self._tracer.start_span("memory.retrieve", attributes=span_attributes) if self._tracer else nullcontext():
-                    memory_response = await self._retrieve_memory_if_enabled(session, message_body, conv_id)
+                with (
+                    self._tracer.start_span("memory.retrieve", attributes=span_attributes)
+                    if self._tracer
+                    else nullcontext()
+                ):
+                    memory_response = await self._retrieve_memory_if_enabled(
+                        session, message_body, conv_id
+                    )
 
                 # 🔍 Span: User callback execution
-                with self._tracer.start_span("conversation.ready", attributes=span_attributes) if self._tracer else nullcontext():
+                with (
+                    self._tracer.start_span("conversation.ready", attributes=span_attributes)
+                    if self._tracer
+                    else nullcontext()
+                ):
                     callback_start = time.time()
-                    response = await self.tac.trigger_message_ready(message_body, session, memory_response)
+                    response = await self.tac.trigger_message_ready(
+                        message_body, session, memory_response
+                    )
                     callback_duration = time.time() - callback_start
 
                     if self._metrics:
@@ -735,8 +766,16 @@ class VoiceChannel(BaseChannel):
 
                 # Auto-send if callback returned a string (None = manual send_response flow)
                 if response is not None:
+                    # Add output to the message.processing span (only if message content is enabled)
+                    if message_span and self._tracer.include_message_content:
+                        message_span.set_attribute("output", response)
+
                     # 🔍 Span: Send response
-                    with self._tracer.start_span("message.send", attributes=span_attributes) if self._tracer else nullcontext():
+                    with (
+                        self._tracer.start_span("message.send", attributes=span_attributes)
+                        if self._tracer
+                        else nullcontext()
+                    ):
                         await self.send_response(conv_id, response, role="assistant")
 
                         # 📊 Metric: Message sent
@@ -804,20 +843,19 @@ class VoiceChannel(BaseChannel):
             self.session_manager.remove_session(conv_id)
 
         if not self.tac.is_orchestrator_enabled() and conv_id in self._conversations:
-            # 🔍 Span: Conversation end
-            span_attributes = {"channel": "voice", "conversation_id": conv_id, "reason": "completed"}
-            with self._tracer.start_span("conversation.end", attributes=span_attributes) if self._tracer else nullcontext():
-                end_start_time = time.time()
+            # 📊 Metric: Conversation end
+            end_start_time = time.time()
 
-                if self._metrics:
-                    self._metrics.conversation_active_count.add(-1)
+            if self._metrics:
+                self._metrics.conversation_active_count.add(-1)
 
-                await self._end_conversation(conv_id)
+            await self._end_conversation(conv_id)
 
-                if self._metrics:
-                    self._metrics.conversation_end_duration.record(
-                        time.time() - end_start_time, attributes={"channel": "voice", "reason": "completed"}
-                    )
+            if self._metrics:
+                self._metrics.conversation_end_duration.record(
+                    time.time() - end_start_time,
+                    attributes={"channel": "voice", "reason": "completed"},
+                )
 
         self.logger.debug(
             "Cleaned up WebSocket and session resources",

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections.abc import AsyncGenerator
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -76,6 +78,21 @@ class VoiceChannel(BaseChannel):
         self.session_manager = config.session_manager
         self._websocket_manager = WebSocketManager()
         self._twilio_client: Client | None = None
+
+        # Initialize telemetry clients
+        try:
+            from tac.telemetry.metrics import MetricsClient
+
+            self._metrics = MetricsClient()
+        except ImportError:
+            self._metrics = None
+
+        try:
+            from tac.telemetry.tracer import TracerClient
+
+            self._tracer = TracerClient()
+        except ImportError:
+            self._tracer = None
 
     @staticmethod
     def _caller_address(setup_msg: SetupMessage) -> str | None:
@@ -243,7 +260,18 @@ class VoiceChannel(BaseChannel):
         profile_id = customer_participant.profile_id if customer_participant else None
 
         self._websocket_manager.add_websocket(conv_id, websocket)
-        session = self._start_conversation(conv_id, profile_id)
+
+        # 🔍 Span: Conversation start (session initialization)
+        span_attributes = {"channel": "voice", "conversation_id": conv_id}
+        with self._tracer.start_span("conversation.start", attributes=span_attributes) if self._tracer else nullcontext():
+            start_conv_time = time.time()
+            session = self._start_conversation(conv_id, profile_id)
+
+            if self._metrics:
+                self._metrics.conversation_start_duration.record(
+                    time.time() - start_conv_time, attributes={"channel": "voice"}
+                )
+                self._metrics.conversation_active_count.add(1)
 
         session_state = None
         if self.session_manager is not None:
@@ -331,6 +359,12 @@ class VoiceChannel(BaseChannel):
             self.logger.info("WebSocket connection closed", conversation_id=conv_id)
         except Exception as e:
             self.logger.error(f"WebSocket error: {str(e)}")
+            # Record error metric
+            if self._metrics:
+                self._metrics.message_error_count.add(
+                    1,
+                    attributes={"channel": "voice", "error_type": type(e).__name__},
+                )
         finally:
             if conv_id:
                 self.logger.debug("Cleanup - removing WebSocket", conversation_id=conv_id)
@@ -662,6 +696,8 @@ class VoiceChannel(BaseChannel):
             conv_id: Conversation ID
             message: Parsed PromptMessage containing user's transcribed speech
         """
+        start_time = time.time()
+
         if conv_id not in self._conversations:
             self.logger.error(
                 f"Received prompt for unknown conversation {conv_id}. "
@@ -673,22 +709,55 @@ class VoiceChannel(BaseChannel):
         message_body = message.voice_prompt or ""
         session = self._conversations[conv_id]
 
-        # Retrieve memory if memory_mode is enabled and Twilio Memory is configured
-        memory_response = await self._retrieve_memory_if_enabled(session, message_body, conv_id)
+        span_attributes = {"channel": "voice", "conversation_id": conv_id}
 
-        # Trigger message ready callback
-        try:
-            response = await self.tac.trigger_message_ready(message_body, session, memory_response)
-            # Auto-send if callback returned a string (None = manual send_response flow)
-            if response is not None:
-                await self.send_response(conv_id, response, role="assistant")
-        except Exception as e:
-            self.logger.error(
-                "Error in message ready callback",
-                conversation_id=conv_id,
-                error=str(e),
-                exc_info=True,
-            )
+        # Start root span for entire message processing
+        with self._tracer.start_span("message.processing", attributes=span_attributes) if self._tracer else nullcontext():
+            try:
+                # 📊 Metric: Message received
+                if self._metrics:
+                    self._metrics.message_received_count.add(1, attributes={"channel": "voice"})
+
+                # 🔍 Span: Memory retrieval
+                with self._tracer.start_span("memory.retrieve", attributes=span_attributes) if self._tracer else nullcontext():
+                    memory_response = await self._retrieve_memory_if_enabled(session, message_body, conv_id)
+
+                # 🔍 Span: User callback execution
+                with self._tracer.start_span("conversation.ready", attributes=span_attributes) if self._tracer else nullcontext():
+                    callback_start = time.time()
+                    response = await self.tac.trigger_message_ready(message_body, session, memory_response)
+                    callback_duration = time.time() - callback_start
+
+                    if self._metrics:
+                        self._metrics.conversation_ready_duration.record(
+                            callback_duration, attributes={"channel": "voice"}
+                        )
+
+                # Auto-send if callback returned a string (None = manual send_response flow)
+                if response is not None:
+                    # 🔍 Span: Send response
+                    with self._tracer.start_span("message.send", attributes=span_attributes) if self._tracer else nullcontext():
+                        await self.send_response(conv_id, response, role="assistant")
+
+                        # 📊 Metric: Message sent
+                        if self._metrics:
+                            self._metrics.message_sent_count.add(1, attributes={"channel": "voice"})
+
+            except Exception as e:
+                # 📊 Metric: Message error
+                if self._metrics:
+                    self._metrics.message_error_count.add(
+                        1,
+                        attributes={"channel": "voice", "error_type": type(e).__name__},
+                    )
+
+                self.logger.error(
+                    "Error in message ready callback",
+                    conversation_id=conv_id,
+                    error=str(e),
+                    exc_info=True,
+                )
+                raise
 
     def _handle_interrupt(self, conv_id: str, message: InterruptMessage) -> None:
         """
@@ -735,7 +804,20 @@ class VoiceChannel(BaseChannel):
             self.session_manager.remove_session(conv_id)
 
         if not self.tac.is_orchestrator_enabled() and conv_id in self._conversations:
-            await self._end_conversation(conv_id)
+            # 🔍 Span: Conversation end
+            span_attributes = {"channel": "voice", "conversation_id": conv_id, "reason": "completed"}
+            with self._tracer.start_span("conversation.end", attributes=span_attributes) if self._tracer else nullcontext():
+                end_start_time = time.time()
+
+                if self._metrics:
+                    self._metrics.conversation_active_count.add(-1)
+
+                await self._end_conversation(conv_id)
+
+                if self._metrics:
+                    self._metrics.conversation_end_duration.record(
+                        time.time() - end_start_time, attributes={"channel": "voice", "reason": "completed"}
+                    )
 
         self.logger.debug(
             "Cleaned up WebSocket and session resources",

--- a/src/tac/context/base.py
+++ b/src/tac/context/base.py
@@ -1,4 +1,5 @@
 import platform
+import time
 from enum import Enum
 
 import httpx
@@ -60,6 +61,14 @@ class BaseAPIClient:
         self._partner_package_version: str | None = None
         self.logger = get_logger(self.__class__.__name__)
 
+        # Initialize metrics client
+        try:
+            from tac.telemetry.metrics import MetricsClient
+
+            self._metrics = MetricsClient()
+        except ImportError:
+            self._metrics = None
+
     @staticmethod
     def _build_base_url(product: str, region: str | None) -> str:
         if region:
@@ -112,3 +121,77 @@ class BaseAPIClient:
             timeout=30.0,
             follow_redirects=True,
         )
+
+    def _record_api_request(
+        self,
+        method: str,
+        start_time: float,
+        status_code: int | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        """Record API request metrics.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            start_time: Request start timestamp
+            status_code: HTTP response status code (if available)
+            error: Exception if request failed
+        """
+        if not self._metrics:
+            return
+
+        client_type = self.__class__.__name__.replace("Client", "").lower()
+        duration = time.time() - start_time
+
+        # Base attributes for all metrics
+        base_attrs = {"client_type": client_type, "method": method}
+
+        # 📊 Metric 7: API request count
+        self._metrics.api_request_count.add(1, attributes=base_attrs)
+
+        # 📊 Metric 8: API request duration
+        self._metrics.api_request_duration.record(duration, attributes=base_attrs)
+
+        # 📊 Metric 9: API error count
+        if error:
+            # Categorize error types to limit cardinality
+            error_category = self._categorize_error(error)
+            error_attrs = {**base_attrs, "error_type": error_category}
+
+            # Add status code if available (from HTTPError)
+            if status_code:
+                error_attrs["status_code"] = str(status_code)
+
+            self._metrics.api_error_count.add(1, attributes=error_attrs)
+
+    @staticmethod
+    def _categorize_error(error: Exception) -> str:
+        """Categorize errors to limit metric cardinality.
+
+        Args:
+            error: Exception to categorize
+
+        Returns:
+            Error category string
+        """
+        # HTTPError with status codes
+        if hasattr(error, "response") and hasattr(error.response, "status_code"):
+            status_code = error.response.status_code
+            if 400 <= status_code < 500:
+                return "http_4xx"
+            elif 500 <= status_code < 600:
+                return "http_5xx"
+
+        # Network errors
+        error_name = type(error).__name__
+        if "Timeout" in error_name or "timeout" in str(error).lower():
+            return "timeout"
+        if "Connect" in error_name or "connection" in str(error).lower():
+            return "connection"
+
+        # Validation/parsing errors
+        if "Validation" in error_name or "Parse" in error_name:
+            return "validation"
+
+        # Generic fallback
+        return "other"

--- a/src/tac/context/memory.py
+++ b/src/tac/context/memory.py
@@ -101,7 +101,9 @@ class MemoryClient(BaseAPIClient):
 
         except httpx.HTTPError as e:
             # Extract status code if available
-            status_code = getattr(e.response, "status_code", None) if hasattr(e, "response") else None
+            status_code = (
+                getattr(e.response, "status_code", None) if hasattr(e, "response") else None
+            )
 
             # Record API metrics for error
             self._record_api_request("POST", start_time, status_code=status_code, error=e)

--- a/src/tac/context/memory.py
+++ b/src/tac/context/memory.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any
 
 import httpx
@@ -76,6 +77,8 @@ class MemoryClient(BaseAPIClient):
         )
         request_payload = request_data.model_dump(by_alias=True, exclude_none=True)
 
+        start_time = time.time()
+
         try:
             # POST request with JSON body as per API spec
             async with self._get_client() as client:
@@ -90,10 +93,19 @@ class MemoryClient(BaseAPIClient):
                 data = response.json()
                 memory_response = MemoryRetrievalResponse(**data)
 
+                # Record successful API metrics
+                self._record_api_request("POST", start_time, status_code=response.status_code)
+
                 # Return full response with observations, summaries, sessions, and metadata
                 return memory_response
 
         except httpx.HTTPError as e:
+            # Extract status code if available
+            status_code = getattr(e.response, "status_code", None) if hasattr(e, "response") else None
+
+            # Record API metrics for error
+            self._record_api_request("POST", start_time, status_code=status_code, error=e)
+
             response_text = (
                 getattr(e.response, "text", "No response body")
                 if hasattr(e, "response")
@@ -109,6 +121,9 @@ class MemoryClient(BaseAPIClient):
             return MemoryRetrievalResponse()
 
         except Exception as e:
+            # Record metrics for general errors (no status code available)
+            self._record_api_request("POST", start_time, error=e)
+
             self.logger.error(f"Failed to parse Conversation Memory response: {e}")
             # Return empty response on parsing errors
             return MemoryRetrievalResponse()

--- a/src/tac/telemetry/__init__.py
+++ b/src/tac/telemetry/__init__.py
@@ -1,0 +1,14 @@
+"""TAC Telemetry Module
+
+Provides OpenTelemetry-based observability for TAC applications.
+"""
+
+from .config import TACTelemetry
+from .metrics import MetricsClient
+from .tracer import TracerClient
+
+__all__ = [
+    "TACTelemetry",
+    "MetricsClient",
+    "TracerClient",
+]

--- a/src/tac/telemetry/config.py
+++ b/src/tac/telemetry/config.py
@@ -40,12 +40,21 @@ class TACTelemetry:
     Environment Variables:
         OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint URL (default: http://localhost:4318)
         OTEL_EXPORTER_OTLP_HEADERS: Headers for OTLP requests
+        TAC_TELEMETRY_INCLUDE_MESSAGE_CONTENT: Include input/output in traces (default: false)
+            WARNING: Setting this to 'true' will send message content (user input and LLM output)
+            to your observability backend. This may include PII and should only be enabled
+            if you have proper data handling agreements and comply with privacy regulations.
     """
 
     def __init__(self):
         self.resource = get_otel_resource()
         self.meter_provider: metrics_sdk.MeterProvider | None = None
         self.tracer_provider: TracerProvider | None = None
+
+        # Check if message content should be included in traces (default: False for privacy)
+        self.include_message_content = os.getenv(
+            "TAC_TELEMETRY_INCLUDE_MESSAGE_CONTENT", "false"
+        ).lower() in ("true", "1", "yes")
 
     def setup_meter(
         self,
@@ -82,7 +91,9 @@ class TACTelemetry:
         # OTLP exporter (for Prometheus/Grafana)
         if enable_otlp_exporter:
             try:
-                from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+                from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+                    OTLPMetricExporter,
+                )
                 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
                 otlp_reader = PeriodicExportingMetricReader(
@@ -172,3 +183,32 @@ class TACTelemetry:
 
         logger.info("TAC tracing configured successfully")
         return self
+
+    def shutdown(self, timeout_millis: int = 30000) -> None:
+        """Shutdown telemetry and flush all pending data
+
+        This ensures all metrics and traces are exported before the application exits.
+        Should be called on application shutdown or when stopping the server.
+
+        Args:
+            timeout_millis: Maximum time to wait for shutdown (default: 30 seconds)
+        """
+        logger.info("Shutting down TAC telemetry...")
+
+        # Shutdown meter provider
+        if self.meter_provider:
+            try:
+                self.meter_provider.shutdown(timeout_millis=timeout_millis)
+                logger.info("Meter provider shutdown complete")
+            except Exception as e:
+                logger.error(f"Error shutting down meter provider: {e}")
+
+        # Shutdown tracer provider (forces span export)
+        if self.tracer_provider:
+            try:
+                self.tracer_provider.shutdown()
+                logger.info("Tracer provider shutdown complete")
+            except Exception as e:
+                logger.error(f"Error shutting down tracer provider: {e}")
+
+        logger.info("TAC telemetry shutdown complete")

--- a/src/tac/telemetry/config.py
+++ b/src/tac/telemetry/config.py
@@ -1,0 +1,174 @@
+"""OpenTelemetry Configuration for TAC"""
+
+import logging
+import os
+
+import opentelemetry.metrics as metrics_api
+import opentelemetry.sdk.metrics as metrics_sdk
+import opentelemetry.trace as trace_api
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+logger = logging.getLogger(__name__)
+
+
+def get_otel_resource() -> Resource:
+    """Create OpenTelemetry resource with TAC service info"""
+    return Resource.create(
+        {
+            "service.name": "tac",
+            "service.version": "1.0.0",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.language": "python",
+        }
+    )
+
+
+class TACTelemetry:
+    """TAC OpenTelemetry Setup
+
+    Usage:
+        # Metrics only (development)
+        TACTelemetry().setup_meter(enable_console_exporter=True)
+
+        # Metrics + Traces (production)
+        telemetry = TACTelemetry()
+        telemetry.setup_meter(enable_otlp_exporter=True)
+        telemetry.setup_tracer(enable_otlp_exporter=True)
+
+    Environment Variables:
+        OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint URL (default: http://localhost:4318)
+        OTEL_EXPORTER_OTLP_HEADERS: Headers for OTLP requests
+    """
+
+    def __init__(self):
+        self.resource = get_otel_resource()
+        self.meter_provider: metrics_sdk.MeterProvider | None = None
+        self.tracer_provider: TracerProvider | None = None
+
+    def setup_meter(
+        self,
+        enable_console_exporter: bool = False,
+        enable_otlp_exporter: bool = False,
+    ) -> "TACTelemetry":
+        """Setup OpenTelemetry MeterProvider
+
+        Args:
+            enable_console_exporter: Output to console (for debugging)
+            enable_otlp_exporter: Export to OTLP endpoint (for production)
+
+        Returns:
+            self (for method chaining)
+        """
+        logger.info("Setting up TAC telemetry")
+
+        metric_readers = []
+
+        # Console exporter (for debugging)
+        if enable_console_exporter:
+            from opentelemetry.sdk.metrics.export import (
+                ConsoleMetricExporter,
+                PeriodicExportingMetricReader,
+            )
+
+            console_reader = PeriodicExportingMetricReader(
+                ConsoleMetricExporter(),
+                export_interval_millis=10000,
+            )
+            metric_readers.append(console_reader)
+            logger.info("Console metrics exporter enabled")
+
+        # OTLP exporter (for Prometheus/Grafana)
+        if enable_otlp_exporter:
+            try:
+                from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+                from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+                otlp_reader = PeriodicExportingMetricReader(
+                    OTLPMetricExporter(),
+                    export_interval_millis=5000,  # Export every 5 seconds for demo
+                )
+                metric_readers.append(otlp_reader)
+                logger.info("OTLP metrics exporter enabled")
+            except Exception as e:
+                logger.error(f"Failed to setup OTLP exporter: {e}")
+
+        # Create and set global meter provider
+        self.meter_provider = metrics_sdk.MeterProvider(
+            resource=self.resource,
+            metric_readers=metric_readers,
+        )
+        metrics_api.set_meter_provider(self.meter_provider)
+
+        logger.info("TAC telemetry configured successfully")
+        return self
+
+    def setup_tracer(
+        self,
+        enable_console_exporter: bool = False,
+        enable_otlp_exporter: bool = False,
+        sampling_ratio: float = 1.0,
+    ) -> "TACTelemetry":
+        """Setup OpenTelemetry TracerProvider
+
+        Args:
+            enable_console_exporter: Output to console (for debugging)
+            enable_otlp_exporter: Export to OTLP endpoint (for Jaeger/Langfuse)
+            sampling_ratio: Trace sampling ratio (0.0 to 1.0, default 1.0 = 100%)
+
+        Returns:
+            self (for method chaining)
+        """
+        logger.info("Setting up TAC tracing")
+
+        span_processors = []
+
+        # Console exporter (for debugging)
+        if enable_console_exporter:
+            from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+            console_processor = SimpleSpanProcessor(ConsoleSpanExporter())
+            span_processors.append(console_processor)
+            logger.info("Console trace exporter enabled")
+
+        # OTLP exporter (for Jaeger/Langfuse)
+        if enable_otlp_exporter:
+            try:
+                from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+                # Check if Langfuse endpoint
+                endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+                is_langfuse = "langfuse" in endpoint.lower()
+
+                if is_langfuse:
+                    logger.info(f"Detected Langfuse endpoint: {endpoint}")
+                    # Langfuse requires auth headers
+                    headers = os.getenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+                    if headers:
+                        logger.info("Using OTLP headers for authentication")
+
+                otlp_processor = BatchSpanProcessor(OTLPSpanExporter())
+                span_processors.append(otlp_processor)
+                logger.info("OTLP trace exporter enabled")
+            except Exception as e:
+                logger.error(f"Failed to setup OTLP trace exporter: {e}")
+
+        # Create sampler based on sampling ratio
+        from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
+
+        if sampling_ratio < 1.0:
+            # Use parent-based sampling to respect upstream sampling decisions
+            sampler = ParentBased(root=TraceIdRatioBased(sampling_ratio))
+            logger.info(f"Trace sampling enabled: {sampling_ratio * 100:.1f}%")
+        else:
+            sampler = ParentBased(root=TraceIdRatioBased(1.0))
+
+        # Create and set global tracer provider
+        self.tracer_provider = TracerProvider(resource=self.resource, sampler=sampler)
+        for processor in span_processors:
+            self.tracer_provider.add_span_processor(processor)
+        trace_api.set_tracer_provider(self.tracer_provider)
+
+        logger.info("TAC tracing configured successfully")
+        return self

--- a/src/tac/telemetry/metrics.py
+++ b/src/tac/telemetry/metrics.py
@@ -1,0 +1,131 @@
+"""TAC Metrics Client - Singleton for recording metrics"""
+
+import logging
+import threading
+from typing import Optional
+
+import opentelemetry.metrics as metrics_api
+from opentelemetry.metrics import Counter, Histogram, Meter, UpDownCounter
+
+from . import metrics_constants as constants
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsClient:
+    """Singleton metrics client for TAC
+
+    Automatically records metrics to configured exporters.
+    If telemetry is not configured, operations are no-op.
+
+    Usage:
+        metrics = MetricsClient()
+        metrics.message_received_count.add(1, attributes={"channel": "sms"})
+    """
+
+    _instance: Optional["MetricsClient"] = None
+    _lock = threading.Lock()
+
+    # Message processing metrics
+    message_received_count: Counter
+    message_sent_count: Counter
+    message_error_count: Counter
+
+    # Lifecycle latency metrics
+    conversation_start_duration: Histogram
+    conversation_ready_duration: Histogram
+    conversation_end_duration: Histogram
+
+    # API request metrics
+    api_request_count: Counter
+    api_request_duration: Histogram
+    api_error_count: Counter
+
+    # Conversation state metrics
+    conversation_active_count: UpDownCounter
+
+    def __new__(cls) -> "MetricsClient":
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if hasattr(self, "_initialized"):
+            return
+
+        logger.info("Initializing TAC MetricsClient")
+        meter_provider: metrics_api.MeterProvider = metrics_api.get_meter_provider()
+        self.meter: Meter = meter_provider.get_meter("tac.telemetry", version="1.0.0")
+        self._create_instruments()
+        self._initialized = True
+
+    def _create_instruments(self) -> None:
+        """Create all metric instruments"""
+
+        # Message processing metrics
+        self.message_received_count = self.meter.create_counter(
+            name=constants.TAC_MESSAGE_RECEIVED_COUNT,
+            unit="1",
+            description="Total messages received by TAC",
+        )
+
+        self.message_sent_count = self.meter.create_counter(
+            name=constants.TAC_MESSAGE_SENT_COUNT,
+            unit="1",
+            description="Total messages sent by TAC",
+        )
+
+        self.message_error_count = self.meter.create_counter(
+            name=constants.TAC_MESSAGE_ERROR_COUNT,
+            unit="1",
+            description="Total message processing errors",
+        )
+
+        # Lifecycle latency metrics
+        self.conversation_start_duration = self.meter.create_histogram(
+            name=constants.TAC_CONVERSATION_START_DURATION,
+            unit="s",
+            description="Time to start a new conversation (on_conversation_start)",
+        )
+
+        self.conversation_ready_duration = self.meter.create_histogram(
+            name=constants.TAC_CONVERSATION_READY_DURATION,
+            unit="s",
+            description="Time spent in user callback (on_message_ready)",
+        )
+
+        self.conversation_end_duration = self.meter.create_histogram(
+            name=constants.TAC_CONVERSATION_END_DURATION,
+            unit="s",
+            description="Time to clean up ended conversation (on_conversation_end)",
+        )
+
+        # API request metrics
+        self.api_request_count = self.meter.create_counter(
+            name=constants.TAC_API_REQUEST_COUNT,
+            unit="1",
+            description="Total API requests",
+        )
+
+        self.api_request_duration = self.meter.create_histogram(
+            name=constants.TAC_API_REQUEST_DURATION,
+            unit="s",
+            description="API request duration",
+        )
+
+        self.api_error_count = self.meter.create_counter(
+            name=constants.TAC_API_ERROR_COUNT,
+            unit="1",
+            description="Total API errors",
+        )
+
+        # Conversation state metrics
+        self.conversation_active_count = self.meter.create_up_down_counter(
+            name=constants.TAC_CONVERSATION_ACTIVE_COUNT,
+            unit="1",
+            description="Number of active conversations",
+        )
+
+        logger.info("TAC metrics instruments created")

--- a/src/tac/telemetry/metrics_constants.py
+++ b/src/tac/telemetry/metrics_constants.py
@@ -1,0 +1,24 @@
+"""TAC Metrics Constants
+
+Note: The service name "tac" is automatically prepended by Prometheus when scraping
+from OpenTelemetry Collector, so these metric names don't include the "tac_" prefix.
+Final metric names in Prometheus will be: tac_message_received_total, etc.
+"""
+
+# Message Processing Metrics
+TAC_MESSAGE_RECEIVED_COUNT = "message_received_total"
+TAC_MESSAGE_SENT_COUNT = "message_sent_total"
+TAC_MESSAGE_ERROR_COUNT = "message_error_total"
+
+# Lifecycle Latency Metrics
+TAC_CONVERSATION_START_DURATION = "conversation_start_seconds"
+TAC_CONVERSATION_READY_DURATION = "conversation_ready_seconds"
+TAC_CONVERSATION_END_DURATION = "conversation_end_seconds"
+
+# API Request Metrics
+TAC_API_REQUEST_COUNT = "api_request_total"
+TAC_API_REQUEST_DURATION = "api_request_duration_seconds"
+TAC_API_ERROR_COUNT = "api_error_total"
+
+# Conversation State Metrics
+TAC_CONVERSATION_ACTIVE_COUNT = "conversation_active"

--- a/src/tac/telemetry/tracer.py
+++ b/src/tac/telemetry/tracer.py
@@ -1,6 +1,7 @@
 """TAC Tracer - Singleton for creating spans"""
 
 import logging
+import os
 import threading
 from typing import Optional
 
@@ -41,6 +42,18 @@ class TracerClient:
         logger.info("Initializing TAC TracerClient")
         tracer_provider = trace.get_tracer_provider()
         self.tracer: Tracer = tracer_provider.get_tracer("tac.telemetry")
+
+        # Check if message content should be included in traces (default: False for privacy)
+        self.include_message_content = os.getenv(
+            "TAC_TELEMETRY_INCLUDE_MESSAGE_CONTENT", "false"
+        ).lower() in ("true", "1", "yes")
+        if self.include_message_content:
+            logger.warning(
+                "TAC_TELEMETRY_INCLUDE_MESSAGE_CONTENT is enabled - message content "
+                "(input/output) will be sent to your observability backend. "
+                "Ensure this complies with your privacy policy."
+            )
+
         self._initialized = True
 
     def start_span(self, name: str, attributes: dict[str, str] | None = None):

--- a/src/tac/telemetry/tracer.py
+++ b/src/tac/telemetry/tracer.py
@@ -1,0 +1,56 @@
+"""TAC Tracer - Singleton for creating spans"""
+
+import logging
+import threading
+from typing import Optional
+
+from opentelemetry import trace
+from opentelemetry.trace import Tracer
+
+logger = logging.getLogger(__name__)
+
+
+class TracerClient:
+    """Singleton tracer client for TAC
+
+    Automatically creates spans for tracing TAC operations.
+    If tracing is not configured, operations are no-op.
+
+    Usage:
+        from tac.telemetry.tracer import TracerClient
+
+        tracer = TracerClient()
+        with tracer.start_span("conversation.start", attributes={"channel": "sms"}):
+            # ... your code ...
+    """
+
+    _instance: Optional["TracerClient"] = None
+    _lock = threading.Lock()
+
+    def __new__(cls) -> "TracerClient":
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if hasattr(self, "_initialized"):
+            return
+
+        logger.info("Initializing TAC TracerClient")
+        tracer_provider = trace.get_tracer_provider()
+        self.tracer: Tracer = tracer_provider.get_tracer("tac.telemetry")
+        self._initialized = True
+
+    def start_span(self, name: str, attributes: dict[str, str] | None = None):
+        """Start a new span
+
+        Args:
+            name: Span name (e.g., "conversation.start")
+            attributes: Optional span attributes
+
+        Returns:
+            Span context manager
+        """
+        return self.tracer.start_as_current_span(name, attributes=attributes or {})

--- a/uv.lock
+++ b/uv.lock
@@ -249,6 +249,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -882,6 +891,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1146,6 +1167,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/31/4b7157be23e7c8c3581ac5f6547c5c003e232e7044c92398c468ef78a809/langfuse-4.6.1.tar.gz", hash = "sha256:7f256c669e610909c2e93ca3e9e4168dbef344b753b6874f14b0edd673863f17", size = 281379, upload-time = "2026-05-08T14:08:15.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/bf/3a6082f7809bdcc1269e9920c07d7c7f92a53cc265a4a879e59c92b23b36/langfuse-4.6.1-py3-none-any.whl", hash = "sha256:a696ac3089a0c8431bf7f1b47b7f6417da311f418dd04ce9ef62d63608fd8797", size = 481237, upload-time = "2026-05-08T14:08:17.141Z" },
 ]
 
 [[package]]
@@ -1540,6 +1580,36 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/48/bce76d3ea772b609757e9bc844e02ab408a6446609bf74fb562062ba6b71/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9", size = 18366, upload-time = "2026-04-24T13:15:18.917Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation"
 version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
@@ -1566,6 +1636,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/2d/2537d5990fa341198cbc8ae70b2c3637037061b8ab1196af1d924a275f55/opentelemetry_instrumentation_threading-0.62b1.tar.gz", hash = "sha256:4b3c876907657e3b8b977bfe15d248f2c02db56302c51883724e7ac2f8ce26d2", size = 9180, upload-time = "2026-04-24T13:23:06.15Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/37/a80fb13b76f85b4e433ff44b4ba177615823c36c28dca12e94d2c37de681/opentelemetry_instrumentation_threading-0.62b1-py3-none-any.whl", hash = "sha256:4596e79c47de122eb2e85877c1a8bfed1cd6ab06bd2c29d120ebcf8a708a433a", size = 9335, upload-time = "2026-04-24T13:22:19.419Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
 ]
 
 [[package]]
@@ -1748,6 +1830,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -2444,6 +2541,12 @@ server = [
     { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
 ]
+telemetry = [
+    { name = "langfuse" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2469,12 +2572,16 @@ examples = [
 requires-dist = [
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115.0,<1" },
     { name = "httpx", specifier = ">=0.27.0,<1" },
+    { name = "langfuse", marker = "extra == 'telemetry'", specifier = ">=4.6.1" },
+    { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.30.0,<2.0.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'telemetry'", specifier = ">=1.30.0,<2.0.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.30.0,<2.0.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
     { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.20,<1" },
     { name = "twilio", specifier = ">=9.8.3,<10" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.32.0,<1" },
 ]
-provides-extras = ["server"]
+provides-extras = ["server", "telemetry"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2830,88 +2937,71 @@ wheels = [
 
 [[package]]
 name = "wrapt"
-version = "2.1.2"
+version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/d2/387594fb592d027366645f3d7cc9b4d7ca7be93845fbaba6d835a912ef3c/wrapt-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b7a86d99a14f76facb269dc148590c01aaf47584071809a70da30555228158c", size = 60669, upload-time = "2026-03-06T02:52:40.671Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/18/3f373935bc5509e7ac444c8026a56762e50c1183e7061797437ca96c12ce/wrapt-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a819e39017f95bf7aede768f75915635aa8f671f2993c036991b8d3bfe8dbb6f", size = 61603, upload-time = "2026-03-06T02:54:21.032Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/7a/32758ca2853b07a887a4574b74e28843919103194bb47001a304e24af62f/wrapt-2.1.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5681123e60aed0e64c7d44f72bbf8b4ce45f79d81467e2c4c728629f5baf06eb", size = 113632, upload-time = "2026-03-06T02:53:54.121Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/d5/eeaa38f670d462e97d978b3b0d9ce06d5b91e54bebac6fbed867809216e7/wrapt-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8b28e97a44d21836259739ae76284e180b18abbb4dcfdff07a415cf1016c3e", size = 115644, upload-time = "2026-03-06T02:54:53.33Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/09/2a41506cb17affb0bdf9d5e2129c8c19e192b388c4c01d05e1b14db23c00/wrapt-2.1.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cef91c95a50596fcdc31397eb6955476f82ae8a3f5a8eabdc13611b60ee380ba", size = 112016, upload-time = "2026-03-06T02:54:43.274Z" },
-    { url = "https://files.pythonhosted.org/packages/64/15/0e6c3f5e87caadc43db279724ee36979246d5194fa32fed489c73643ba59/wrapt-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dad63212b168de8569b1c512f4eac4b57f2c6934b30df32d6ee9534a79f1493f", size = 114823, upload-time = "2026-03-06T02:54:29.392Z" },
-    { url = "https://files.pythonhosted.org/packages/56/b2/0ad17c8248f4e57bedf44938c26ec3ee194715f812d2dbbd9d7ff4be6c06/wrapt-2.1.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d307aa6888d5efab2c1cde09843d48c843990be13069003184b67d426d145394", size = 111244, upload-time = "2026-03-06T02:54:02.149Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/04/bcdba98c26f2c6522c7c09a726d5d9229120163493620205b2f76bd13c01/wrapt-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c87cf3f0c85e27b3ac7d9ad95da166bf8739ca215a8b171e8404a2d739897a45", size = 113307, upload-time = "2026-03-06T02:54:12.428Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/1b/5e2883c6bc14143924e465a6fc5a92d09eeabe35310842a481fb0581f832/wrapt-2.1.2-cp310-cp310-win32.whl", hash = "sha256:d1c5fea4f9fe3762e2b905fdd67df51e4be7a73b7674957af2d2ade71a5c075d", size = 57986, upload-time = "2026-03-06T02:54:26.823Z" },
-    { url = "https://files.pythonhosted.org/packages/42/5a/4efc997bccadd3af5749c250b49412793bc41e13a83a486b2b54a33e240c/wrapt-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:d8f7740e1af13dff2684e4d56fe604a7e04d6c94e737a60568d8d4238b9a0c71", size = 60336, upload-time = "2026-03-06T02:54:18Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/f5/a2bb833e20181b937e87c242645ed5d5aa9c373006b0467bfe1a35c727d0/wrapt-2.1.2-cp310-cp310-win_arm64.whl", hash = "sha256:1c6cc827c00dc839350155f316f1f8b4b0c370f52b6a19e782e2bda89600c7dc", size = 58757, upload-time = "2026-03-06T02:53:51.545Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
-    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
-    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
-    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
-    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
-    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
-    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
-    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
-    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
-    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
-    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
-    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
-    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
-    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
-    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
-    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
-    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
-    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
-    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
-    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
-    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
-    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04", size = 53482, upload-time = "2025-08-12T05:51:44.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/69/f3c47642b79485a30a59c63f6d739ed779fb4cc8323205d047d741d55220/wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2", size = 38676, upload-time = "2025-08-12T05:51:32.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/71/e7e7f5670c1eafd9e990438e69d8fb46fa91a50785332e06b560c869454f/wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c", size = 38957, upload-time = "2025-08-12T05:51:54.655Z" },
+    { url = "https://files.pythonhosted.org/packages/de/17/9f8f86755c191d6779d7ddead1a53c7a8aa18bccb7cea8e7e72dfa6a8a09/wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775", size = 81975, upload-time = "2025-08-12T05:52:30.109Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/15/dd576273491f9f43dd09fce517f6c2ce6eb4fe21681726068db0d0467096/wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd", size = 83149, upload-time = "2025-08-12T05:52:09.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c4/5eb4ce0d4814521fee7aa806264bf7a114e748ad05110441cd5b8a5c744b/wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05", size = 82209, upload-time = "2025-08-12T05:52:10.331Z" },
+    { url = "https://files.pythonhosted.org/packages/31/4b/819e9e0eb5c8dc86f60dfc42aa4e2c0d6c3db8732bce93cc752e604bb5f5/wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418", size = 81551, upload-time = "2025-08-12T05:52:31.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/83/ed6baf89ba3a56694700139698cf703aac9f0f9eb03dab92f57551bd5385/wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390", size = 36464, upload-time = "2025-08-12T05:53:01.204Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/ee61d36862340ad7e9d15a02529df6b948676b9a5829fd5e16640156627d/wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6", size = 38748, upload-time = "2025-08-12T05:53:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c3/cefe0bd330d389c9983ced15d326f45373f4073c9f4a8c2f99b50bfea329/wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18", size = 36810, upload-time = "2025-08-12T05:52:51.906Z" },
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Add OpenTelemetry observability with metrics and traces

This PR adds comprehensive OpenTelemetry integration to TAC, enabling production-grade observability with metrics (Grafana) and traces (Langfuse/Jaeger).

## Summary

OpenTelemetry provides standardized observability for TAC applications with:
- **Metrics** → Prometheus → Grafana (monitoring & alerting)
- **Traces** → Langfuse/Jaeger (debugging & request flow)

## What's Changed

### Telemetry Module (`src/tac/telemetry/`)
- `TACTelemetry`: Setup class for configuring meters and tracers with shutdown support
- `MetricsClient`: Thread-safe singleton for recording metrics
- `TracerClient`: Thread-safe singleton for creating spans with privacy controls
- Support for OTLP exporters (production) and console exporters (dev)
- Configurable trace sampling for production environments

### Metrics

**Message Processing:**
- `message_received_total` - Total messages received by channel
- `message_sent_total` - Total messages sent by channel
- `message_error_total` - Message processing errors with error type

**Lifecycle Latency:**
- `conversation_start_seconds` - Time to start conversation
- `conversation_ready_seconds` - User callback duration (critical path)
- `conversation_end_seconds` - Time to end conversation

**API Requests:**
- `api_request_total` - Total API requests by client type
- `api_request_duration_seconds` - API request latency
- `api_error_total` - API errors with categorized error types

**Conversation State:**
- `conversation_active` - Number of active conversations (UpDownCounter)

All metrics include labels: `channel` (sms/voice/whatsapp/rcs/chat), `client_type` (conversation/memory/knowledge), `error_type` (http_4xx/http_5xx/timeout/etc)

### Traces

**Message-level traces** (independent traces per message):
```
message.processing (root span)
├── memory.retrieve
├── conversation.ready  ← User callback
└── message.send
```

**Trace attributes:**
- `channel` - Communication channel
- `conversation_id` - Conversation identifier
- `enduser.id` - Profile ID (for user filtering in Langfuse)
- `input` - User message (opt-in only, see privacy section)
- `output` - LLM response (opt-in only, see privacy section)

### Privacy Controls

**TAC_TELEMETRY_INCLUDE_MESSAGE_CONTENT** (default: `false`)
- When `false`: Only metadata (conversation_id, channel, timings) is sent
- When `true`: Input (user message) and output (LLM response) are included in traces

⚠️ **Privacy by Design**: Message content is **disabled by default** to prevent accidental PII leakage. Only enable if:
- You have proper data handling agreements with your observability provider
- You comply with GDPR, CCPA, HIPAA, and other privacy regulations
- You understand that user messages may contain sensitive information

When enabled, a warning is logged to remind developers of the privacy implications.

### Code Changes

**Channels:**
- Added message-level tracing to messaging and voice channels
- Records metrics at each stage (received, sent, errors, latencies)
- Conditionally includes input/output based on privacy setting

**Base API Client:**
- Added `_record_api_request()` method with status code tracking
- Added `_categorize_error()` to limit metric cardinality
- Groups errors: `http_4xx`, `http_5xx`, `timeout`, `connection`, `validation`, `other`

### Observability Demo

Complete working example at `getting_started/examples/observability-demo/`:
- **Application**: `openai_with_observability.py` - Full TAC app with observability
- **Infrastructure**: `docker-compose.yml` - Prometheus, Grafana, Langfuse, OTel Collector
- **Dashboards**: Pre-configured Grafana dashboard with P95 latencies, message volume, errors
- **Test Data**: `generate_test_data.py` - Synthetic data generator for testing
- **Documentation**: `README.md` - Setup and usage guide

Services:
- Grafana (port 3000) - Metrics visualization
- Langfuse (port 3001) - Trace visualization with Input/Output/User fields
- Prometheus (port 9090) - Metrics storage
- OTel Collector (port 4318) - OTLP receiver

### Dependencies

**Core (included by default):**
- `opentelemetry-api>=1.20.0`
- `opentelemetry-sdk>=1.20.0`

**Optional (`pip install tac[telemetry]`):**
- `opentelemetry-exporter-otlp-proto-http>=1.20.0`

The core SDK is lightweight (~2MB) and no-op when not configured. Exporters are optional to minimize bundle size.

## Usage

```python
from tac import TAC, TACConfig
from tac.telemetry import TACTelemetry
import os

# Configure OTLP endpoint
os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"

# Setup telemetry BEFORE creating TAC
telemetry = TACTelemetry()
telemetry.setup_meter(enable_otlp_exporter=True)   # Metrics
telemetry.setup_tracer(enable_otlp_exporter=True)  # Traces

# TAC automatically records metrics and traces
tac = TAC(config=TACConfig.from_env())

# Graceful shutdown to flush telemetry
import atexit
atexit.register(lambda: telemetry.shutdown())
```

**Enable message content (use with caution):**
```bash
export TAC_TELEMETRY_INCLUDE_MESSAGE_CONTENT=true
```

## Key Features

✅ **Industry standard** - Uses OpenTelemetry (CNCF standard)  
✅ **Vendor-neutral** - Works with Grafana, Datadog, New Relic, etc.  
✅ **Production-ready** - Thread-safe, sampling, error categorization  
✅ **Zero overhead** - No-op when not configured  
✅ **Consistent** - Same observability across SMS, Voice, WhatsApp, RCS, Chat  
✅ **Privacy-safe** - Message content disabled by default  
✅ **Complete** - Metrics + Traces with user tracking  
✅ **Optional** - Core SDK included, exporters are opt-in extras  

## Testing

Run the observability demo:
```bash
cd getting_started/examples/observability-demo
docker compose up -d
python generate_test_data.py

# View results:
# Grafana: http://localhost:3000
# Langfuse: http://localhost:3001
```

## Commits

1. **feat: Add OpenTelemetry observability with metrics and traces** - Initial implementation with complete metrics and trace structure
2. **feat(telemetry): add message-level tracing with input/output and privacy controls** - Added input/output to traces with privacy controls, user tracking, and graceful shutdown
