### PR TITLE
fix(voice): populate ai_agent_info for voice

### DIFF
--- a/src/tac/channels/base.py
+++ b/src/tac/channels/base.py
@@ -8,9 +8,17 @@ from typing import Any
 
 from tac import TAC
 from tac.core.logging import get_logger
+from tac.models.conversation import ParticipantResponse
 from tac.models.memory import MemoryMode
 from tac.models.session import ConversationSession
 from tac.models.tac import TACMemoryResponse
+
+# Participant types that represent TAC itself at TAC's (channel, address).
+# `AI_AGENT` is the canonical type; `AGENT` is the legacy Conversation
+# Orchestrator form. A participant typed either way at TAC's address is
+# recognized as TAC and not overwritten; anything else (HUMAN_AGENT,
+# CUSTOMER, …) is someone else's assignment.
+AGENT_TYPES: frozenset[str] = frozenset({"AGENT", "AI_AGENT"})
 
 
 class BaseChannel(ABC):
@@ -164,6 +172,53 @@ class BaseChannel(ABC):
                 return False
 
         return True
+
+    @staticmethod
+    def _owns_address(
+        participant: ParticipantResponse,
+        channel: str,
+        address: str,
+        extra: dict[str, str | None] | None = None,
+    ) -> bool:
+        """Whether a participant holds the given (channel, address).
+
+        This is the address-only predicate — it does NOT consider participant
+        type. Use it directly when the type is decided separately (e.g.
+        reconciliation, which must detect an UNKNOWN at TAC's address before
+        promoting it); use `_find_agent_participant` when you want the agent.
+
+        `extra` matches additional ParticipantAddress fields (e.g. messaging
+        sub-addressing); only truthy values are compared.
+        """
+        return any(
+            a.channel == channel
+            and a.address == address
+            and (not extra or all(getattr(a, k) == v for k, v in extra.items() if v))
+            for a in participant.addresses
+        )
+
+    @classmethod
+    def _find_agent_participant(
+        cls,
+        participants: list[ParticipantResponse],
+        channel: str,
+        address: str,
+        extra: dict[str, str | None] | None = None,
+    ) -> ParticipantResponse | None:
+        """Find the participant representing TAC's agent in a conversation.
+
+        The agent is the participant that owns TAC's (channel, address) AND has
+        an agent type (`AGENT` or `AI_AGENT`). A HUMAN_AGENT or other type at
+        that address is someone else and is NOT returned.
+        """
+        return next(
+            (
+                p
+                for p in participants
+                if p.type in AGENT_TYPES and cls._owns_address(p, channel, address, extra)
+            ),
+            None,
+        )
 
     def _start_conversation(
         self,

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -8,7 +8,7 @@ import httpx
 from pydantic import BaseModel, Field
 
 from tac import TAC
-from tac.channels.base import BaseChannel
+from tac.channels.base import AGENT_TYPES, BaseChannel
 from tac.context.conversation import ConversationClient
 from tac.models.conversation import (
     ActionChannelSettings,
@@ -27,12 +27,8 @@ from tac.models.outbound import InitiateConversationResult, InitiateMessagingCon
 from tac.models.session import AuthorInfo
 from tac.utils.redaction import mask_address
 
-# Participant types that represent TAC itself at TAC's (channel, address).
-# `AI_AGENT` is the canonical type; `AGENT` is the legacy Conversation
-# Orchestrator form. A participant typed either way at TAC's address is
-# recognized as TAC and not overwritten; anything else (HUMAN_AGENT,
-# CUSTOMER, …) is someone else's assignment.
-AGENT_TYPES: frozenset[str] = frozenset({"AGENT", "AI_AGENT"})
+# AGENT_TYPES now lives on BaseChannel (channel-agnostic); it is imported above
+# so existing `from tac.channels.messaging import AGENT_TYPES` keeps working.
 
 
 class MessagingChannelConfig(BaseModel):
@@ -379,38 +375,20 @@ class MessagingChannel(BaseChannel):
                 conversation_id
             )
 
-            def _match_address(
-                p_addresses: list[ParticipantAddress],
-                addr: str,
-                extra_kwargs: dict[str, str | None],
-            ) -> bool:
-                return any(
-                    a.channel == channel_type
-                    and a.address == addr
-                    and all(getattr(a, k) == v for k, v in extra_kwargs.items() if v)
-                    for a in p_addresses
-                )
-
             customer = next(
                 (
                     p
                     for p in participants
                     if p.type == "CUSTOMER"
-                    and _match_address(p.addresses, options.to, customer_address_kwargs)
+                    and self._owns_address(p, channel_type, options.to, customer_address_kwargs)
                 ),
                 None,
             )
             if not customer:
                 raise RuntimeError("Customer participant not found after conversation creation")
 
-            agent = next(
-                (
-                    p
-                    for p in participants
-                    if p.type in AGENT_TYPES
-                    and _match_address(p.addresses, from_address, agent_address_kwargs)
-                ),
-                None,
+            agent = self._find_agent_participant(
+                participants, channel_type, from_address, agent_address_kwargs
             )
             if not agent:
                 raise RuntimeError("Agent participant not found after conversation creation")
@@ -517,9 +495,7 @@ class MessagingChannel(BaseChannel):
         channel = agent_address.channel
 
         def _owns_agent_address(p: ParticipantResponse) -> bool:
-            return any(
-                a.channel == channel and a.address == agent_address.address for a in p.addresses
-            )
+            return self._owns_address(p, channel, agent_address.address)
 
         def _matches_channel(p: ParticipantResponse) -> bool:
             return any(a.channel == channel for a in p.addresses)

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -27,9 +27,6 @@ from tac.models.outbound import InitiateConversationResult, InitiateMessagingCon
 from tac.models.session import AuthorInfo
 from tac.utils.redaction import mask_address
 
-# AGENT_TYPES now lives on BaseChannel (channel-agnostic); it is imported above
-# so existing `from tac.channels.messaging import AGENT_TYPES` keeps working.
-
 
 class MessagingChannelConfig(BaseModel):
     """Base configuration for messaging channels (SMS, RCS, WhatsApp, Chat).

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -270,8 +270,11 @@ class VoiceChannel(BaseChannel):
             session.author_info = AuthorInfo(address=profile_lookup_address)
 
         if agent_participant:
+            # Fall back to the configured phone number we matched on — the
+            # participant owns it by definition, so it's a meaningful address
+            # even in the unlikely case it carries no explicit VOICE address.
             session.ai_agent_info = AuthorInfo(
-                address=agent_address or "",
+                address=agent_address or self.tac.config.phone_number,
                 participant_id=agent_participant.id,
             )
 

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -242,6 +242,23 @@ class VoiceChannel(BaseChannel):
         profile_lookup_address = customer_address or self._caller_address(setup_msg)
         profile_id = customer_participant.profile_id if customer_participant else None
 
+        # Resolve the AI agent participant so ai_agent_info is populated on the
+        # session, matching the messaging channels. Match AI_AGENT strictly — a
+        # redirected/escalated call may add a human AGENT participant we must not
+        # treat as the AI agent.
+        agent_participant = next(
+            (p for p in participants if p.type == "AI_AGENT"),
+            None,
+        )
+        agent_address = (
+            next(
+                (a.address for a in agent_participant.addresses if a.channel == "VOICE"),
+                None,
+            )
+            if agent_participant and agent_participant.addresses
+            else None
+        )
+
         self._websocket_manager.add_websocket(conv_id, websocket)
         session = self._start_conversation(conv_id, profile_id)
 
@@ -251,6 +268,12 @@ class VoiceChannel(BaseChannel):
 
         if profile_lookup_address:
             session.author_info = AuthorInfo(address=profile_lookup_address)
+
+        if agent_participant:
+            session.ai_agent_info = AuthorInfo(
+                address=agent_address or "",
+                participant_id=agent_participant.id,
+            )
 
         return conv_id, session_state
 

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 from pydantic import ValidationError
 
 from tac.channels.base import BaseChannel
-from tac.channels.messaging import AGENT_TYPES
 from tac.channels.websocket_manager import WebSocketManager
 from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
 from tac.core.tac import TAC
@@ -244,23 +243,12 @@ class VoiceChannel(BaseChannel):
         profile_id = customer_participant.profile_id if customer_participant else None
 
         # Resolve the agent participant so ai_agent_info is populated on the
-        # session, matching how the messaging channels reconcile it: identify
-        # the agent by the participant that owns TAC's address on this channel,
-        # then accept it only if its type is an agent type (AGENT or AI_AGENT).
-        # A HUMAN_AGENT added by a redirected/escalated call is NOT TAC and must
-        # not be treated as the AI agent. Voice's agent address is the
-        # configured phone number (Conversation Orchestrator carries it as the
-        # agent participant's VOICE address).
-        agent_phone_number = self.tac.config.phone_number
-
-        def _owns_agent_address(p: Any) -> bool:
-            return any(
-                a.channel == "VOICE" and a.address == agent_phone_number for a in p.addresses
-            )
-
-        agent_participant = next(
-            (p for p in participants if p.type in AGENT_TYPES and _owns_agent_address(p)),
-            None,
+        # session, matching the messaging channels. The agent is the participant
+        # that owns TAC's address (the configured phone number) on the VOICE
+        # channel and has an agent type. A HUMAN_AGENT added by a
+        # redirected/escalated call is NOT TAC and is not adopted here.
+        agent_participant = self._find_agent_participant(
+            participants, "VOICE", self.tac.config.phone_number
         )
         agent_address = (
             next(

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 from pydantic import ValidationError
 
 from tac.channels.base import BaseChannel
+from tac.channels.messaging import AGENT_TYPES
 from tac.channels.websocket_manager import WebSocketManager
 from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
 from tac.core.tac import TAC
@@ -242,12 +243,23 @@ class VoiceChannel(BaseChannel):
         profile_lookup_address = customer_address or self._caller_address(setup_msg)
         profile_id = customer_participant.profile_id if customer_participant else None
 
-        # Resolve the AI agent participant so ai_agent_info is populated on the
-        # session, matching the messaging channels. Match AI_AGENT strictly — a
-        # redirected/escalated call may add a human AGENT participant we must not
-        # treat as the AI agent.
+        # Resolve the agent participant so ai_agent_info is populated on the
+        # session, matching how the messaging channels reconcile it: identify
+        # the agent by the participant that owns TAC's address on this channel,
+        # then accept it only if its type is an agent type (AGENT or AI_AGENT).
+        # A HUMAN_AGENT added by a redirected/escalated call is NOT TAC and must
+        # not be treated as the AI agent. Voice's agent address is the
+        # configured phone number (Conversation Orchestrator carries it as the
+        # agent participant's VOICE address).
+        agent_phone_number = self.tac.config.phone_number
+
+        def _owns_agent_address(p: Any) -> bool:
+            return any(
+                a.channel == "VOICE" and a.address == agent_phone_number for a in p.addresses
+            )
+
         agent_participant = next(
-            (p for p in participants if p.type == "AI_AGENT"),
+            (p for p in participants if p.type in AGENT_TYPES and _owns_agent_address(p)),
             None,
         )
         agent_address = (

--- a/src/tac/models/session.py
+++ b/src/tac/models/session.py
@@ -46,7 +46,11 @@ class ConversationSession(BaseModel):
         None, description="Author information from communication event (optional)"
     )
     ai_agent_info: AuthorInfo | None = Field(
-        None, description="AI agent information from communication event (optional)"
+        None,
+        description="AI agent information from communication event (optional). "
+        "Populated on messaging channels and on Orchestrator-backed voice calls. "
+        "Remains None in ConversationRelay-only voice mode, where there is no "
+        "Orchestrator participant to resolve.",
     )
     metadata: dict = Field(
         default_factory=dict, description="Generic metadata storage for session-specific data"

--- a/src/tac/models/session.py
+++ b/src/tac/models/session.py
@@ -48,9 +48,9 @@ class ConversationSession(BaseModel):
     ai_agent_info: AuthorInfo | None = Field(
         None,
         description="AI agent information from communication event (optional). "
-        "Populated on messaging channels and on Orchestrator-backed voice calls. "
-        "Remains None in ConversationRelay-only voice mode, where there is no "
-        "Orchestrator participant to resolve.",
+        "Populated on messaging channels and on Conversation Orchestrator-backed "
+        "voice calls. Remains None in ConversationRelay-only voice mode, where "
+        "there is no Conversation Orchestrator participant to resolve.",
     )
     metadata: dict = Field(
         default_factory=dict, description="Generic metadata storage for session-specific data"

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -123,8 +123,9 @@ class TestVoiceChannel:
 
     @pytest.mark.asyncio
     async def test_initialize_conversation_populates_ai_agent_info(self) -> None:
-        """_initialize_conversation resolves the AI_AGENT participant and sets
-        ai_agent_info, matching the messaging channels."""
+        """_initialize_conversation resolves the agent participant by its address
+        (TAC's phone number) and accepts the AGENT type voice uses, setting
+        ai_agent_info — matching the messaging channels' address-based match."""
         from tac.models.conversation import (
             ConversationResponse,
             ParticipantAddress,
@@ -144,12 +145,14 @@ class TestVoiceChannel:
             profileId="profile_xyz",
             addresses=[ParticipantAddress(channel="VOICE", address="+15559998888")],
         )
+        # Voice's agent participant is typed AGENT (not AI_AGENT) and sits at
+        # TAC's configured phone number.
         agent = ParticipantResponse(
             id="part_agent",
             conversationId="conv_abc",
             accountId="ACtest123",
-            name="AI Agent",
-            type="AI_AGENT",
+            name="Agent",
+            type="AGENT",
             addresses=[ParticipantAddress(channel="VOICE", address="+15551234567")],
         )
 
@@ -173,8 +176,9 @@ class TestVoiceChannel:
 
     @pytest.mark.asyncio
     async def test_initialize_conversation_skips_human_agent_for_ai_agent_info(self) -> None:
-        """A redirected/escalated call's HUMAN_AGENT participant must not be
-        treated as the AI agent; ai_agent_info stays None when no AI_AGENT."""
+        """A redirected/escalated call's HUMAN_AGENT participant at TAC's address
+        must not be treated as the AI agent — its type is not an agent type, so
+        ai_agent_info stays None."""
         from tac.models.conversation import (
             ConversationResponse,
             ParticipantAddress,
@@ -193,6 +197,8 @@ class TestVoiceChannel:
             type="CUSTOMER",
             addresses=[ParticipantAddress(channel="VOICE", address="+15559998888")],
         )
+        # Human agent sits at TAC's address but is a real person — must not be
+        # adopted as the AI agent.
         human_agent = ParticipantResponse(
             id="part_human",
             conversationId="conv_def",

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -16,6 +16,7 @@ from tac.models.voice import (
     CustomParameters,
     InterruptMessage,
     PromptMessage,
+    SetupMessage,
     TwiMLOptions,
 )
 
@@ -119,6 +120,99 @@ class TestVoiceChannel:
 
         # Verify memory retrieval was called
         tac.conversation_memory_client.retrieve_memory.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_initialize_conversation_populates_ai_agent_info(self) -> None:
+        """_initialize_conversation resolves the AI_AGENT participant and sets
+        ai_agent_info, matching the messaging channels."""
+        from tac.models.conversation import (
+            ConversationResponse,
+            ParticipantAddress,
+            ParticipantResponse,
+        )
+
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+
+        conversation = ConversationResponse(id="conv_abc", accountId="ACtest123", status="ACTIVE")
+        customer = ParticipantResponse(
+            id="part_customer",
+            conversationId="conv_abc",
+            accountId="ACtest123",
+            name="Customer",
+            type="CUSTOMER",
+            profileId="profile_xyz",
+            addresses=[ParticipantAddress(channel="VOICE", address="+15559998888")],
+        )
+        agent = ParticipantResponse(
+            id="part_agent",
+            conversationId="conv_abc",
+            accountId="ACtest123",
+            name="AI Agent",
+            type="AI_AGENT",
+            addresses=[ParticipantAddress(channel="VOICE", address="+15551234567")],
+        )
+
+        co_client = MagicMock()
+        co_client.list_conversations = AsyncMock(return_value=[conversation])
+        co_client.list_participants = AsyncMock(return_value=[customer, agent])
+        tac.conversation_orchestrator_client = co_client
+
+        setup_msg = SetupMessage(type="setup", callSid="CALL123", **{"from": "+15559998888"})
+
+        conv_id, _ = await channel._initialize_conversation("CALL123", setup_msg, MagicMock())
+
+        assert conv_id == "conv_abc"
+        session = channel._conversations["conv_abc"]
+        assert session.ai_agent_info is not None
+        assert session.ai_agent_info.participant_id == "part_agent"
+        assert session.ai_agent_info.address == "+15551234567"
+        # Customer side still resolved as before.
+        assert session.author_info is not None
+        assert session.author_info.address == "+15559998888"
+
+    @pytest.mark.asyncio
+    async def test_initialize_conversation_skips_human_agent_for_ai_agent_info(self) -> None:
+        """A redirected/escalated call's HUMAN_AGENT participant must not be
+        treated as the AI agent; ai_agent_info stays None when no AI_AGENT."""
+        from tac.models.conversation import (
+            ConversationResponse,
+            ParticipantAddress,
+            ParticipantResponse,
+        )
+
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+
+        conversation = ConversationResponse(id="conv_def", accountId="ACtest123", status="ACTIVE")
+        customer = ParticipantResponse(
+            id="part_customer",
+            conversationId="conv_def",
+            accountId="ACtest123",
+            name="Customer",
+            type="CUSTOMER",
+            addresses=[ParticipantAddress(channel="VOICE", address="+15559998888")],
+        )
+        human_agent = ParticipantResponse(
+            id="part_human",
+            conversationId="conv_def",
+            accountId="ACtest123",
+            name="Human Agent",
+            type="HUMAN_AGENT",
+            addresses=[ParticipantAddress(channel="VOICE", address="+15551234567")],
+        )
+
+        co_client = MagicMock()
+        co_client.list_conversations = AsyncMock(return_value=[conversation])
+        co_client.list_participants = AsyncMock(return_value=[customer, human_agent])
+        tac.conversation_orchestrator_client = co_client
+
+        setup_msg = SetupMessage(type="setup", callSid="CALL456", **{"from": "+15559998888"})
+
+        conv_id, _ = await channel._initialize_conversation("CALL456", setup_msg, MagicMock())
+
+        session = channel._conversations[conv_id]
+        assert session.ai_agent_info is None
 
     @pytest.mark.asyncio
     async def test_handle_interrupt_message(self) -> None:


### PR DESCRIPTION
## Summary

All channels except voice populate `ConversationSession.ai_agent_info`. The messaging channels set it (via participant reconciliation on inbound, directly on outbound) and depend on it for participant-based send routing. The voice channel only ever set `author_info` (the customer side), so `ai_agent_info` came up **blank on incoming/redirected calls** — a cross-channel session-contract gap. A developer writing a shared `on_message_ready` callback reasonably expects `session.ai_agent_info` to be populated, but on voice it was silently `None`.

Voice never crashed because it replies over the ConversationRelay WebSocket rather than through Conversation Orchestrator participants, so it never hit the messaging `send_response` guards — the field was simply dead.

### How the agent participant is resolved

Matching mirrors the messaging channels' reconciliation discriminator: the agent is the participant that **owns TAC's address** (the configured phone number) on the `VOICE` channel **and** has an agent type — `AGENT` or `AI_AGENT` (`AGENT` is the form Conversation Orchestrator uses on voice; `AI_AGENT` is the canonical type). A `HUMAN_AGENT` added by a redirected/escalated call sits at TAC's address but is a real person, so it is **not** adopted as the AI agent.

### Changes

- **`channels/base.py`** — Lift the shared participant-matching surface into `BaseChannel` so voice and messaging stop re-implementing it (and voice stops importing from messaging):
  - `AGENT_TYPES` constant (`{"AGENT", "AI_AGENT"}`), relocated here as a channel-agnostic concept.
  - `_owns_address(p, channel, address, extra)` — the address-only predicate.
  - `_find_agent_participant(participants, channel, address, extra)` — composes the predicate with the `AGENT_TYPES` check.
- **`channels/voice/channel.py`** — Resolve the agent participant in `_initialize_conversation` via `_find_agent_participant` and set `session.ai_agent_info`. Falls back to the matched phone number if the participant carries no explicit VOICE address (since `AuthorInfo.address` is required).
- **`channels/messaging.py`** — Use the shared base helpers; drop the local `_match_address`.
- **`models/session.py`** — Document the `ai_agent_info` contract.
- **`tests/test_voice_channel.py`** — `ai_agent_info` is populated from an `AGENT`-typed participant at TAC's address; a `HUMAN_AGENT` at the same address is **not** adopted (stays `None`).

### Known limitation

ConversationRelay-only voice mode (`conversation_configuration_id` omitted) still leaves `ai_agent_info` as `None` — there is no Conversation Orchestrator participant to resolve, so it's structurally unavailable. This is now documented on the field rather than silent, and is harmless in that mode since sends don't go through participants.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **Python SDK**. The TypeScript SDK voice channel likely has the same gap and should be checked for parity.

- [ ] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
