### PR TITLE
feat(voice): memory injection, auto-close on call end, CI webhook, docs

### DIFF
--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -126,11 +126,65 @@ See `examples/.env.example` for all available configuration options. Key variabl
 ### Optional (OpenAI Example)
 - `OPENAI_API_KEY`: Your OpenAI API key (only needed to run OpenAI examples)
 
+### Optional (Conversation Intelligence)
+- `CONVERSATION_INTELLIGENCE_CONFIGURATION_ID`: CI Configuration ID — enables the `/ci-webhook` route on the TAC server to receive operator results
+- `CONVERSATION_INTELLIGENCE_OBSERVATION_OPERATOR_SID`: Operator SID for a custom observation extraction operator
+- `CONVERSATION_INTELLIGENCE_SUMMARY_OPERATOR_SID`: Operator SID for a custom summary operator
+
 ### Optional (Channel-Specific)
 - `TWILIO_STUDIO_HANDOFF_FLOW_SID`: Studio Flow SID used by `create_studio_handoff_tool` (required for `features/handoff.py`)
 - `TWILIO_RCS_SENDER_ID`: RCS Sender ID (required for `features/rcs.py`)
 - `TWILIO_WHATSAPP_NUMBER`: WhatsApp-enabled phone number in format `whatsapp:+1234567890` (required for `features/whatsapp.py`)
 - `TWILIO_CONVERSATIONS_SERVICE_SID`: Conversations Service SID (required for Chat channel examples)
+
+## Conversation Intelligence and Memory
+
+### How memory gets written (the standard path)
+
+TAC does **not** write observations or summaries into Conversation Memory directly. Instead, Memora (Twilio's memory service) creates an internal Conversation Intelligence configuration automatically when you set up a Conversation Configuration. After a call ends and the session goes INACTIVE (typically ~5 minutes), Memora's ingest pipeline fires, processes the transcript, and writes observations and summaries into the Memory Store. These are then available via Recall on the next call.
+
+This means there is typically a **5–10 minute delay** between a call ending and the memories being available.
+
+### Custom Conversation Intelligence operators
+
+You can create your own CI operators (e.g. "extract product preferences", "detect customer sentiment") with custom prompts via the Twilio Console. However, **results from custom operators do not automatically flow into Memora's ingest pipeline** — only Memora's own internal operators do.
+
+TAC provides an alternate path for custom operators: if you set `CONVERSATION_INTELLIGENCE_CONFIGURATION_ID` in your `.env`, the TAC server exposes a `/ci-webhook` route. Twilio will POST custom operator results to this endpoint, and TAC will actively write them into Conversation Memory via `create_observation()`. This enables near real-time observation ingestion for custom operators, bypassing the standard delay.
+
+To enable this in your voice example:
+
+```python
+if __name__ == "__main__":
+    from tac.server.config import TACServerConfig
+
+    server_config = TACServerConfig.from_env()
+    if os.environ.get("CONVERSATION_INTELLIGENCE_CONFIGURATION_ID"):
+        server_config.cintel_webhook_path = "/ci-webhook"
+
+    server = TACFastAPIServer(tac=tac, voice_channel=voice_channel, config=server_config)
+    server.start()
+```
+
+Then configure the webhook URL in the Twilio Console under your CI configuration to point to `https://<your-domain>/ci-webhook`.
+
+> **Note:** This is an alternate path intended for custom operator use cases. For standard memory (observations and summaries from calls), Memora's ingest pipeline handles everything automatically — you do not need to configure CI webhooks.
+
+### Reducing memory availability latency
+
+By default, the Twilio Console sets the VOICE inactive timeout to a minimum of 5 minutes — but this is a UI constraint only. The underlying API allows values as low as 1 minute:
+
+```bash
+curl -X PUT "https://conversations.twilio.com/v2/ControlPlane/Configurations/<your-config-id>" \
+  -u "<api-key>:<api-secret>" \
+  -H "Content-Type: application/json" \
+  -d '{"channelSettings": {"VOICE": {"statusTimeouts": {"inactive": 1, "closed": 5}}}}'
+```
+
+See the [Conversation Configuration API](http://twilio.com/docs/api/conversations/v2/configuration/update-configuration) for full details.
+
+Even better: TAC automatically closes the conversation via the CO API as soon as the call ends (WebSocket disconnect), bypassing the inactive timer entirely and triggering Memora extraction immediately. This is the fastest path to getting memories available for the next call.
+
+For background on how conversation state transitions (ACTIVE → INACTIVE → CLOSED) trigger memory extraction, see the [Conversation Lifecycle docs](https://www.twilio.com/docs/conversations/orchestrator/concepts/lifecycle). Key insight: observations are extracted on both INACTIVE and CLOSED, but summaries are only extracted on CLOSED — so closing immediately on call end is important for summaries.
 
 ## Next Steps
 

--- a/getting_started/examples/features/voice_streaming.py
+++ b/getting_started/examples/features/voice_streaming.py
@@ -9,6 +9,7 @@ Performance comparison (streaming vs non-streaming):
 - Result: ~40-50% faster time-to-first-audio with streaming
 """
 
+import os
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -16,6 +17,7 @@ from agents import Agent, Runner, set_tracing_disabled
 from dotenv import load_dotenv
 
 from tac import TAC, TACConfig
+from tac.adapters.prompt_builder import MemoryPromptBuilder
 from tac.channels.voice import VoiceChannel
 from tac.models.session import ConversationSession
 from tac.models.tac import TACMemoryResponse
@@ -25,7 +27,7 @@ load_dotenv()
 set_tracing_disabled(True)
 
 tac = TAC(config=TACConfig.from_env())
-voice_channel = VoiceChannel(tac)
+voice_channel = VoiceChannel(tac, config={"memory_mode": "always"})
 
 SYSTEM_INSTRUCTIONS = (
     "You are a voice assistant speaking with a user over the phone. "
@@ -33,8 +35,6 @@ SYSTEM_INSTRUCTIONS = (
     "Do not use markdown, asterisks, bullets, or emojis; your words will be "
     "spoken aloud."
 )
-
-agent = Agent(name="Voice Assistant", instructions=SYSTEM_INSTRUCTIONS)
 
 conversation_history: dict[str, list[Any]] = {}
 
@@ -48,6 +48,9 @@ async def handle_message_ready(
     so tokens are sent to the caller as they arrive from the LLM.
     """
     conv_id = context.conversation_id
+
+    instructions = MemoryPromptBuilder.compose(SYSTEM_INSTRUCTIONS, memory_response, context)
+    agent = Agent(name="Voice Assistant", instructions=instructions)
 
     history = conversation_history.get(conv_id, [])
     agent_input = history + [{"role": "user", "content": user_message}]
@@ -65,5 +68,11 @@ async def handle_message_ready(
 tac.on_message_ready(handle_message_ready)
 
 if __name__ == "__main__":
-    server = TACFastAPIServer(tac=tac, voice_channel=voice_channel)
+    from tac.server.config import TACServerConfig
+
+    server_config = TACServerConfig.from_env()
+    if os.environ.get("CONVERSATION_INTELLIGENCE_CONFIGURATION_ID"):
+        server_config.cintel_webhook_path = "/ci-webhook"
+
+    server = TACFastAPIServer(tac=tac, voice_channel=voice_channel, config=server_config)
     server.start()

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -715,10 +715,9 @@ class VoiceChannel(BaseChannel):
         """
         Clean up WebSocket and session resources when connection closes.
 
-        In orchestrated mode, the conversation remains tracked in
-        self._conversations until the CONVERSATION_UPDATED/CLOSED webhook
-        arrives from Conversation Orchestrator. In relay-only mode there is no such webhook,
-        so we also end the conversation here.
+        In orchestrated mode, immediately closes the conversation via the CO API
+        so Memora's extraction pipeline starts without waiting for the inactive timeout.
+        In relay-only mode there is no CO webhook, so we end the conversation locally.
 
         Args:
             conv_id: Conversation ID
@@ -734,7 +733,23 @@ class VoiceChannel(BaseChannel):
             await session_state.cancel_stream_task()
             self.session_manager.remove_session(conv_id)
 
-        if not self.tac.is_orchestrator_enabled() and conv_id in self._conversations:
+        if self.tac.is_orchestrator_enabled():
+            # Close conversation immediately so Memora extraction starts right away
+            # instead of waiting for the inactive timeout.
+            co_client = self.tac.conversation_orchestrator_client
+            if co_client is not None and conv_id in self._conversations:
+                try:
+                    await co_client.update_conversation(conv_id, status="CLOSED")
+                    self.logger.debug(
+                        "Closed conversation on call end", conversation_id=conv_id
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        "Failed to close conversation on call end",
+                        conversation_id=conv_id,
+                        error=str(e),
+                    )
+        elif conv_id in self._conversations:
             await self._end_conversation(conv_id)
 
         self.logger.debug(

--- a/src/tac/context/memory.py
+++ b/src/tac/context/memory.py
@@ -310,14 +310,13 @@ class MemoryClient(BaseAPIClient):
         endpoint = f"/v1/Stores/{self.store_id}/Profiles/{profile_id}/Observations"
         url = f"{self.base_url}{endpoint}"
 
-        payload: dict[str, Any] = {
-            "content": content,
-            "source": source,
-        }
+        observation: dict[str, Any] = {"content": content, "source": source}
         if conversation_ids:
-            payload["conversationIds"] = conversation_ids
+            observation["conversationIds"] = conversation_ids
         if occurred_at:
-            payload["occurredAt"] = occurred_at
+            observation["occurredAt"] = occurred_at
+
+        payload: dict[str, Any] = {"observations": [observation]}
 
         try:
             async with self._get_client() as client:


### PR DESCRIPTION
- Fix create_observation() payload format: wrap in {"observations": [...]} so Memora API accepts the request (was sending flat dict → silent 400)
- Inject Memora memory into agent instructions via MemoryPromptBuilder.compose() so the LLM actually uses observations/summaries from past calls
- Enable memory_mode="always" in voice_streaming.py example
- Wire up CI webhook: if CONVERSATION_INTELLIGENCE_CONFIGURATION_ID is set, expose /ci-webhook route for near real-time custom operator ingestion
- Auto-close conversation via CO API on WebSocket disconnect so Memora extraction triggers immediately instead of waiting for inactive timeout
- Add CI/memory section to getting_started/README.md explaining standard vs alternate write paths, latency tips, and links to lifecycle docs

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

> **Tip:** Use the `/sync-to-ts-sdk` skill in Claude Code to automatically generate and create a TypeScript SDK PR from your changes.

- [ ] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->
