### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twilio-agent-connect"
-version = "1.0.1"
+version = "1.0.2"
 description = "A Python framework for building agentic applications with Twilio"
 authors = [{ name = "Twilio Conversation AI", email = "team_conversational-ai@twilio.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2430,7 +2430,7 @@ wheels = [
 
 [[package]]
 name = "twilio-agent-connect"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Patch version bump from 1.0.1 → 1.0.2. Updates `version` in `pyproject.toml` and the corresponding entry in `uv.lock`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **Python SDK**. Version bumps are release-management only and Python-specific.

- [x] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created:

🤖 Generated with [Claude Code](https://claude.com/claude-code)