### PR TITLE
feat(server): validate channel types at TACFastAPIServer construction

### DIFF
--- a/src/tac/server/fastapi_server.py
+++ b/src/tac/server/fastapi_server.py
@@ -10,18 +10,16 @@ Requires: pip install tac[server]
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from tac.channels.base import BaseChannel
+from tac.channels.messaging import MessagingChannel
+from tac.channels.voice import VoiceChannel
 from tac.channels.websocket_protocol import WebSocketDisconnectError
 from tac.core.logging import get_logger
 from tac.core.tac import TAC
 from tac.models.voice import TwiMLRequest
 from tac.server.config import TACServerConfig
-
-if TYPE_CHECKING:
-    from tac.channels.messaging import MessagingChannel
-    from tac.channels.voice import VoiceChannel
 
 try:
     import uvicorn
@@ -112,6 +110,8 @@ class TACFastAPIServer:
         self.voice_channel = voice_channel
         self.messaging_channels: list[MessagingChannel] = messaging_channels or []
 
+        self._validate_channel_types()
+
         if self.voice_channel is not None:
             self._validate_voice_url_config()
 
@@ -123,6 +123,30 @@ class TACFastAPIServer:
 
         self.app: FastAPI = app if app is not None else FastAPI(title="TAC Server")
         self._register_routes(self.app)
+
+    def _validate_channel_types(self) -> None:
+        """Fail fast at server construction if a channel is the wrong type.
+
+        A common mistake is passing ``None`` (e.g. a connector channel that
+        wasn't configured) or an otherwise wrong object into
+        ``messaging_channels`` / ``voice_channel``. Without this check that
+        surfaces much later as an opaque ``AttributeError`` (e.g. ``'NoneType'
+        object has no attribute 'get_channel_name'``) deep in webhook dispatch,
+        far from the actual misconfiguration.
+        """
+        if self.voice_channel is not None and not isinstance(self.voice_channel, VoiceChannel):
+            raise TypeError(
+                "voice_channel must be a VoiceChannel or None, got "
+                f"{type(self.voice_channel).__name__}."
+            )
+        for channel in self.messaging_channels:
+            if not isinstance(channel, MessagingChannel):
+                raise TypeError(
+                    "messaging_channels must contain MessagingChannel instances "
+                    "(SMSChannel, RCSChannel, WhatsAppChannel, ChatChannel), got "
+                    f"{type(channel).__name__}. A None here usually means a channel "
+                    "that wasn't configured was passed through — filter those out."
+                )
 
     def _validate_voice_url_config(self) -> None:
         """Fail fast at server construction if the voice channel can't build a

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -118,6 +118,57 @@ class TestVoiceUrlConfigValidationAtStartup:
         TACFastAPIServer(tac=tac)  # no raise
 
 
+class TestChannelTypeValidationAtStartup:
+    """TACFastAPIServer fails fast at construction if a channel is the wrong
+    type — e.g. a None (an unconfigured connector channel) slipping into
+    messaging_channels — instead of an opaque AttributeError during dispatch."""
+
+    def test_none_in_messaging_channels_raises(self) -> None:
+        from tac.channels import SMSChannel
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        with pytest.raises(TypeError, match="MessagingChannel"):
+            TACFastAPIServer(tac=tac, messaging_channels=[SMSChannel(tac), None])
+
+    def test_wrong_type_in_messaging_channels_raises(self) -> None:
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        with pytest.raises(TypeError, match="MessagingChannel"):
+            TACFastAPIServer(tac=tac, messaging_channels=["not a channel"])
+
+    def test_voice_channel_in_messaging_channels_raises(self) -> None:
+        """A VoiceChannel is not a MessagingChannel — passing it in the
+        messaging list is a mistake and is rejected."""
+        from tac.channels.voice import VoiceChannel
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        with pytest.raises(TypeError, match="MessagingChannel"):
+            TACFastAPIServer(tac=tac, messaging_channels=[VoiceChannel(tac)])
+
+    def test_wrong_type_voice_channel_raises(self) -> None:
+        from tac.channels import SMSChannel
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        with pytest.raises(TypeError, match="VoiceChannel"):
+            TACFastAPIServer(tac=tac, voice_channel=SMSChannel(tac))
+
+    def test_valid_channels_pass(self) -> None:
+        from tac.channels import ChatChannel, SMSChannel
+        from tac.channels.voice import VoiceChannel
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        TACFastAPIServer(
+            tac=tac,
+            voice_channel=VoiceChannel(tac),
+            messaging_channels=[SMSChannel(tac), ChatChannel(tac)],
+        )  # no raise
+
+
 class TestWebSocketDisconnectError:
     """Test WebSocketDisconnectError."""
 


### PR DESCRIPTION
## Summary

`TACFastAPIServer` now validates channel types at construction and fails fast with a clear `TypeError`, instead of letting a bad entry surface much later as an opaque `AttributeError` deep in webhook dispatch.

- `voice_channel` must be a `VoiceChannel` or `None`.
- Every `messaging_channels` entry must be a `MessagingChannel` (`SMSChannel` / `RCSChannel` / `WhatsAppChannel` / `ChatChannel`).

## Motivation

The common failure mode: a caller passes a channel that wasn't configured — e.g. a connector exposes `rcs_channel` / `whatsapp_channel` as `None` when the address isn't set, and a `None` slips into `messaging_channels`. Today that `None` is accepted silently, `extend`ed into `webhook_channels`, and only blows up on the **first inbound webhook** with:

```
AttributeError: 'NoneType' object has no attribute 'get_channel_name'
```

— far from the actual mistake, and easy to miss in CI/smoke tests that don't exercise webhooks. This change catches it at construction, next to where the channels are wired.

It mirrors the existing `_validate_voice_url_config` "fail fast at construction" pattern already in this class.

## Changes

- Add `_validate_channel_types()`, called first in `__init__`.
- Move `VoiceChannel` / `MessagingChannel` from `TYPE_CHECKING`-only to runtime imports (needed for `isinstance`).
- 5 new tests in `TestChannelTypeValidationAtStartup` (None entry, wrong type, VoiceChannel-in-messaging, wrong-type voice, and the valid-channels-pass case).

## Verification

`make check` — ruff + mypy strict (75 files) + **766 tests** pass (761 existing + 5 new; no existing test changed).

## Context

The Azure connectors' `TACHostedAgentsApp` added the same guard for its own server. This PR brings the check to the shared `TACFastAPIServer` so **both** the AWS and Azure packages (and any direct consumer) benefit, rather than each server reimplementing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)