### PR TITLE
feat(tools): add knowledge base search example

### DIFF
--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -128,7 +128,7 @@ See `examples/.env.example` for all available configuration options. Key variabl
 ### Optional (OpenAI Example)
 - `OPENAI_API_KEY`: Your OpenAI API key (only needed to run OpenAI examples)
 
-### Optional (Channel-Specific)
+### Optional
 - `TWILIO_STUDIO_HANDOFF_FLOW_SID`: Studio Flow SID used by `create_studio_handoff_tool` (required for `features/handoff.py`)
 - `TWILIO_KNOWLEDGE_BASE_ID`: Knowledge Base ID used by `create_knowledge_tool` (required for `features/knowledge.py`)
 - `TWILIO_RCS_SENDER_ID`: RCS Sender ID (required for `features/rcs.py`)

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -55,6 +55,7 @@ Production-ready examples integrating TAC with partner SDKs:
 
 - **`voice_streaming.py`**: Stream LLM responses token-by-token for ~40-50% faster time-to-first-audio
 - **`handoff.py`**: Hand the conversation off to a human agent via a Twilio Studio Flow (works on voice and SMS)
+- **`knowledge.py`**: Answer user questions by searching a Twilio Knowledge Base (works on voice and SMS)
 - **`rcs.py`**: RCS (Rich Communication Services) channel with automatic memory retrieval
 - **`whatsapp.py`**: WhatsApp channel with automatic memory retrieval
 - **`outbound.py`**: Agent-initiated outbound conversations via SMS, RCS, WhatsApp, or Voice channels
@@ -90,6 +91,7 @@ uv run getting_started/examples/partners/aws_bedrock_agentcore.py
 uv run getting_started/examples/partners/aws_strands.py
 uv run getting_started/examples/features/voice_streaming.py
 uv run getting_started/examples/features/handoff.py
+uv run getting_started/examples/features/knowledge.py
 uv run getting_started/examples/features/relay_only.py
 ```
 
@@ -128,6 +130,7 @@ See `examples/.env.example` for all available configuration options. Key variabl
 
 ### Optional (Channel-Specific)
 - `TWILIO_STUDIO_HANDOFF_FLOW_SID`: Studio Flow SID used by `create_studio_handoff_tool` (required for `features/handoff.py`)
+- `TWILIO_KNOWLEDGE_BASE_ID`: Knowledge Base ID used by `create_knowledge_tool` (required for `features/knowledge.py`)
 - `TWILIO_RCS_SENDER_ID`: RCS Sender ID (required for `features/rcs.py`)
 - `TWILIO_WHATSAPP_NUMBER`: WhatsApp-enabled phone number in format `whatsapp:+1234567890` (required for `features/whatsapp.py`)
 - `TWILIO_CONVERSATIONS_SERVICE_SID`: Conversations Service SID (required for Chat channel examples)

--- a/getting_started/examples/.env.example
+++ b/getting_started/examples/.env.example
@@ -24,6 +24,9 @@ OPENAI_API_KEY=sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # Required for features/handoff.py
 TWILIO_STUDIO_HANDOFF_FLOW_SID=FWxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# Required for features/knowledge.py
+TWILIO_KNOWLEDGE_BASE_ID=know_knowledgebase_xxxxxxxxxxxxxxxxxxxxxxxxxx
+
 # Required for features/rcs.py
 TWILIO_RCS_SENDER_ID=rcs:your_sender_id
 

--- a/getting_started/examples/features/knowledge.py
+++ b/getting_started/examples/features/knowledge.py
@@ -1,0 +1,101 @@
+"""
+Feature: Knowledge Base Search Tool
+
+Demonstrates TAC's knowledge tool letting an LLM agent answer questions by
+searching a Twilio Knowledge Base. Works on voice and SMS.
+
+Requires ``TWILIO_KNOWLEDGE_BASE_ID`` in addition to the usual TAC env vars —
+see ``.env.example``. The knowledge base must be ACTIVE.
+"""
+
+from typing import Any
+
+from agents import Agent, Runner, set_tracing_disabled
+from dotenv import load_dotenv
+
+from tac import TAC, TACConfig
+from tac.channels.sms import SMSChannel, SMSChannelConfig
+from tac.channels.voice import VoiceChannel, VoiceChannelConfig
+from tac.models.session import ConversationSession
+from tac.models.tac import TACMemoryResponse
+from tac.server import TACFastAPIServer
+from tac.tools.knowledge import create_knowledge_tool
+
+load_dotenv()
+set_tracing_disabled(True)
+
+tac = TAC(config=TACConfig.from_env())
+
+# The knowledge client is only initialized when TWILIO_KNOWLEDGE_BASE_ID is set.
+if not tac.knowledge_client or not tac.config.knowledge_base_id:
+    raise RuntimeError(
+        "TWILIO_KNOWLEDGE_BASE_ID is required to run the knowledge example. "
+        "Set it in your .env (see .env.example)."
+    )
+
+knowledge_client = tac.knowledge_client
+knowledge_base_id = tac.config.knowledge_base_id
+
+SYSTEM_INSTRUCTIONS = (
+    "You are a customer service agent speaking with a user over voice or SMS. "
+    "Keep responses short and conversational — a sentence or two. "
+    "Do not use markdown, asterisks, bullets, or emojis; your words will be "
+    "spoken aloud or sent as plain text. "
+    "When the user asks a question, use the knowledge search tool to look up an "
+    "answer before responding. If the knowledge base has no relevant information, "
+    "say you don't know rather than guessing."
+)
+
+conversation_history: dict[str, list[Any]] = {}
+
+# Build the knowledge tool once at startup. Passing name and description avoids
+# a metadata lookup; omit them to derive defaults from the knowledge base.
+knowledge_tool = None
+
+
+async def get_knowledge_tool() -> Any:
+    global knowledge_tool
+    if knowledge_tool is None:
+        knowledge_tool = await create_knowledge_tool(
+            knowledge_client=knowledge_client,
+            knowledge_base_id=knowledge_base_id,
+            name="search_knowledge_base",
+            description="Search the company knowledge base to answer user questions.",
+            top_k=3,
+        )
+    return knowledge_tool
+
+
+async def handle_message_ready(
+    user_message: str,
+    context: ConversationSession,
+    memory_response: TACMemoryResponse | None,
+) -> str:
+    tool = await get_knowledge_tool()
+
+    agent = Agent(
+        name="Customer Service Agent",
+        instructions=SYSTEM_INSTRUCTIONS,
+        tools=[tool.to_openai_agents_sdk_tool()],
+    )
+
+    history = conversation_history.get(context.conversation_id, [])
+    agent_input = history + [{"role": "user", "content": user_message}]
+
+    result = await Runner.run(agent, agent_input)
+
+    conversation_history[context.conversation_id] = result.to_input_list()
+    return result.final_output_as(str)
+
+
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig())
+sms_channel = SMSChannel(tac, config=SMSChannelConfig())
+
+tac.on_message_ready(handle_message_ready)
+
+
+if __name__ == "__main__":
+    server = TACFastAPIServer(
+        tac=tac, voice_channel=voice_channel, messaging_channels=[sms_channel]
+    )
+    server.start()

--- a/getting_started/examples/features/knowledge.py
+++ b/getting_started/examples/features/knowledge.py
@@ -2,7 +2,7 @@
 Feature: Knowledge Base Search Tool
 
 Demonstrates TAC's knowledge tool letting an LLM agent answer questions by
-searching a Twilio Knowledge Base. Works on voice and SMS.
+searching a Twilio Knowledge Base.
 
 Requires ``TWILIO_KNOWLEDGE_BASE_ID`` in addition to the usual TAC env vars —
 see ``.env.example``. The knowledge base must be ACTIVE.

--- a/src/tac/tools/base.py
+++ b/src/tac/tools/base.py
@@ -303,7 +303,8 @@ class TACTool:
             # knowledge tool returns list[KnowledgeChunkResult]), which the
             # stdlib json encoder can't handle on its own.
             if isinstance(obj, BaseModel):
-                return obj.model_dump(by_alias=True, exclude_none=True)
+                # mode="json" coerces datetime/UUID/Decimal to JSON primitives.
+                return obj.model_dump(mode="json", by_alias=True, exclude_none=True)
             raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
         async def on_invoke(_ctx: object, args_json: str) -> str:

--- a/src/tac/tools/base.py
+++ b/src/tac/tools/base.py
@@ -18,13 +18,17 @@ from typing import (
     get_type_hints,
 )
 
-from pydantic import TypeAdapter
+from pydantic import BaseModel, TypeAdapter
+
+from tac import get_logger
 
 if TYPE_CHECKING:
     # Typing-only soft dep: `openai-agents` is optional at runtime. The ignore
     # silences strict-mode downstream mypy when the package isn't installed
     # (and is a no-op when it is — `unused-ignore` covers both environments).
     from agents import FunctionTool  # type: ignore[import-not-found,unused-ignore]
+
+logger = get_logger(__name__)
 
 
 # Marker class for injected tool arguments
@@ -188,12 +192,10 @@ class TACTool:
 
             try:
                 try:
-                    from pydantic import BaseModel
-
                     is_pydantic_model = isinstance(expected_type, type) and issubclass(
                         expected_type, BaseModel
                     )
-                except (ImportError, TypeError):
+                except TypeError:
                     is_pydantic_model = False
 
                 adapter: TypeAdapter[object]
@@ -296,10 +298,19 @@ class TACTool:
                 "Install with: pip install openai-agents"
             ) from e
 
+        def _json_default(obj: object) -> object:
+            # Tool implementations may return Pydantic models (e.g. the
+            # knowledge tool returns list[KnowledgeChunkResult]), which the
+            # stdlib json encoder can't handle on its own.
+            if isinstance(obj, BaseModel):
+                return obj.model_dump(by_alias=True, exclude_none=True)
+            raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
         async def on_invoke(_ctx: object, args_json: str) -> str:
             args = json.loads(args_json) if args_json else {}
+            logger.debug("TOOL | Called", tool_name=self.name)
             result = await self(**args)
-            return json.dumps(result)
+            return json.dumps(result, default=_json_default)
 
         return FunctionTool(
             name=self.name,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import BaseModel
 
 from tac.context.knowledge import KnowledgeClient
 from tac.context.memory import MemoryClient
@@ -123,6 +124,34 @@ class TestTACTool:
 
         result_json = await sdk_tool.on_invoke_tool(None, '{"x": "hello"}')
         assert json.loads(result_json) == {"echo": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_to_openai_agents_sdk_tool_serializes_pydantic_results(self):
+        """Tools returning Pydantic models (e.g. the knowledge tool) are JSON-encoded."""
+
+        class ChunkResult(BaseModel):
+            content: str
+            score: float | None = None
+
+        async def search(x: str) -> list[ChunkResult]:
+            return [ChunkResult(content=f"result for {x}")]
+
+        tool = TACTool(
+            name="search_tool",
+            description="A search tool",
+            params_json_schema={
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": ["x"],
+            },
+            _raw_implementation=search,
+        )
+
+        sdk_tool = tool.to_openai_agents_sdk_tool()
+
+        result_json = await sdk_tool.on_invoke_tool(None, '{"x": "hello"}')
+        # exclude_none drops the null score
+        assert json.loads(result_json) == [{"content": "result for hello"}]
 
     def test_to_json(self):
         """Test conversion to JSON string."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -153,6 +153,42 @@ class TestTACTool:
         # exclude_none drops the null score
         assert json.loads(result_json) == [{"content": "result for hello"}]
 
+    @pytest.mark.asyncio
+    async def test_to_openai_agents_sdk_tool_serializes_non_json_primitives(self):
+        """Models with datetime/UUID fields serialize via mode="json"."""
+        from datetime import datetime
+        from uuid import UUID
+
+        class Record(BaseModel):
+            id: UUID
+            created_at: datetime
+
+        async def fetch(x: str) -> Record:
+            return Record(
+                id=UUID("12345678-1234-5678-1234-567812345678"),
+                created_at=datetime(2026, 7, 10, 12, 0, 0),
+            )
+
+        tool = TACTool(
+            name="fetch_tool",
+            description="A fetch tool",
+            params_json_schema={
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": ["x"],
+            },
+            _raw_implementation=fetch,
+        )
+
+        sdk_tool = tool.to_openai_agents_sdk_tool()
+
+        # Without mode="json" this raises "not JSON serializable" on datetime/UUID.
+        result_json = await sdk_tool.on_invoke_tool(None, '{"x": "hello"}')
+        assert json.loads(result_json) == {
+            "id": "12345678-1234-5678-1234-567812345678",
+            "created_at": "2026-07-10T12:00:00",
+        }
+
     def test_to_json(self):
         """Test conversion to JSON string."""
 


### PR DESCRIPTION
## Summary

Adds a runnable knowledge base search example and fixes serialization bugs in the OpenAI Agents SDK tool bridge.

- **New example** `getting_started/examples/features/knowledge.py` — an LLM agent that answers user questions by searching a Twilio Knowledge Base via `create_knowledge_tool`. Modeled on the existing `handoff.py`.
- **Bug fix** `TACTool.to_openai_agents_sdk_tool()` now JSON-serializes Pydantic tool results. The built-in knowledge tool returns `list[KnowledgeChunkResult]`, which the stdlib `json.dumps` couldn't encode — any tool returning Pydantic models crashed with `Object of type ... is not JSON serializable`.
- **Bug fix** the same path now uses `model_dump(mode="json")` so models with non-primitive fields (datetime, UUID, Decimal) coerce to JSON-encodable values instead of crashing at `json.dumps`. Covered by a new test.
- **Observability** — added a `debug` log on tool invocation so tool calls are visible in logs.
- Docs: added the example + `TWILIO_KNOWLEDGE_BASE_ID` to `getting_started/README.md` and `.env.example`.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

The serialization fixes affect shared tool functionality and should be mirrored in the TypeScript SDK.

- [ ] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
