### PR TITLE
refactor(channels): return uppercase Twilio channel type from get_channel_name

### DIFF
--- a/getting_started/examples/features/dashboard/dashboard.py
+++ b/getting_started/examples/features/dashboard/dashboard.py
@@ -59,13 +59,6 @@ def create_dashboard_router(
             sessions.update(get_voice_sessions())
         return sessions
 
-    def _resolve_channel(conv_id: str) -> str:
-        if get_sms_sessions and conv_id in get_sms_sessions():
-            return "sms"
-        if get_voice_sessions and conv_id in get_voice_sessions():
-            return "voice"
-        return "chat"
-
     def _get_display_messages(conv_id: str) -> list[dict[str, str]]:
         """Get user/assistant messages for display."""
         if not get_messages:
@@ -115,7 +108,7 @@ def create_dashboard_router(
             results.append(
                 {
                     "id": conv_id,
-                    "channel": session.channel or _resolve_channel(conv_id),
+                    "channel": session.channel,
                     "status": live_status.get(conv_id, "ACTIVE")
                     if live_status is not None
                     else "ACTIVE",
@@ -143,7 +136,7 @@ def create_dashboard_router(
         return JSONResponse(
             content={
                 "id": conv_id,
-                "channel": session.channel or _resolve_channel(conv_id),
+                "channel": session.channel,
                 "profile_id": session.profile_id,
                 "author_address": (session.author_info.address if session.author_info else None),
                 "messages": msgs,

--- a/src/tac/channels/base.py
+++ b/src/tac/channels/base.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from tac import TAC
 from tac.core.logging import get_logger
-from tac.models.conversation import ParticipantResponse
+from tac.models.conversation import ChannelType, ParticipantResponse
 from tac.models.memory import MemoryMode
 from tac.models.session import ConversationSession
 from tac.models.tac import TACMemoryResponse
@@ -104,24 +104,15 @@ class BaseChannel(ABC):
         pass
 
     @abstractmethod
-    def get_channel_name(self) -> str:
+    def get_channel_name(self) -> ChannelType:
         """
-        Get the channel name identifier.
+        Get the channel type identifier.
 
         Returns:
-            Channel name (e.g., 'sms', 'voice')
+            Uppercase Twilio channel type (e.g., 'SMS', 'VOICE')
         """
         # TODO: Parse Channel Type based on webhook data
         pass
-
-    def get_channel_type_upper(self) -> str:
-        """
-        Get uppercase channel type for webhook filtering.
-
-        Returns:
-            Uppercase channel type (e.g., 'SMS', 'VOICE')
-        """
-        return self.get_channel_name().upper()
 
     def _is_duplicate_webhook(self, idempotency_token: str) -> bool:
         """Check if a webhook has already been processed using Twilio's idempotency token.
@@ -162,7 +153,7 @@ class BaseChannel(ABC):
             author_channel = author.get("channel")
             if not author_channel:
                 return False
-            return bool(author_channel == self.get_channel_type_upper())
+            return bool(author_channel == self.get_channel_name())
 
         if event_type == "CONVERSATION_UPDATED":
             if not isinstance(event_data, dict):
@@ -253,7 +244,7 @@ class BaseChannel(ABC):
         )
 
         self.logger.info(
-            f"CONVERSATION | Started {self.get_channel_name().upper()} conversation",
+            f"CONVERSATION | Started {self.get_channel_name()} conversation",
             conversation_id=conv_id,
             profile_id=profile_id,
         )

--- a/src/tac/channels/chat.py
+++ b/src/tac/channels/chat.py
@@ -11,6 +11,7 @@ from tac.models.conversation import (
     ActionChannelSettings,
     ActionParticipantRef,
     ActionTextContent,
+    ChannelType,
     ParticipantAddress,
     SendMessageActionPayload,
     SendMessageActionRequest,
@@ -64,10 +65,7 @@ class ChatChannel(MessagingChannel):
         )
         self.agent_address = config.agent_address
 
-    def get_channel_name(self) -> str:
-        return "chat"
-
-    def get_channel_type_upper(self) -> str:
+    def get_channel_name(self) -> ChannelType:
         return "CHAT"
 
     def is_default_agent_address(self, author_address: str) -> bool:

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -64,7 +64,6 @@ class MessagingChannel(BaseChannel):
 
     Subclasses must implement:
     - is_default_agent_address(): Fast-path check for the channel's default agent address
-    - get_channel_type_upper(): Return uppercase channel type ("SMS", "RCS", "WHATSAPP", "CHAT")
     - get_agent_address(conversation_id): Return the agent's ParticipantAddress for a conversation
     - send_response(): Send messages back through the channel
     - get_channel_name(): Return lowercase channel name ("sms", "rcs", "whatsapp", "chat")
@@ -147,15 +146,6 @@ class MessagingChannel(BaseChannel):
                 )
 
         return False
-
-    @abstractmethod
-    def get_channel_type_upper(self) -> str:
-        """Return the uppercase channel type for webhook filtering.
-
-        Returns:
-            Channel type string (e.g., "SMS", "CHAT")
-        """
-        pass
 
     @abstractmethod
     def get_agent_address(self, conversation_id: str) -> ParticipantAddress:
@@ -335,7 +325,7 @@ class MessagingChannel(BaseChannel):
 
         Subclasses call this with channel-specific address kwargs and settings.
         """
-        channel_type = self.get_channel_type_upper()
+        channel_type = self.get_channel_name()
         conversation_id: str | None = None
         reused = False
 

--- a/src/tac/channels/rcs.py
+++ b/src/tac/channels/rcs.py
@@ -11,6 +11,7 @@ from tac.models.conversation import (
     ActionChannelSettings,
     ActionParticipantRef,
     ActionTextContent,
+    ChannelType,
     ParticipantAddress,
     SendMessageActionPayload,
     SendMessageActionRequest,
@@ -67,10 +68,7 @@ class RCSChannel(MessagingChannel):
                 "provide rcs_sender_id in TACConfig."
             )
 
-    def get_channel_name(self) -> str:
-        return "rcs"
-
-    def get_channel_type_upper(self) -> str:
+    def get_channel_name(self) -> ChannelType:
         return "RCS"
 
     def is_default_agent_address(self, author_address: str) -> bool:

--- a/src/tac/channels/sms.py
+++ b/src/tac/channels/sms.py
@@ -11,6 +11,7 @@ from tac.models.conversation import (
     ActionChannelSettings,
     ActionParticipantRef,
     ActionTextContent,
+    ChannelType,
     ParticipantAddress,
     SendMessageActionPayload,
     SendMessageActionRequest,
@@ -65,10 +66,7 @@ class SMSChannel(MessagingChannel):
                 "provide phone_number in TACConfig."
             )
 
-    def get_channel_name(self) -> str:
-        return "sms"
-
-    def get_channel_type_upper(self) -> str:
+    def get_channel_name(self) -> ChannelType:
         return "SMS"
 
     def is_default_agent_address(self, author_address: str) -> bool:

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -14,6 +14,7 @@ from tac.channels.base import BaseChannel
 from tac.channels.websocket_manager import WebSocketManager
 from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
 from tac.core.tac import TAC
+from tac.models.conversation import ChannelType
 from tac.models.outbound import InitiateVoiceConversationOptions, InitiateVoiceConversationResult
 from tac.models.session import AuthorInfo
 from tac.models.voice import (
@@ -848,8 +849,8 @@ class VoiceChannel(BaseChannel):
                 f"Error sending response: {e}", conversation_id=conversation_id, exc_info=True
             )
 
-    def get_channel_name(self) -> str:
-        return "voice"
+    def get_channel_name(self) -> ChannelType:
+        return "VOICE"
 
     def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
         """

--- a/src/tac/channels/whatsapp.py
+++ b/src/tac/channels/whatsapp.py
@@ -11,6 +11,7 @@ from tac.models.conversation import (
     ActionChannelSettings,
     ActionParticipantRef,
     ActionTextContent,
+    ChannelType,
     ParticipantAddress,
     SendMessageActionPayload,
     SendMessageActionRequest,
@@ -68,10 +69,7 @@ class WhatsAppChannel(MessagingChannel):
                 "provide whatsapp_number in TACConfig."
             )
 
-    def get_channel_name(self) -> str:
-        return "whatsapp"
-
-    def get_channel_type_upper(self) -> str:
+    def get_channel_name(self) -> ChannelType:
         return "WHATSAPP"
 
     def is_default_agent_address(self, author_address: str) -> bool:

--- a/src/tac/models/conversation.py
+++ b/src/tac/models/conversation.py
@@ -6,6 +6,10 @@ from pydantic import BaseModel, Field, model_validator
 
 from tac.models.pagination import PaginationMeta
 
+# Twilio Conversation Orchestrator channel-type enum. Used for API payloads
+# (participant addresses, action refs) and webhook `author.channel` matching.
+ChannelType = Literal["VOICE", "SMS", "RCS", "EMAIL", "WHATSAPP", "CHAT", "API", "SYSTEM"]
+
 
 class StatusTimeouts(BaseModel):
     """Timeout settings for channel status transitions."""
@@ -80,7 +84,7 @@ class StatusCallback(BaseModel):
 class ParticipantAddress(BaseModel):
     """Communication address for a conversation participant."""
 
-    channel: Literal["VOICE", "SMS", "RCS", "EMAIL", "WHATSAPP", "CHAT", "API", "SYSTEM"] = Field(
+    channel: ChannelType = Field(
         ..., description="The channel for Communication (VOICE, SMS, EMAIL, etc.)"
     )
     address: str = Field(..., description="The address value (phone number, email, etc.)")
@@ -267,9 +271,7 @@ class CommunicationParticipant(BaseModel):
         description="Address of the participant formatted according to channel type",
         json_schema_extra={"example": "+12025551234"},
     )
-    channel: Literal["VOICE", "SMS", "RCS", "EMAIL", "WHATSAPP", "CHAT", "API", "SYSTEM"] = Field(
-        ..., description="Channel type for the participant address"
-    )
+    channel: ChannelType = Field(..., description="Channel type for the participant address")
     participant_id: str = Field(
         ...,
         alias="participantId",
@@ -442,9 +444,7 @@ class ActionParticipantRef(BaseModel):
     address: str | None = Field(
         default=None, min_length=1, max_length=254, description="Participant address"
     )
-    channel: Literal["VOICE", "SMS", "RCS", "EMAIL", "WHATSAPP", "CHAT", "API", "SYSTEM"] = Field(
-        ..., description="Channel type"
-    )
+    channel: ChannelType = Field(..., description="Channel type")
 
     model_config = {"populate_by_name": True}
 

--- a/src/tac/models/memory.py
+++ b/src/tac/models/memory.py
@@ -2,6 +2,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+from tac.models.conversation import ChannelType
+
 # Memory retrieval mode for channels
 MemoryMode = Literal["always", "never", "once"]
 
@@ -93,9 +95,7 @@ class MemoryParticipant(BaseModel):
         description="Address of the Participant (e.g., phone number, email address)",
         json_schema_extra={"example": "+12025551234"},
     )
-    channel: Literal["VOICE", "SMS", "RCS", "EMAIL", "WHATSAPP", "CHAT", "API", "SYSTEM"] = Field(
-        ..., description="The channel on which the message originated"
-    )
+    channel: ChannelType = Field(..., description="The channel on which the message originated")
     type: Literal["HUMAN_AGENT", "CUSTOMER", "AI_AGENT", "AGENT", "UNKNOWN"] | None = Field(
         default=None,
         description="Type of Participant in the Conversation",

--- a/src/tac/models/session.py
+++ b/src/tac/models/session.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from tac.models.conversation import ChannelType
 from tac.models.handoff import PendingHandoffData
 from tac.models.memory import ProfileResponse
 
@@ -34,7 +35,7 @@ class ConversationSession(BaseModel):
     profile_id: str | None = Field(
         None, description="Profile ID associated with conversation (optional)"
     )
-    channel: str = Field(..., description="Channel type (e.g., 'sms', 'voice')")
+    channel: ChannelType = Field(..., description="Channel type (e.g., 'SMS', 'VOICE')")
     started_at: datetime = Field(
         default_factory=datetime.now,
         description="When the conversation session was started",

--- a/src/tac/models/tac.py
+++ b/src/tac/models/tac.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from tac.models.conversation import Communication, Transcription
+from tac.models.conversation import ChannelType, Communication, Transcription
 from tac.models.memory import (
     MemoryCommunication,
     MemoryRetrievalResponse,
@@ -20,9 +20,7 @@ class TACCommunicationAuthor(BaseModel):
 
     # Common fields (both APIs)
     address: str = Field(..., description="Address of the communication author")
-    channel: Literal["VOICE", "SMS", "RCS", "EMAIL", "WHATSAPP", "CHAT", "API", "SYSTEM"] = Field(
-        ..., description="Channel type"
-    )
+    channel: ChannelType = Field(..., description="Channel type")
 
     # Conversation Orchestrator-only fields
     participant_id: str | None = Field(

--- a/src/tac/tools/handoff.py
+++ b/src/tac/tools/handoff.py
@@ -179,7 +179,7 @@ async def _handoff_impl(
         )
 
     # 3. Deliver handoff payload.
-    if channel == "voice":
+    if channel == "VOICE":
         # Voice: store on session for deferred delivery. The voice channel
         # sends the WS "end" message after the LLM's final response so the
         # caller hears a goodbye before transfer.

--- a/tests/test_chat_channel.py
+++ b/tests/test_chat_channel.py
@@ -88,8 +88,7 @@ class TestChatChannel:
         tac = TAC(get_test_config())
         channel = ChatChannel(tac)
         assert channel.agent_address == "ai-assistant"
-        assert channel.get_channel_name() == "chat"
-        assert channel.get_channel_type_upper() == "CHAT"
+        assert channel.get_channel_name() == "CHAT"
 
     def test_initialization_custom_agent_address(self) -> None:
         tac = TAC(get_test_config())
@@ -233,7 +232,7 @@ class TestChatChannel:
         channel = ChatChannel(tac)
 
         channel._conversations["CH123"] = ConversationSession(
-            conversation_id="CH123", channel="chat", profile_id="profile_123"
+            conversation_id="CH123", channel="CHAT", profile_id="profile_123"
         )
 
         await channel.process_webhook(
@@ -250,7 +249,7 @@ class TestChatChannel:
         tac.on_conversation_ended(lambda ctx: captured.append(ctx))
 
         channel._conversations["CH123"] = ConversationSession(
-            conversation_id="CH123", channel="chat", profile_id="profile_123"
+            conversation_id="CH123", channel="CHAT", profile_id="profile_123"
         )
         await channel.process_webhook(
             create_conversation_updated_webhook("CH123", "CLOSED", "2025-11-18T00:10:00.000Z")
@@ -258,7 +257,7 @@ class TestChatChannel:
 
         assert len(captured) == 1
         assert captured[0].conversation_id == "CH123"
-        assert captured[0].channel == "chat"
+        assert captured[0].channel == "CHAT"
 
     @pytest.mark.asyncio
     async def test_send_response_uses_stashed_ids(self) -> None:
@@ -269,7 +268,7 @@ class TestChatChannel:
         # Session is pre-populated as if reconcile (or outbound initiation) ran.
         channel._conversations["CH123"] = ConversationSession(
             conversation_id="CH123",
-            channel="chat",
+            channel="CHAT",
             author_info=AuthorInfo(address="user@example.com", participant_id="PA_USER"),
             ai_agent_info=AuthorInfo(address="ai-assistant", participant_id="PA_AGENT"),
             metadata={"channel_id": "CH_CHAT_SID_123"},
@@ -309,7 +308,7 @@ class TestChatChannel:
 
         channel._conversations["CH123"] = ConversationSession(
             conversation_id="CH123",
-            channel="chat",
+            channel="CHAT",
             author_info=AuthorInfo(address="user@example.com", participant_id="PA_USER"),
             ai_agent_info=AuthorInfo(address="ai-assistant", participant_id="PA_AGENT"),
             metadata={},  # No channel_id
@@ -329,7 +328,7 @@ class TestChatChannel:
 
         channel._conversations["CH123"] = ConversationSession(
             conversation_id="CH123",
-            channel="chat",
+            channel="CHAT",
             author_info=AuthorInfo(address="user@example.com", participant_id="PA_USER"),
             # ai_agent_info is intentionally missing
             metadata={"channel_id": "CH_CHAT_SID_123"},
@@ -420,7 +419,7 @@ class TestChatChannel:
         # Pre-seed session with profile_id so retrieve_memory skips the
         # lookup_profile fallback path.
         channel._conversations["CH123"] = ConversationSession(
-            conversation_id="CH123", channel="chat", profile_id="profile_test_123"
+            conversation_id="CH123", channel="CHAT", profile_id="profile_test_123"
         )
         tac.conversation_memory_client.get_profile = AsyncMock(
             side_effect=Exception("skip profile")

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -127,7 +127,7 @@ class TestCreateStudioHandoffTool:
     def test_returns_tac_tool(self) -> None:
         """Test that create_studio_handoff_tool returns a TACTool."""
         tac = TAC(get_test_config())
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         assert isinstance(tool, TACTool)
@@ -135,7 +135,7 @@ class TestCreateStudioHandoffTool:
     def test_tool_name_is_handoff(self) -> None:
         """Test that the tool is named 'handoff'."""
         tac = TAC(get_test_config())
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         assert tool.name == "handoff"
@@ -143,7 +143,7 @@ class TestCreateStudioHandoffTool:
     def test_schema_only_shows_reason(self) -> None:
         """Test that the LLM schema only exposes the 'reason' parameter."""
         tac = TAC(get_test_config())
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
 
@@ -157,7 +157,7 @@ class TestCreateStudioHandoffTool:
     def test_openai_format(self) -> None:
         """Test OpenAI format output."""
         tac = TAC(get_test_config())
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         openai_fmt = tool.to_openai_format()
@@ -169,7 +169,7 @@ class TestCreateStudioHandoffTool:
     def test_anthropic_format(self) -> None:
         """Test Anthropic format output."""
         tac = TAC(get_test_config())
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         anthropic_fmt = tool.to_anthropic_format()
@@ -192,7 +192,7 @@ class TestHandoffExecution:
         session = ConversationSession(
             conversation_id="conv_123",
             profile_id="prof_456",
-            channel="voice",
+            channel="VOICE",
         )
 
         tool = create_studio_handoff_tool(tac, session)
@@ -208,7 +208,7 @@ class TestHandoffExecution:
         assert handoff_data["profileId"] == "prof_456"
         assert handoff_data["attributes"]["reason"] == "Customer wants human agent"
 
-        assert result == {"status": "handoff_initiated", "channel": "voice"}
+        assert result == {"status": "handoff_initiated", "channel": "VOICE"}
 
     @pytest.mark.asyncio
     async def test_handoff_sets_conversation_inactive(self) -> None:
@@ -217,7 +217,7 @@ class TestHandoffExecution:
         tac.conversation_orchestrator_client.update_conversation = AsyncMock()
         tac.conversation_orchestrator_client.clear_status_callbacks = AsyncMock()
 
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         await tool(reason="Escalation needed")
@@ -247,7 +247,7 @@ class TestHandoffExecution:
         post_mock = AsyncMock()
         monkeypatch.setattr(handoff_module, "post_studio_handoff", post_mock)
 
-        session = ConversationSession(conversation_id="conv_123", channel="sms")
+        session = ConversationSession(conversation_id="conv_123", channel="SMS")
 
         tool = create_studio_handoff_tool(tac, session)
         result = await tool(reason="Customer wants human")
@@ -267,12 +267,12 @@ class TestHandoffExecution:
 
         # Digital channels should NOT store pending handoff data
         assert session.pending_handoff_data is None
-        assert result == {"status": "handoff_initiated", "channel": "sms"}
+        assert result == {"status": "handoff_initiated", "channel": "SMS"}
 
     def test_factory_raises_without_flow_sid(self) -> None:
         """Factory rejects missing studio_handoff_flow_sid — it's misconfig, not a soft fallback."""
         tac = TAC(get_test_config(studio_handoff_flow_sid=None))
-        session = ConversationSession(conversation_id="conv_123", channel="sms")
+        session = ConversationSession(conversation_id="conv_123", channel="SMS")
 
         with pytest.raises(ValueError, match="studio_handoff_flow_sid"):
             create_studio_handoff_tool(tac, session)
@@ -280,7 +280,7 @@ class TestHandoffExecution:
     def test_factory_raises_in_relay_only_mode(self) -> None:
         """Factory rejects relay-only TAC — orchestrator and memory are required."""
         tac = TAC(get_test_config(conversation_configuration_id=None))
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         with pytest.raises(ValueError, match="Conversation Orchestrator"):
             create_studio_handoff_tool(tac, session)
@@ -289,7 +289,7 @@ class TestHandoffExecution:
         """Factory rejects TAC with orchestrator but no memory store."""
         tac = TAC(get_test_config())
         tac.conversation_memory_client = None
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         with pytest.raises(ValueError, match="memory store ID"):
             create_studio_handoff_tool(tac, session)
@@ -306,13 +306,13 @@ class TestHandoffExecution:
         post_mock = AsyncMock(side_effect=httpx.HTTPError("boom"))
         monkeypatch.setattr(handoff_module, "post_studio_handoff", post_mock)
 
-        session = ConversationSession(conversation_id="conv_123", channel="sms")
+        session = ConversationSession(conversation_id="conv_123", channel="SMS")
 
         tool = create_studio_handoff_tool(tac, session)
         result = await tool(reason="Customer wants human")
 
         assert result["status"] == "handoff_failed"
-        assert result["channel"] == "sms"
+        assert result["channel"] == "SMS"
         assert "boom" in result["error"]
 
     @pytest.mark.asyncio
@@ -322,11 +322,11 @@ class TestHandoffExecution:
         tac.conversation_orchestrator_client.update_conversation = AsyncMock()
         tac.conversation_orchestrator_client.clear_status_callbacks = AsyncMock()
 
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         result = await tool(reason="test")
-        assert result["channel"] == "voice"
+        assert result["channel"] == "VOICE"
 
     @pytest.mark.asyncio
     async def test_handoff_includes_store_id_from_memory_client(self) -> None:
@@ -339,7 +339,7 @@ class TestHandoffExecution:
         session = ConversationSession(
             conversation_id="conv_123",
             profile_id="prof_456",
-            channel="voice",
+            channel="VOICE",
         )
 
         tool = create_studio_handoff_tool(tac, session)
@@ -358,7 +358,7 @@ class TestHandoffExecution:
 
         session = ConversationSession(
             conversation_id="conv_123",
-            channel="voice",
+            channel="VOICE",
         )
 
         tool = create_studio_handoff_tool(tac, session)
@@ -377,11 +377,11 @@ class TestHandoffExecution:
         )
         tac.conversation_orchestrator_client.clear_status_callbacks = AsyncMock()
 
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         result = await tool(reason="test")
-        assert result == {"status": "handoff_initiated", "channel": "voice"}
+        assert result == {"status": "handoff_initiated", "channel": "VOICE"}
 
         # Payload should still be stored on session
         assert session.pending_handoff_data is not None
@@ -393,7 +393,7 @@ class TestHandoffExecution:
         tac.conversation_orchestrator_client.update_conversation = AsyncMock()
         tac.conversation_orchestrator_client.clear_status_callbacks = AsyncMock()
 
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         await tool(reason="test")
@@ -421,7 +421,7 @@ class TestHandoffExecution:
             side_effect=track_clear
         )
 
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         await tool(reason="test")
@@ -439,11 +439,11 @@ class TestHandoffExecution:
             side_effect=Exception("API error")
         )
 
-        session = ConversationSession(conversation_id="conv_123", channel="voice")
+        session = ConversationSession(conversation_id="conv_123", channel="VOICE")
 
         tool = create_studio_handoff_tool(tac, session)
         result = await tool(reason="test")
-        assert result == {"status": "handoff_initiated", "channel": "voice"}
+        assert result == {"status": "handoff_initiated", "channel": "VOICE"}
 
         # Payload should still be stored
         assert session.pending_handoff_data is not None
@@ -462,7 +462,7 @@ class TestHandoffAttributes:
         session = ConversationSession(
             conversation_id="conv_123",
             profile_id="prof_456",
-            channel="voice",
+            channel="VOICE",
         )
 
         tool = create_studio_handoff_tool(
@@ -487,7 +487,7 @@ class TestHandoffAttributes:
 
         session = ConversationSession(
             conversation_id="conv_123",
-            channel="voice",
+            channel="VOICE",
         )
 
         tool = create_studio_handoff_tool(tac, session)
@@ -506,7 +506,7 @@ class TestHandoffAttributes:
 
         session = ConversationSession(
             conversation_id="conv_123",
-            channel="voice",
+            channel="VOICE",
         )
 
         tool = create_studio_handoff_tool(
@@ -530,7 +530,7 @@ class TestBuildHandoffPayload:
         session = ConversationSession(
             conversation_id="conv_123",
             profile_id="prof_456",
-            channel="voice",
+            channel="VOICE",
         )
         payload = build_handoff_payload(
             session=session,
@@ -548,7 +548,7 @@ class TestBuildHandoffPayload:
         """Test payload has empty profile_id when not set on session."""
         session = ConversationSession(
             conversation_id="conv_123",
-            channel="voice",
+            channel="VOICE",
         )
         payload = build_handoff_payload(
             session=session,
@@ -602,7 +602,7 @@ class TestPostStudioHandoff:
 
         session = ConversationSession(
             conversation_id="conv_123",
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(address="+15559998888"),
         )
         payload = self._make_payload()
@@ -656,7 +656,7 @@ class TestPostStudioHandoff:
 
         self._install_mock_transport(monkeypatch, handler)
 
-        session = ConversationSession(conversation_id="conv_123", channel="sms")
+        session = ConversationSession(conversation_id="conv_123", channel="SMS")
         payload = self._make_payload()
 
         await post_studio_handoff(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -206,7 +206,7 @@ class TestTACIntegration:
         assert callback_invoked
         assert received_context is not None
         assert received_context.conversation_id == "CH123456"
-        assert received_context.channel == "sms"
+        assert received_context.channel == "SMS"
         assert received_context.profile_id == "profile_test_123"
         assert isinstance(received_memories, TACMemoryResponse)
 
@@ -299,7 +299,7 @@ class TestTACIntegration:
         channel = SMSChannel(tac)
 
         channel._conversations["CH222"] = ConversationSession(
-            conversation_id="CH222", channel="sms"
+            conversation_id="CH222", channel="SMS"
         )
 
         await channel.process_webhook(
@@ -433,7 +433,7 @@ class TestTACIntegration:
         assert callback_invoked
         assert received_context is not None
         assert received_context.conversation_id == conv_id
-        assert received_context.channel == "sms"
+        assert received_context.channel == "SMS"
 
     @pytest.mark.asyncio
     async def test_sms_channel_posts_agent_on_solo_customer_inbound(self) -> None:

--- a/tests/test_interrupt.py
+++ b/tests/test_interrupt.py
@@ -36,7 +36,7 @@ class TestInterruptCallbacks:
 
         tac.on_interrupt(sync_handler)
 
-        context = ConversationSession(conversation_id="conv123", channel="voice")
+        context = ConversationSession(conversation_id="conv123", channel="VOICE")
         interrupt = InterruptMessage(
             type="interrupt",
             utteranceUntilInterrupt="Hello",
@@ -75,7 +75,7 @@ class TestInterruptCallbacks:
 
         tac.on_interrupt(callback_returning_task)
 
-        context = ConversationSession(conversation_id="conv456", channel="voice")
+        context = ConversationSession(conversation_id="conv456", channel="VOICE")
         interrupt = InterruptMessage(
             type="interrupt",
             utteranceUntilInterrupt="Test",
@@ -107,7 +107,7 @@ class TestInterruptCallbacks:
 
         tac.on_interrupt(async_handler)
 
-        context = ConversationSession(conversation_id="conv789", channel="voice")
+        context = ConversationSession(conversation_id="conv789", channel="VOICE")
         interrupt = InterruptMessage(
             type="interrupt",
             utteranceUntilInterrupt="Test",
@@ -139,7 +139,7 @@ class TestInterruptCallbacks:
 
         tac.on_interrupt(async_handler)
 
-        context = ConversationSession(conversation_id="conv999", channel="voice")
+        context = ConversationSession(conversation_id="conv999", channel="VOICE")
         interrupt = InterruptMessage(
             type="interrupt",
             utteranceUntilInterrupt="Test",
@@ -166,7 +166,7 @@ class TestInterruptCallbacks:
         tac = TAC(get_test_config())
 
         # Don't register any callback
-        context = ConversationSession(conversation_id="conv_no_cb", channel="voice")
+        context = ConversationSession(conversation_id="conv_no_cb", channel="VOICE")
         interrupt = InterruptMessage(
             type="interrupt",
             utteranceUntilInterrupt="Test",
@@ -186,7 +186,7 @@ class TestInterruptCallbacks:
 
         tac.on_interrupt(failing_handler)
 
-        context = ConversationSession(conversation_id="conv_fail", channel="voice")
+        context = ConversationSession(conversation_id="conv_fail", channel="VOICE")
         interrupt = InterruptMessage(
             type="interrupt",
             utteranceUntilInterrupt="Test",
@@ -212,7 +212,7 @@ class TestInterruptCallbacks:
 
         tac.on_interrupt(failing_async_handler)
 
-        context = ConversationSession(conversation_id="conv_async_fail", channel="voice")
+        context = ConversationSession(conversation_id="conv_async_fail", channel="VOICE")
         interrupt = InterruptMessage(
             type="interrupt",
             utteranceUntilInterrupt="Test",
@@ -257,7 +257,7 @@ class TestInterruptCallbacks:
 
         tac.on_interrupt(callback_returning_future)
 
-        context = ConversationSession(conversation_id="conv_future", channel="voice")
+        context = ConversationSession(conversation_id="conv_future", channel="VOICE")
         interrupt = InterruptMessage(
             type="interrupt",
             utteranceUntilInterrupt="Test",
@@ -294,7 +294,7 @@ class TestInterruptCallbacks:
         wrapped_handler = partial(async_handler_with_extra_arg, "test_extra")
         tac.on_interrupt(wrapped_handler)
 
-        context = ConversationSession(conversation_id="conv_wrapped", channel="voice")
+        context = ConversationSession(conversation_id="conv_wrapped", channel="VOICE")
         interrupt = InterruptMessage(
             type="interrupt",
             utteranceUntilInterrupt="Test",

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -131,7 +131,7 @@ def sample_context() -> ConversationSession:
     return ConversationSession(
         conversation_id="conv123",
         profile_id="prof456",
-        channel="sms",
+        channel="SMS",
         profile=ProfileResponse(
             id="prof456",
             createdAt="2024-01-01T00:00:00Z",
@@ -321,7 +321,7 @@ def test_multiple_wrappers_no_memory_bleeding(
 
     context_1 = sample_context
     context_2 = ConversationSession(
-        conversation_id="conv456", profile_id="prof789", channel="voice"
+        conversation_id="conv456", profile_id="prof789", channel="VOICE"
     )
 
     wrapper_1 = with_tac_memory(mock_openai_client, memory_1, context_1)

--- a/tests/test_outbound.py
+++ b/tests/test_outbound.py
@@ -185,7 +185,7 @@ class TestSMSOutbound:
         )
 
         assert result.conversation_id == "CHsms_out"
-        assert result.session.channel == "sms"
+        assert result.session.channel == "SMS"
         assert result.session.metadata["direction"] == "outbound"
         assert result.session.author_info is not None
         assert result.session.author_info.address == "+15559876543"
@@ -351,7 +351,7 @@ class TestChatOutbound:
         )
 
         assert result.conversation_id == "CHchat_out"
-        assert result.session.channel == "chat"
+        assert result.session.channel == "CHAT"
         assert result.session.metadata["direction"] == "outbound"
         assert result.session.metadata["channel_id"] == "CHSIDabc"
         tac.conversation_orchestrator_client.create_action.assert_called_once()
@@ -868,7 +868,7 @@ class TestRCSOutbound:
         )
 
         assert result.conversation_id == "CHrcs_out"
-        assert result.session.channel == "rcs"
+        assert result.session.channel == "RCS"
         assert result.session.metadata["direction"] == "outbound"
         assert result.session.author_info is not None
         assert result.session.author_info.address == "rcs:+15559876543"
@@ -967,7 +967,7 @@ class TestWhatsAppOutbound:
         )
 
         assert result.conversation_id == "CHwhatsapp_out"
-        assert result.session.channel == "whatsapp"
+        assert result.session.channel == "WHATSAPP"
         assert result.session.metadata["direction"] == "outbound"
         assert result.session.author_info is not None
         assert result.session.author_info.address == "whatsapp:+15559876543"

--- a/tests/test_profile_lookup_in_memory.py
+++ b/tests/test_profile_lookup_in_memory.py
@@ -57,7 +57,7 @@ class TestProfileLookupInMemoryRetrieval:
         session = ConversationSession(
             conversation_id="conv_test_123",
             profile_id="mem_profile_existing",
-            channel="sms",
+            channel="SMS",
         )
 
         # Retrieve memory
@@ -106,7 +106,7 @@ class TestProfileLookupInMemoryRetrieval:
         session = ConversationSession(
             conversation_id="conv_test_123",
             profile_id=None,  # No profile_id
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(
                 address="+1 (317) 555-6789",
                 participant_id="participant_123",
@@ -170,7 +170,7 @@ class TestProfileLookupInMemoryRetrieval:
         session = ConversationSession(
             conversation_id="conv_test_123",
             profile_id=None,
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(address="+13175556789"),
         )
 
@@ -234,7 +234,7 @@ class TestProfileLookupInMemoryRetrieval:
         session = ConversationSession(
             conversation_id="conv_test_123",
             profile_id=None,
-            channel="sms",
+            channel="SMS",
             author_info=None,  # No author info
         )
 
@@ -290,7 +290,7 @@ class TestProfileLookupInMemoryRetrieval:
         session = ConversationSession(
             conversation_id="conv_test_123",
             profile_id=None,
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(
                 address="",  # Empty address
                 participant_id="participant_123",
@@ -357,7 +357,7 @@ class TestProfileLookupInMemoryRetrieval:
         session = ConversationSession(
             conversation_id="conv_test_123",
             profile_id=None,
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(address="+13175556789"),
         )
 
@@ -419,7 +419,7 @@ class TestProfileLookupInMemoryRetrieval:
         session = ConversationSession(
             conversation_id="conv_test_123",
             profile_id=None,
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(address="+13175556789"),
         )
 
@@ -454,7 +454,7 @@ class TestProfileLookupInMemoryRetrieval:
         session = ConversationSession(
             conversation_id="conv_test_123",
             profile_id=None,
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(address="+13175556789"),
         )
 
@@ -490,7 +490,7 @@ class TestProfileLookupInMemoryRetrieval:
         session = ConversationSession(
             conversation_id="conv_test_123",
             profile_id=None,
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(
                 address="+1 (317) 555-6789"  # Formatted input
             ),

--- a/tests/test_profile_retrieval.py
+++ b/tests/test_profile_retrieval.py
@@ -133,7 +133,7 @@ class TestProfileFetchingInRetrieveMemory:
         context = ConversationSession(
             conversation_id="conv123",
             profile_id="profile_test_123",
-            channel="sms",
+            channel="SMS",
         )
 
         await tac.retrieve_memory(context)
@@ -165,7 +165,7 @@ class TestProfileFetchingInRetrieveMemory:
         context = ConversationSession(
             conversation_id="conv123",
             profile_id="profile_test_123",
-            channel="sms",
+            channel="SMS",
         )
 
         await tac.retrieve_memory(context)
@@ -199,7 +199,7 @@ class TestProfileFetchingInRetrieveMemory:
         context = ConversationSession(
             conversation_id="conv123",
             profile_id="profile_test_123",
-            channel="sms",
+            channel="SMS",
         )
 
         # Should not raise - exception is swallowed and memory retrieval continues
@@ -383,7 +383,7 @@ class TestProfileInConversationSession:
         session = ConversationSession(
             conversation_id="CH123456",
             profile_id="profile_test_123",
-            channel="sms",
+            channel="SMS",
             profile=mock_profile,
         )
 
@@ -396,7 +396,7 @@ class TestProfileInConversationSession:
         session = ConversationSession(
             conversation_id="CH123456",
             profile_id="profile_test_123",
-            channel="sms",
+            channel="SMS",
             profile=None,
         )
 
@@ -407,7 +407,7 @@ class TestProfileInConversationSession:
         session = ConversationSession(
             conversation_id="CH123456",
             profile_id="profile_test_123",
-            channel="sms",
+            channel="SMS",
             profile=None,  # Explicitly set to None (also the default)
         )
 

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -43,7 +43,7 @@ def sample_context() -> ConversationSession:
     return ConversationSession(
         conversation_id="conv1",
         profile_id="profile1",
-        channel="sms",
+        channel="SMS",
         profile=profile,
         phone_number="+1234567890",
     )

--- a/tests/test_rcs_channel.py
+++ b/tests/test_rcs_channel.py
@@ -118,7 +118,7 @@ def rcs_channel(mock_tac: TAC) -> RCSChannel:
 async def test_rcs_channel_initialization(mock_tac: TAC) -> None:
     """Test RCS channel initialization succeeds with rcs_sender_id in TAC config."""
     channel = RCSChannel(mock_tac)
-    assert channel.get_channel_name() == "rcs"
+    assert channel.get_channel_name() == "RCS"
 
 
 @pytest.mark.asyncio
@@ -126,8 +126,7 @@ async def test_rcs_channel_initialization_with_config(mock_tac: TAC) -> None:
     """Test RCS channel initialization with explicit config."""
     config = RCSChannelConfig()
     channel = RCSChannel(mock_tac, config=config)
-    assert channel.get_channel_name() == "rcs"
-    assert channel.get_channel_type_upper() == "RCS"
+    assert channel.get_channel_name() == "RCS"
 
 
 @pytest.mark.asyncio

--- a/tests/test_relay_only_mode.py
+++ b/tests/test_relay_only_mode.py
@@ -74,7 +74,7 @@ class TestRelayOnlyMode:
         session = ConversationSession(
             conversation_id="CA_relay_only",
             profile_id=None,
-            channel="voice",
+            channel="VOICE",
         )
 
         response = await tac.retrieve_memory(session)

--- a/tests/test_sms_channel.py
+++ b/tests/test_sms_channel.py
@@ -212,7 +212,7 @@ class TestSMSChannel:
         assert captured_context.conversation_id == "CH123456"
         # No profile_id since message auto-initialized without participant.added event
         assert captured_context.profile_id is None
-        assert captured_context.channel == "sms"
+        assert captured_context.channel == "SMS"
 
     @pytest.mark.asyncio
     async def test_process_message_with_existing_conversation(self) -> None:
@@ -327,7 +327,7 @@ class TestSMSChannel:
 
         channel._conversations["CH123456"] = ConversationSession(
             conversation_id="CH123456",
-            channel="sms",
+            channel="SMS",
             profile_id="profile_test_123",
         )
 
@@ -348,7 +348,7 @@ class TestSMSChannel:
         # Session is pre-populated as if reconcile (or outbound initiation) ran.
         channel._conversations["CH123456"] = ConversationSession(
             conversation_id="CH123456",
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(address="+12345678901", participant_id="PA_CUSTOMER"),
             ai_agent_info=AuthorInfo(address="+15551234567", participant_id="PA_AGENT"),
         )
@@ -388,7 +388,7 @@ class TestSMSChannel:
         # (as inbound ingestion + reconcile would).
         channel._conversations["CH_WITH_CH_ID"] = ConversationSession(
             conversation_id="CH_WITH_CH_ID",
-            channel="sms",
+            channel="SMS",
             author_info=AuthorInfo(address="+12345678901", participant_id="PA_CUSTOMER"),
             ai_agent_info=AuthorInfo(address="+15551234567", participant_id="PA_AGENT"),
             metadata={"channel_id": "SMabcdef"},
@@ -411,10 +411,10 @@ class TestSMSChannel:
         channel = SMSChannel(tac)
 
         channel._conversations["CH111"] = ConversationSession(
-            conversation_id="CH111", channel="sms", profile_id="PR111"
+            conversation_id="CH111", channel="SMS", profile_id="PR111"
         )
         channel._conversations["CH222"] = ConversationSession(
-            conversation_id="CH222", channel="sms", profile_id="PR222"
+            conversation_id="CH222", channel="SMS", profile_id="PR222"
         )
 
         # Verify both conversations tracked.
@@ -458,7 +458,7 @@ class TestSMSChannel:
         tac.on_conversation_ended(handler)
 
         channel._conversations["CH_CB1"] = ConversationSession(
-            conversation_id="CH_CB1", channel="sms", profile_id="prof_cb1"
+            conversation_id="CH_CB1", channel="SMS", profile_id="prof_cb1"
         )
 
         # Close conversation
@@ -469,7 +469,7 @@ class TestSMSChannel:
         assert len(captured) == 1
         assert captured[0].conversation_id == "CH_CB1"
         assert captured[0].profile_id == "prof_cb1"
-        assert captured[0].channel == "sms"
+        assert captured[0].channel == "SMS"
 
     @pytest.mark.asyncio
     async def test_conversation_ended_callback_error_does_not_prevent_cleanup(self) -> None:
@@ -483,7 +483,7 @@ class TestSMSChannel:
         tac.on_conversation_ended(bad_handler)
 
         channel._conversations["CH_CB2"] = ConversationSession(
-            conversation_id="CH_CB2", channel="sms", profile_id="prof_cb2"
+            conversation_id="CH_CB2", channel="SMS", profile_id="prof_cb2"
         )
         await channel.process_webhook(
             create_conversation_updated_webhook("CH_CB2", "CLOSED", "2025-11-18T00:10:00.000Z")
@@ -505,7 +505,7 @@ class TestSMSChannel:
         tac.on_conversation_ended(async_handler)
 
         channel._conversations["CH_ASYNC1"] = ConversationSession(
-            conversation_id="CH_ASYNC1", channel="sms", profile_id="prof_async1"
+            conversation_id="CH_ASYNC1", channel="SMS", profile_id="prof_async1"
         )
         await channel.process_webhook(
             create_conversation_updated_webhook("CH_ASYNC1", "CLOSED", "2025-11-18T00:10:00.000Z")
@@ -513,7 +513,7 @@ class TestSMSChannel:
 
         assert len(captured) == 1
         assert captured[0].conversation_id == "CH_ASYNC1"
-        assert captured[0].channel == "sms"
+        assert captured[0].channel == "SMS"
 
     @pytest.mark.asyncio
     async def test_conversation_ended_no_callback_registered(self) -> None:
@@ -523,7 +523,7 @@ class TestSMSChannel:
 
         # No callback registered — should not raise
         channel._conversations["CH_NOCB"] = ConversationSession(
-            conversation_id="CH_NOCB", channel="sms", profile_id="prof_nocb"
+            conversation_id="CH_NOCB", channel="SMS", profile_id="prof_nocb"
         )
         await channel.process_webhook(
             create_conversation_updated_webhook("CH_NOCB", "CLOSED", "2025-11-18T00:10:00.000Z")
@@ -541,7 +541,7 @@ class TestSMSChannel:
         # ai_agent_info is set, but author_info is missing — misuse.
         channel._conversations["CH123456"] = ConversationSession(
             conversation_id="CH123456",
-            channel="sms",
+            channel="SMS",
             ai_agent_info=AuthorInfo(address="+15551234567", participant_id="PA_AGENT"),
         )
 

--- a/tests/test_tac.py
+++ b/tests/test_tac.py
@@ -89,7 +89,7 @@ class TestTAC:
         session = ConversationSession(
             conversation_id="CH123",
             profile_id="prof123",
-            channel="sms",
+            channel="SMS",
         )
 
         with pytest.raises(
@@ -114,7 +114,7 @@ class TestTAC:
         session = ConversationSession(
             conversation_id="CH123",
             profile_id="prof123",
-            channel="sms",
+            channel="SMS",
         )
 
         with pytest.raises(
@@ -139,7 +139,7 @@ class TestTAC:
         session = ConversationSession(
             conversation_id="CH123",
             profile_id="prof123",
-            channel="sms",
+            channel="SMS",
         )
 
         with pytest.raises(
@@ -164,7 +164,7 @@ class TestTAC:
         session = ConversationSession(
             conversation_id="CH123",
             profile_id="prof123",
-            channel="sms",
+            channel="SMS",
         )
 
         result = await tac.trigger_message_ready("test message", session, None)
@@ -186,7 +186,7 @@ class TestTAC:
         session = ConversationSession(
             conversation_id="CH123",
             profile_id="prof123",
-            channel="sms",
+            channel="SMS",
         )
 
         result = await tac.trigger_message_ready("test message", session, None)
@@ -209,7 +209,7 @@ class TestTAC:
         session = ConversationSession(
             conversation_id="CH123",
             profile_id="prof123",
-            channel="sms",
+            channel="SMS",
         )
 
         result = await tac.trigger_message_ready("test message", session, None)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -476,7 +476,7 @@ class TestMemoryTools:
         mock_memory_client = MagicMock(spec=MemoryClient)
 
         session = ConversationSession(
-            profile_id="prof_123", conversation_id="conv_123", channel="sms"
+            profile_id="prof_123", conversation_id="conv_123", channel="SMS"
         )
 
         tool = create_memory_tool(mock_memory_client, session)
@@ -489,7 +489,7 @@ class TestMemoryTools:
         mock_memory_client = MagicMock(spec=MemoryClient)
 
         session = ConversationSession(
-            profile_id="prof_123", conversation_id="conv_123", channel="sms"
+            profile_id="prof_123", conversation_id="conv_123", channel="SMS"
         )
 
         memory_tool = create_memory_tool(mock_memory_client, session)
@@ -512,7 +512,7 @@ class TestMemoryTools:
         mock_memory_client.retrieve_memory = MagicMock(side_effect=mock_retrieve)
 
         session = ConversationSession(
-            profile_id="prof_123", conversation_id="conv_123", channel="sms"
+            profile_id="prof_123", conversation_id="conv_123", channel="SMS"
         )
 
         memory_tool = create_memory_tool(mock_memory_client, session)
@@ -537,8 +537,8 @@ class TestMemoryTools:
         mock_client1 = MagicMock(spec=MemoryClient)
         mock_client2 = MagicMock(spec=MemoryClient)
 
-        session1 = ConversationSession(profile_id="prof_1", conversation_id="conv_1", channel="sms")
-        session2 = ConversationSession(profile_id="prof_2", conversation_id="conv_2", channel="sms")
+        session1 = ConversationSession(profile_id="prof_1", conversation_id="conv_1", channel="SMS")
+        session2 = ConversationSession(profile_id="prof_2", conversation_id="conv_2", channel="SMS")
 
         tool1 = create_memory_tool(mock_client1, session1)
         tool2 = create_memory_tool(mock_client2, session2)
@@ -566,7 +566,7 @@ class TestMemoryTools:
         mock_memory_client.retrieve_memory = MagicMock(side_effect=mock_retrieve)
 
         session = ConversationSession(
-            profile_id="prof_123", conversation_id="conv_123", channel="sms"
+            profile_id="prof_123", conversation_id="conv_123", channel="SMS"
         )
 
         memory_tool = create_memory_tool(mock_memory_client, session)

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -50,7 +50,7 @@ class TestVoiceChannel:
         tac = TAC(get_test_config())
         channel = VoiceChannel(tac)
 
-        assert channel.get_channel_name() == "voice"
+        assert channel.get_channel_name() == "VOICE"
 
     @pytest.mark.asyncio
     async def test_handle_prompt_message_without_memory_retrieval(self) -> None:
@@ -472,7 +472,7 @@ class TestVoiceChannel:
         assert captured_context is not None
         assert captured_context.conversation_id == "CALL123"
         assert captured_context.profile_id == "profile_test"
-        assert captured_context.channel == "voice"
+        assert captured_context.channel == "VOICE"
         # Voice channel doesn't fetch memory, so it should be None
         assert captured_memories is None
         assert captured_user_message == "Test message"
@@ -1018,7 +1018,7 @@ class TestVoiceChannel:
         # Callback should be triggered
         assert len(captured) == 1
         assert captured[0].conversation_id == "CALL_ASYNC1"
-        assert captured[0].channel == "voice"
+        assert captured[0].channel == "VOICE"
         # Conversation should be removed
         assert "CALL_ASYNC1" not in channel._conversations
 

--- a/tests/test_whatsapp_channel.py
+++ b/tests/test_whatsapp_channel.py
@@ -118,7 +118,7 @@ def whatsapp_channel(mock_tac: TAC) -> WhatsAppChannel:
 async def test_whatsapp_channel_initialization(mock_tac: TAC) -> None:
     """Test WhatsApp channel initialization succeeds with whatsapp_number in TAC config."""
     channel = WhatsAppChannel(mock_tac)
-    assert channel.get_channel_name() == "whatsapp"
+    assert channel.get_channel_name() == "WHATSAPP"
 
 
 @pytest.mark.asyncio
@@ -126,8 +126,7 @@ async def test_whatsapp_channel_initialization_with_config(mock_tac: TAC) -> Non
     """Test WhatsApp channel initialization with explicit config."""
     config = WhatsAppChannelConfig()
     channel = WhatsAppChannel(mock_tac, config=config)
-    assert channel.get_channel_name() == "whatsapp"
-    assert channel.get_channel_type_upper() == "WHATSAPP"
+    assert channel.get_channel_name() == "WHATSAPP"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`get_channel_name()` now returns the uppercase `ChannelType` Literal (`"SMS"`, `"VOICE"`, `"RCS"`, `"WHATSAPP"`, `"CHAT"`) that matches Twilio's channel enum, instead of a lowercase `str`. This lets the channel string flow through webhook filtering, API payloads, and session storage in a single consistent form — no more `.upper()`/`.lower()` juggling and no type-checker friction at `ParticipantAddress(channel=...)`.

**What changed:**
- Removed `get_channel_type_upper()` and every `.upper()`/`.lower()` conversion on the channel name.
- Centralized the channel-type `Literal`, previously duplicated across 5 model fields, into one shared `ChannelType` alias in `models/conversation.py`.
- Typed `ConversationSession.channel` and `get_channel_name()` as `ChannelType`.
- Simplified the dashboard example (`session.channel` is now always populated, so the lowercase fallback helper was dead code).

**⚠️ Breaking change:** `ConversationSession.channel` and `get_channel_name()` now return uppercase (e.g. `"SMS"` not `"sms"`). Consumers comparing `session.channel == "voice"` must switch to `"VOICE"`.

## Type of Change

- [x] Breaking change
- [x] Refactoring

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **Python SDK**. This change affects shared channel-type behavior — the TypeScript SDK should be reviewed for parity.

- [ ] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: