### PR TITLE
ci: pin jaraco.functools to avoid Artifactory 403 in build job

### DIFF
--- a/.github/ci-requirements.txt
+++ b/.github/ci-requirements.txt
@@ -1,0 +1,12 @@
+# Pinned versions for the "Check package metadata" step in ci.yml.
+#
+# jaraco.functools is pinned because the latest release isn't always mirrored
+# yet in Twilio's Artifactory virtual-pypi-thirdparty repo, which causes a 403
+# on download. twine is pinned alongside it to reduce future resolution drift.
+#
+# Dependabot watches this file (see dependabot.yml) and will open a PR when a
+# newer version is available on PyPI. Before merging such a PR, confirm the
+# new version is actually mirrored in Artifactory (re-run this workflow) —
+# Dependabot only checks PyPI, not Artifactory's mirror status.
+twine==6.2.0
+jaraco.functools==4.5.0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/.github"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
           # Pin jaraco.functools (a transitive dep via twine->keyring): the latest
           # release (4.6.0) isn't mirrored in Artifactory's virtual-pypi-thirdparty
           # repo yet and 403s on download. Remove this pin once 4.6.0+ is mirrored.
-          pip install twine "jaraco.functools==4.5.0"
+          pip install "twine==6.2.0" "jaraco.functools==4.5.0"
           twine check dist/*
 
       - name: Test package installation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,9 @@ jobs:
         run: |
           uv venv
           . .venv/bin/activate
+          # Pin jaraco.functools (a transitive dep via twine->keyring): the latest
+          # release (4.6.0) isn't mirrored in Artifactory's virtual-pypi-thirdparty
+          # repo yet and 403s on download. Remove this pin once 4.6.0+ is mirrored.
           pip install twine "jaraco.functools==4.5.0"
           twine check dist/*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,7 @@ jobs:
         run: |
           uv venv
           . .venv/bin/activate
-          # Pin jaraco.functools (a transitive dep via twine->keyring): the latest
-          # release (4.6.0) isn't mirrored in Artifactory's virtual-pypi-thirdparty
-          # repo yet and 403s on download. Remove this pin once 4.6.0+ is mirrored.
-          pip install "twine==6.2.0" "jaraco.functools==4.5.0"
+          pip install -r .github/ci-requirements.txt
           twine check dist/*
 
       - name: Test package installation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           uv venv
           . .venv/bin/activate
-          pip install twine
+          pip install twine "jaraco.functools==4.5.0"
           twine check dist/*
 
       - name: Test package installation


### PR DESCRIPTION
## Summary

- The `Build Package` job's `pip install twine` step was resolving `jaraco.functools` to the latest PyPI release (4.6.0), which isn't yet mirrored in Twilio's Artifactory `virtual-pypi-thirdparty` repo, causing the download to fail with HTTP 403.
- Pins `jaraco.functools==4.5.0`, the latest version confirmed present/downloadable in Artifactory, to unblock the CI pipeline.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Release / version bump

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [x] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->