### PR TITLE
fix(server): validate webhook body against bodySHA256 on JSON webhooks

### DIFF
--- a/src/tac/server/signature_validation.py
+++ b/src/tac/server/signature_validation.py
@@ -32,9 +32,9 @@ def validate_twilio_webhook(
         request: FastAPI Request object containing headers and URL info.
         auth_token: Twilio Auth Token used for signature validation.
         body: Request body - pass str for JSON bodies (SMS webhooks from Conversation Orchestrator,
-              where signature is computed with empty POST params), or pass a mapping
-              for form-encoded bodies (Voice webhooks, where params are included).
-              Accepts dict, FormData, or any Mapping[str, str].
+              where Twilio signs a ``bodySHA256`` query param and the raw body is hashed and
+              compared), or pass a mapping for form-encoded bodies (Voice webhooks, where params
+              are folded into the signature). Accepts dict, FormData, or any Mapping[str, str].
 
     Returns:
         True if signature is valid, False otherwise.
@@ -47,10 +47,16 @@ def validate_twilio_webhook(
 
     validator = RequestValidator(auth_token)
 
-    # For JSON bodies (string), Twilio signs with URL only (empty params).
-    # For form-encoded bodies (mapping), params are included in signature.
-    params = dict(body) if isinstance(body, Mapping) else {}
-    result: bool = validator.validate(url, params, signature)
+    # For JSON bodies (string), the raw body is passed so RequestValidator can verify
+    # it against the bodySHA256 query param Twilio signs. For form-encoded bodies
+    # (mapping), params are folded directly into the signature.
+    params = dict(body) if isinstance(body, Mapping) else body
+    try:
+        result: bool = validator.validate(url, params, signature)
+    except TypeError:
+        # String body without a bodySHA256 query param (not a genuine Twilio JSON
+        # webhook) — fail closed rather than error.
+        return False
     return result
 
 

--- a/src/tac/server/signature_validation.py
+++ b/src/tac/server/signature_validation.py
@@ -9,7 +9,7 @@ Requires: pip install tac[server]
 
 import logging
 from collections.abc import Awaitable, Callable, Mapping
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlsplit
 
 from fastapi import HTTPException, Request, WebSocket, WebSocketDisconnect
 from twilio.request_validator import RequestValidator
@@ -45,18 +45,21 @@ def validate_twilio_webhook(
 
     url = _build_url(request)
 
-    validator = RequestValidator(auth_token)
-
     # For JSON bodies (string), the raw body is passed so RequestValidator can verify
     # it against the bodySHA256 query param Twilio signs. For form-encoded bodies
     # (mapping), params are folded directly into the signature.
-    params = dict(body) if isinstance(body, Mapping) else body
-    try:
-        result: bool = validator.validate(url, params, signature)
-    except TypeError:
-        # String body without a bodySHA256 query param (not a genuine Twilio JSON
-        # webhook) — fail closed rather than error.
-        return False
+    if isinstance(body, Mapping):
+        params: str | dict[str, str] = dict(body)
+    else:
+        # A genuine Twilio JSON webhook always carries a bodySHA256 query param; without
+        # it RequestValidator can't hash the body, so fail closed rather than skip the
+        # body check. (RequestValidator also raises TypeError on a str body in this case.)
+        if "bodySHA256" not in parse_qs(urlsplit(url).query):
+            return False
+        params = body
+
+    validator = RequestValidator(auth_token)
+    result: bool = validator.validate(url, params, signature)
     return result
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -611,7 +611,10 @@ class TestTwiMLConnectAction:
         client = self._build_server(studio_handoff_flow_sid=flow_sid)
         resp = client.post(  # type: ignore[attr-defined]
             "/twiml",
-            headers={"X-Twilio-Signature": self._twiml_signature()},
+            headers={
+                "X-Twilio-Signature": self._twiml_signature(),
+                "content-type": "application/x-www-form-urlencoded",
+            },
         )
 
         assert resp.status_code == 200
@@ -628,7 +631,10 @@ class TestTwiMLConnectAction:
         client = self._build_server()  # no studio_handoff_flow_sid
         resp = client.post(  # type: ignore[attr-defined]
             "/twiml",
-            headers={"X-Twilio-Signature": self._twiml_signature()},
+            headers={
+                "X-Twilio-Signature": self._twiml_signature(),
+                "content-type": "application/x-www-form-urlencoded",
+            },
         )
 
         assert resp.status_code == 200

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,7 @@
 """Tests for TACFastAPIServer module."""
 
+from hashlib import sha256
+
 import pytest
 from twilio.request_validator import RequestValidator
 
@@ -26,6 +28,18 @@ def get_test_config() -> dict:
 def compute_signature(url: str, params: dict[str, str] | None = None) -> str:
     """Compute a valid Twilio signature for test requests."""
     return RequestValidator(AUTH_TOKEN).compute_signature(url, params or {})
+
+
+def sign_json_webhook(url: str, raw_body: bytes) -> tuple[str, str]:
+    """Sign a JSON webhook the way Twilio does: bodySHA256 query param over the raw body.
+
+    Returns ``(signed_url, signature)``. Post ``raw_body`` verbatim so the server's
+    body hash matches.
+    """
+    body_hash = sha256(raw_body).hexdigest()
+    sep = "&" if "?" in url else "?"
+    signed_url = f"{url}{sep}bodySHA256={body_hash}"
+    return signed_url, compute_signature(signed_url, {})
 
 
 class TestTACServerConfig:
@@ -257,14 +271,15 @@ class TestTACFastAPIServer:
             patch.object(sms, "process_webhook", new_callable=AsyncMock) as mock_sms,
             patch.object(chat, "process_webhook", new_callable=AsyncMock) as mock_chat,
         ):
-            url = "http://test/webhook"
-            signature = compute_signature(url)
+            raw_body = b'{"eventType": "COMMUNICATION_CREATED", "data": {}}'
+            signed_url, signature = sign_json_webhook("http://test/webhook", raw_body)
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
                 resp = await client.post(
-                    "/webhook",
-                    json={"eventType": "COMMUNICATION_CREATED", "data": {}},
+                    signed_url,
+                    content=raw_body,
                     headers={
+                        "content-type": "application/json",
                         "i-twilio-idempotency-token": "tok-123",
                         "X-Twilio-Signature": signature,
                     },
@@ -313,14 +328,15 @@ class TestTACFastAPIServer:
             ) as mock_sms,
             patch.object(chat, "process_webhook", new_callable=AsyncMock) as mock_chat,
         ):
-            url = "http://test/webhook"
-            signature = compute_signature(url)
+            raw_body = b'{"eventType": "COMMUNICATION_CREATED", "data": {}}'
+            signed_url, signature = sign_json_webhook("http://test/webhook", raw_body)
             transport = ASGITransport(app=app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
                 resp = await client.post(
-                    "/webhook",
-                    json={"eventType": "COMMUNICATION_CREATED", "data": {}},
+                    signed_url,
+                    content=raw_body,
                     headers={
+                        "content-type": "application/json",
                         "i-twilio-idempotency-token": "tok-456",
                         "X-Twilio-Signature": signature,
                     },
@@ -679,14 +695,17 @@ class TestSignatureValidation:
             messaging_channels=[sms],
         )
         with patch.object(sms, "process_webhook", new_callable=AsyncMock):
-            url = "http://test/webhook"
-            signature = compute_signature(url)
+            raw_body = b'{"eventType": "test"}'
+            signed_url, signature = sign_json_webhook("http://test/webhook", raw_body)
             transport = ASGITransport(app=server.app)
             async with AsyncClient(transport=transport, base_url="http://test") as client:
                 resp = await client.post(
-                    "/webhook",
-                    json={"eventType": "test"},
-                    headers={"X-Twilio-Signature": signature},
+                    signed_url,
+                    content=raw_body,
+                    headers={
+                        "content-type": "application/json",
+                        "X-Twilio-Signature": signature,
+                    },
                 )
         assert resp.status_code == 200
 

--- a/tests/test_webhook_validation.py
+++ b/tests/test_webhook_validation.py
@@ -1,5 +1,6 @@
 """Tests for Twilio webhook signature validation."""
 
+from hashlib import sha256
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -69,9 +70,60 @@ class TestValidateTwilioWebhook:
         assert validate_twilio_webhook(request, auth_token, body) is False
 
     def test_valid_string_body_signature(self) -> None:
-        """Test validation passes with correct signature for JSON/string body."""
+        """Test validation passes with correct signature for JSON/string body.
+
+        Mirrors the real Twilio JSON flow: Twilio signs a bodySHA256 query param and
+        the raw body is hashed and compared against it.
+        """
         auth_token = "test_auth_token"
         body_str = '{"event": "onMessageAdded", "conversationSid": "CH123"}'
+
+        validator = RequestValidator(auth_token)
+        query = f"bodySHA256={sha256(body_str.encode()).hexdigest()}"
+        url = f"https://example.com/webhook?{query}"
+        signature = validator.compute_signature(url, {})
+
+        request = MagicMock()
+        request.headers = {
+            "X-Twilio-Signature": signature,
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "example.com",
+        }
+        request.url.path = "/webhook"
+        request.url.query = query
+
+        assert validate_twilio_webhook(request, auth_token, body_str) is True
+
+    def test_forged_json_body_rejected(self) -> None:
+        """Regression test (SECOPS-25406): a captured signature must not accept a forged body.
+
+        Twilio signs the genuine body via bodySHA256. Replaying the signed URL/signature
+        with a different body must fail the body-hash check.
+        """
+        auth_token = "test_auth_token"
+        genuine_body = '{"event": "onMessageAdded", "conversationSid": "CH123"}'
+        forged_body = '{"event": "onMessageAdded", "conversationSid": "CHforged"}'
+
+        validator = RequestValidator(auth_token)
+        query = f"bodySHA256={sha256(genuine_body.encode()).hexdigest()}"
+        url = f"https://example.com/webhook?{query}"
+        signature = validator.compute_signature(url, {})
+
+        request = MagicMock()
+        request.headers = {
+            "X-Twilio-Signature": signature,
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "example.com",
+        }
+        request.url.path = "/webhook"
+        request.url.query = query
+
+        assert validate_twilio_webhook(request, auth_token, forged_body) is False
+
+    def test_string_body_without_bodysha256_returns_false(self) -> None:
+        """Test a string body with no bodySHA256 query param fails closed (no exception)."""
+        auth_token = "test_auth_token"
+        body_str = '{"event": "onMessageAdded"}'
 
         validator = RequestValidator(auth_token)
         url = "https://example.com/webhook"
@@ -86,7 +138,7 @@ class TestValidateTwilioWebhook:
         request.url.path = "/webhook"
         request.url.query = ""
 
-        assert validate_twilio_webhook(request, auth_token, body_str) is True
+        assert validate_twilio_webhook(request, auth_token, body_str) is False
 
     def test_invalid_string_body_signature(self) -> None:
         """Test validation fails with incorrect signature for JSON/string body."""
@@ -259,7 +311,9 @@ class TestBuildHttpSignatureDependency:
     @pytest.mark.asyncio
     async def test_valid_json_signature_passes(self) -> None:
         auth_token = "test_token"
-        url = "http://testserver/webhook"
+        raw_body = b'{"event": "test"}'
+        query = f"bodySHA256={sha256(raw_body).hexdigest()}"
+        url = f"http://testserver/webhook?{query}"
         validator = RequestValidator(auth_token)
         signature = validator.compute_signature(url, {})
 
@@ -268,10 +322,10 @@ class TestBuildHttpSignatureDependency:
         request = AsyncMock()
         request.headers = {"X-Twilio-Signature": signature, "content-type": "application/json"}
         request.url.path = "/webhook"
-        request.url.query = ""
+        request.url.query = query
         request.url.scheme = "http"
         request.url.netloc = "testserver"
-        request.body.return_value = b'{"event": "test"}'
+        request.body.return_value = raw_body
 
         await dep(request)
 


### PR DESCRIPTION
## Summary

For JSON webhooks, Twilio signs a `bodySHA256` query param and expects the receiver to hash the raw body and compare it. `validate_twilio_webhook` passed an empty params dict (`{}`) instead of the raw body for string bodies, so `RequestValidator.validate` never ran the body-hash check — it only runs when `params` is a `str`. This meant a captured `X-Twilio-Signature` would validate any forged JSON body, since the replayed signed URL (including its `bodySHA256`) still matched the URL-level HMAC while the body itself went unverified.

Changes:

- `src/tac/server/signature_validation.py`: pass the raw body string through to `RequestValidator.validate` so the `bodySHA256` comparison runs. Fail closed (return `False`) when a string body has no `bodySHA256` query param — a non-Twilio/malformed request, which `RequestValidator` surfaces as a `TypeError` — rather than erroring. Form-encoded (Voice) and WebSocket paths are unchanged.
- `tests/test_webhook_validation.py`: rework the string-body test to the real Twilio JSON flow (`bodySHA256` over the raw body), add a regression test for forged JSON bodies, and add coverage for the fail-closed path.
- `tests/test_server.py`: update the JSON-webhook integration tests to sign with `bodySHA256` and post the raw body verbatim (via a new `sign_json_webhook` helper).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E

## SDK Parity

This is the **Python SDK**. The TypeScript SDK should be checked for the same webhook body-validation pattern, as it may share this behavior.

- [ ] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)