### PR TITLE
Add .worktreeinclude to copy example .env files into new worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,10 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
+*.env
+.*env
+!.env.example
 .mcp.json
 .venv
 env/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Copy local env files into new worktrees (see .gitignore for what's ignored).
+# Only gitignored matches are copied, so tracked .env.example/.env.template are skipped.
+getting_started/examples/**/.env*


### PR DESCRIPTION
## Summary

New worktrees are fresh checkouts, so gitignored `.env` files under `getting_started/examples/` don't carry over — examples can't run without recreating secrets by hand. This adds a `.worktreeinclude` ([docs](https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees)) that copies them in automatically. It uses gitignore syntax and only copies files that are already gitignored, so tracked `.env.example` files are never duplicated.

Also broadens the `.gitignore` env patterns (`.env.*`, `*.env`, `.*env`) to catch `.env.local`/`.env.development`, keeping `.env.example` tracked via `!.env.example`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Release / version bump

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

> **Tip:** Use the `/sync-to-ts-sdk` skill in Claude Code to automatically generate and create a TypeScript SDK PR from your changes.

- [x] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->
