### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twilio-agent-connect"
-version = "2.1.0"
+version = "2.1.1"
 description = "A Python framework for building agentic applications with Twilio"
 authors = [{ name = "Twilio Conversation AI", email = "team_conversational-ai@twilio.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2768,7 +2768,7 @@ wheels = [
 
 [[package]]
 name = "twilio-agent-connect"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Bump the package version from 2.1.0 to 2.1.1 (patch) and regenerate `uv.lock`.

Since `v2.1.0`, the changes on `main` are: a webhook body validation fix (#85), MkDocs documentation infrastructure and docstring updates (#77), and a CI dependency pin (#84). The only substantive runtime change (#85) preserves the public `validate_twilio_webhook` signature, so per semantic versioning this is a patch release.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Release / version bump

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [x] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created:

🤖 Generated with [Claude Code](https://claude.com/claude-code)