### PR TITLE
fix: parse Memory /Recall response per-item to avoid dropping valid results

### DIFF
--- a/src/tac/context/memory.py
+++ b/src/tac/context/memory.py
@@ -1,15 +1,22 @@
-from typing import Any
+from typing import Any, TypeVar
 
 import httpx
+from pydantic import BaseModel, ValidationError
 
 from tac.context.base import BaseAPIClient
 from tac.models.memory import (
+    MemoryCommunication,
+    MemoryRetrievalMeta,
     MemoryRetrievalRequest,
     MemoryRetrievalResponse,
+    ObservationInfo,
     ProfileLookupRequest,
     ProfileLookupResponse,
     ProfileResponse,
+    SummaryInfo,
 )
+
+_ItemModel = TypeVar("_ItemModel", bound=BaseModel)
 
 
 class MemoryClient(BaseAPIClient):
@@ -90,12 +97,11 @@ class MemoryClient(BaseAPIClient):
 
                 response.raise_for_status()
 
-                # Parse the response according to the API spec
+                # Parse the response according to the API spec. Validate each
+                # item independently so a single malformed observation, summary,
+                # or communication does not collapse the entire response to empty.
                 data = response.json()
-                memory_response = MemoryRetrievalResponse(**data)
-
-                # Return full response with observations, summaries, sessions, and metadata
-                return memory_response
+                return self._parse_recall_response(data)
 
         except httpx.HTTPError as e:
             response_text = (
@@ -116,6 +122,46 @@ class MemoryClient(BaseAPIClient):
             self.logger.error(f"Failed to parse Conversation Memory response: {e}")
             # Return empty response on parsing errors
             return MemoryRetrievalResponse()
+
+    def _parse_recall_response(self, data: Any) -> MemoryRetrievalResponse:
+        """Parse a /Recall response, dropping (and logging) invalid items.
+
+        Observations, summaries, and communications are validated per item so a
+        single malformed entry does not discard the valid results alongside it.
+        """
+        if not isinstance(data, dict):
+            self.logger.warning(
+                f"Unexpected Conversation Memory response type: {type(data).__name__}; "
+                "returning empty response"
+            )
+            return MemoryRetrievalResponse()
+
+        meta = MemoryRetrievalMeta()
+        raw_meta = data.get("meta")
+        if raw_meta is not None:
+            try:
+                meta = MemoryRetrievalMeta.model_validate(raw_meta)
+            except ValidationError as e:
+                self.logger.warning(f"Dropping invalid Conversation Memory meta: {e}")
+
+        return MemoryRetrievalResponse(
+            observations=self._parse_items(data.get("observations"), ObservationInfo),
+            summaries=self._parse_items(data.get("summaries"), SummaryInfo),
+            communications=self._parse_items(data.get("communications"), MemoryCommunication),
+            meta=meta,
+        )
+
+    def _parse_items(self, items: Any, model: type[_ItemModel]) -> list[_ItemModel]:
+        """Validate a list of items into `model`, skipping invalid entries."""
+        if not items:
+            return []
+        parsed: list[_ItemModel] = []
+        for item in items:
+            try:
+                parsed.append(model.model_validate(item))
+            except ValidationError as e:
+                self.logger.warning(f"Dropping invalid Conversation Memory {model.__name__}: {e}")
+        return parsed
 
     async def get_profile(
         self,

--- a/src/tac/context/memory.py
+++ b/src/tac/context/memory.py
@@ -153,7 +153,13 @@ class MemoryClient(BaseAPIClient):
 
     def _parse_items(self, items: Any, model: type[_ItemModel]) -> list[_ItemModel]:
         """Validate a list of items into `model`, skipping invalid entries."""
-        if not items:
+        if items is None:
+            return []
+        if not isinstance(items, list):
+            self.logger.warning(
+                f"Expected a list of Conversation Memory {model.__name__} but received "
+                f"{type(items).__name__}; returning empty list"
+            )
             return []
         parsed: list[_ItemModel] = []
         for item in items:

--- a/tests/test_recall_parsing_resilience.py
+++ b/tests/test_recall_parsing_resilience.py
@@ -1,0 +1,130 @@
+"""Tests for per-item resilience when parsing the Memory /Recall response.
+
+A single malformed item (bad field value or missing required field) must not
+collapse the entire response to empty; valid items should still be returned.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from tac.context.memory import MemoryClient
+
+
+def _make_client() -> MemoryClient:
+    return MemoryClient(
+        store_id="mem_store_01abc",
+        api_key="SK123",
+        api_secret="secret",
+    )
+
+
+def _valid_observation(obs_id: str) -> dict:
+    return {
+        "content": "Customer prefers email contact.",
+        "source": "conversational-intelligence",
+        "id": obs_id,
+        "createdAt": "2025-01-15T10:30:45Z",
+        "updatedAt": "2025-01-15T10:30:45Z",
+    }
+
+
+def _valid_summary(summary_id: str) -> dict:
+    return {
+        "content": "Customer resolved a billing issue.",
+        "id": summary_id,
+        "createdAt": "2025-01-15T10:30:45Z",
+        "updatedAt": "2025-01-15T10:30:45Z",
+    }
+
+
+def _valid_communication(comm_id: str) -> dict:
+    return {
+        "id": comm_id,
+        "author": {
+            "id": "conv_participant_1",
+            "name": "John Doe",
+            "address": "+12025551234",
+            "channel": "SMS",
+        },
+        "content": {"text": "Hello"},
+        "recipients": [],
+        "createdAt": "2025-01-15T10:15:30Z",
+    }
+
+
+async def _call_retrieve(recall_payload: dict) -> object:
+    client = _make_client()
+
+    mock_response = Mock()
+    mock_response.json.return_value = recall_payload
+    mock_response.raise_for_status = Mock()
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client_class.return_value.__aenter__.return_value = mock_http
+        return await client.retrieve_memory(profile_id="mem_profile_01abc")
+
+
+class TestRecallParsingResilience:
+    @pytest.mark.asyncio
+    async def test_invalid_observation_does_not_drop_valid_items(self) -> None:
+        payload = {
+            "observations": [
+                _valid_observation("mem_observation_1"),
+                {"content": "missing required id and timestamps"},  # invalid
+                _valid_observation("mem_observation_2"),
+            ],
+            "summaries": [_valid_summary("mem_summary_1")],
+            "communications": [_valid_communication("conv_communication_1")],
+            "meta": {"queryTime": 100},
+        }
+
+        result = await _call_retrieve(payload)
+
+        # The two valid observations survive; the invalid one is dropped.
+        assert [o.id for o in result.observations] == [
+            "mem_observation_1",
+            "mem_observation_2",
+        ]
+        # Other sections are untouched.
+        assert [s.id for s in result.summaries] == ["mem_summary_1"]
+        assert [c.id for c in result.communications] == ["conv_communication_1"]
+        assert result.meta.query_time == 100
+
+    @pytest.mark.asyncio
+    async def test_invalid_summary_does_not_drop_valid_items(self) -> None:
+        payload = {
+            "observations": [],
+            "summaries": [
+                _valid_summary("mem_summary_1"),
+                {"content": ""},  # invalid: content min_length=1, missing id/timestamps
+                _valid_summary("mem_summary_2"),
+            ],
+            "communications": [],
+        }
+
+        result = await _call_retrieve(payload)
+
+        assert [s.id for s in result.summaries] == ["mem_summary_1", "mem_summary_2"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_communication_does_not_drop_valid_items(self) -> None:
+        payload = {
+            "observations": [],
+            "summaries": [],
+            "communications": [
+                _valid_communication("conv_communication_1"),
+                {"id": "conv_communication_bad"},  # invalid: missing author/content/recipients
+                _valid_communication("conv_communication_2"),
+            ],
+        }
+
+        result = await _call_retrieve(payload)
+
+        assert [c.id for c in result.communications] == [
+            "conv_communication_1",
+            "conv_communication_2",
+        ]

--- a/tests/test_recall_parsing_resilience.py
+++ b/tests/test_recall_parsing_resilience.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from tac.context.memory import MemoryClient
+from tac.models.memory import MemoryRetrievalResponse
 
 
 def _make_client() -> MemoryClient:
@@ -53,7 +54,7 @@ def _valid_communication(comm_id: str) -> dict:
     }
 
 
-async def _call_retrieve(recall_payload: dict) -> object:
+async def _call_retrieve(recall_payload: dict) -> MemoryRetrievalResponse:
     client = _make_client()
 
     mock_response = Mock()
@@ -63,8 +64,11 @@ async def _call_retrieve(recall_payload: dict) -> object:
     mock_http = AsyncMock()
     mock_http.post = AsyncMock(return_value=mock_response)
 
-    with patch("httpx.AsyncClient") as mock_client_class:
-        mock_client_class.return_value.__aenter__.return_value = mock_http
+    mock_client = Mock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_http)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
         return await client.retrieve_memory(profile_id="mem_profile_01abc")
 
 
@@ -128,3 +132,21 @@ class TestRecallParsingResilience:
             "conv_communication_1",
             "conv_communication_2",
         ]
+
+    @pytest.mark.asyncio
+    async def test_invalid_meta_falls_back_to_defaults(self) -> None:
+        payload = {
+            "observations": [_valid_observation("mem_observation_1")],
+            "summaries": [_valid_summary("mem_summary_1")],
+            "communications": [_valid_communication("conv_communication_1")],
+            "meta": {"queryTime": "not-a-number"},  # invalid: queryTime must be an int
+        }
+
+        result = await _call_retrieve(payload)
+
+        # Valid items still parse.
+        assert [o.id for o in result.observations] == ["mem_observation_1"]
+        assert [s.id for s in result.summaries] == ["mem_summary_1"]
+        assert [c.id for c in result.communications] == ["conv_communication_1"]
+        # Invalid meta is dropped and falls back to defaults.
+        assert result.meta.query_time is None


### PR DESCRIPTION
## Summary

`MemoryClient.retrieve_memory()` parsed the Conversation Memory /Recall response with a single `MemoryRetrievalResponse(**data)` call wrapped in a broad `except` that returned an empty response. A single malformed item (unexpected field value or a missing required field on one observation, summary, or communication) raised `ValidationError` and collapsed the entire response to empty, silently discarding all valid results.

This change validates observations, summaries, and communications independently. Invalid items are dropped and logged via the existing structlog logger while the valid items are returned. The existing behavior of returning an empty response when the API request itself fails is preserved.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **Python SDK**. This is the Python parity fix for the TypeScript change in twilio/twilio-agent-connect-typescript PR #79.

- [ ] Change is Python-specific (no TypeScript update needed)
- [x] TypeScript SDK PR created: twilio/twilio-agent-connect-typescript#79

🤖 Generated with [Claude Code](https://claude.com/claude-code)