### PR TITLE
refactor(channels): Deduplicate send_response across messaging channels

### DIFF
--- a/src/tac/channels/chat.py
+++ b/src/tac/channels/chat.py
@@ -1,24 +1,17 @@
 """Chat Channel implementation for TAC."""
 
-from collections.abc import AsyncGenerator
 from typing import Any
 
 from pydantic import Field
 
 from tac import TAC
 from tac.channels.messaging import MessagingChannel, MessagingChannelConfig
-from tac.models.conversation import (
-    ActionChannelSettings,
-    ActionParticipantRef,
-    ActionTextContent,
-    ParticipantAddress,
-    SendMessageActionPayload,
-    SendMessageActionRequest,
-)
+from tac.models.conversation import ActionChannelSettings, ParticipantAddress
 from tac.models.outbound import (
     InitiateChatConversationOptions,
     InitiateConversationResult,
 )
+from tac.models.session import ConversationSession
 
 
 class ChatChannelConfig(MessagingChannelConfig):
@@ -79,96 +72,21 @@ class ChatChannel(MessagingChannel):
             channel_id=channel_id if isinstance(channel_id, str) else None,
         )
 
-    async def send_response(
-        self,
-        conversation_id: str,
-        response: str | AsyncGenerator[str | dict[str, Any], None],
-        role: str | None = None,
-    ) -> None:
-        """Send chat response using the Conversation Orchestrator Send API.
-
-        Reads the agent and customer participant ids stashed on the session
-        by inbound reconciliation or outbound initiation. Missing ids are a
-        misuse — send_response is only expected to be called after an inbound
-        webhook (COMMUNICATION_CREATED → reconcile) or after
-        `initiate_outbound_conversation`, both of which populate the session.
-
-        Args:
-            conversation_id: Conversation ID to send response to
-            response: Message content (must be string for Chat)
-            role: Optional message role (not used in Chat channel)
-
-        Raises:
-            TypeError: If response is not a string
-            RuntimeError: If the session, channel_id, or participant ids are missing
-        """
-        if not isinstance(response, str):
-            raise TypeError("Chat channel only supports string responses")
-
-        session = self._conversations.get(conversation_id)
-        if session is None or not session.author_info or not session.ai_agent_info:
-            raise RuntimeError(
-                f"Unable to send chat message: send_response called without a "
-                f"reconciled session for conversation {conversation_id}. Wait for "
-                "an inbound webhook or call initiate_outbound_conversation first."
-            )
-
-        customer_participant_id = session.author_info.participant_id
-        agent_participant_id = session.ai_agent_info.participant_id
-        if not customer_participant_id or not agent_participant_id:
-            raise RuntimeError(
-                f"Unable to send chat message: session for conversation "
-                f"{conversation_id} is missing participant ids."
-            )
-
+    def _build_channel_settings(
+        self, conversation_id: str, session: ConversationSession
+    ) -> ActionChannelSettings:
         # channelId (Chat Channel SID) is required for CHAT delivery — the V1
         # Chat backend uses it to pick the destination thread. Inbound webhooks
         # always populate it, so a missing value here is a misuse.
-        chat_channel_sid = session.metadata.get("channel_id")
-        if not chat_channel_sid or not isinstance(chat_channel_sid, str):
+        channel_id = session.metadata.get("channel_id")
+        if not channel_id or not isinstance(channel_id, str):
             raise RuntimeError(
                 "Missing required session.metadata['channel_id'] for chat send_response; "
                 "this is normally populated by an inbound webhook. Ensure an inbound "
                 "message has been processed before calling send_response, or set "
                 "session.metadata['channel_id'] explicitly in advanced usage."
             )
-
-        channel_settings = ActionChannelSettings(channel_id=chat_channel_sid)
-
-        try:
-            action_request = SendMessageActionRequest(
-                payload=SendMessageActionPayload(
-                    from_=ActionParticipantRef(
-                        channel="CHAT",
-                        participant_id=agent_participant_id,
-                    ),
-                    to=[
-                        ActionParticipantRef(
-                            channel="CHAT",
-                            participant_id=customer_participant_id,
-                        )
-                    ],
-                    content=ActionTextContent(text=response),
-                    channel_settings=channel_settings,
-                ),
-            )
-
-            await self.conversation_orchestrator_client.create_action(
-                conversation_id, action_request
-            )
-
-            self.logger.info(
-                "Sent chat response via Actions API",
-                conversation_id=conversation_id,
-                channel_id=chat_channel_sid,
-            )
-        except Exception as e:
-            self.logger.error(
-                "Failed to create action",
-                conversation_id=conversation_id,
-                error=str(e),
-                exc_info=True,
-            )
+        return ActionChannelSettings(channel_id=channel_id)
 
     async def initiate_outbound_conversation(
         self,

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -24,7 +24,7 @@ from tac.models.conversation import (
 )
 from tac.models.memory import MemoryMode
 from tac.models.outbound import InitiateConversationResult, InitiateMessagingConversationOptions
-from tac.models.session import AuthorInfo
+from tac.models.session import AuthorInfo, ConversationSession
 from tac.utils.redaction import mask_address
 
 
@@ -65,8 +65,11 @@ class MessagingChannel(BaseChannel):
     Subclasses must implement:
     - is_default_agent_address(): Fast-path check for the channel's default agent address
     - get_agent_address(conversation_id): Return the agent's ParticipantAddress for a conversation
-    - send_response(): Send messages back through the channel
     - get_channel_name(): Return channel name ("SMS", "RCS", "WHATSAPP", "CHAT")
+
+    send_response() is provided here as a shared implementation. Subclasses may
+    override _build_channel_settings() to customize how ActionChannelSettings
+    is built for the outbound send (e.g. chat requires channel_id).
 
     Subclass class attributes:
     - reconcile_customer_type: If True, reconciliation will also promote a
@@ -157,14 +160,102 @@ class MessagingChannel(BaseChannel):
         """
         pass
 
-    @abstractmethod
+    def _build_channel_settings(
+        self, conversation_id: str, session: ConversationSession
+    ) -> ActionChannelSettings | None:
+        """Build the ActionChannelSettings for an outbound send, if any.
+
+        Default behavior (SMS, RCS, WhatsApp): channel_id is optional and,
+        when present in session metadata, is passed through as-is. Chat
+        overrides this since channel_id is required for delivery.
+        """
+        channel_id = session.metadata.get("channel_id")
+        return (
+            ActionChannelSettings(channel_id=channel_id)
+            if isinstance(channel_id, str) and channel_id
+            else None
+        )
+
     async def send_response(
         self,
         conversation_id: str,
         response: str | AsyncGenerator[str | dict[str, Any], None],
         role: str | None = None,
     ) -> None:
-        pass
+        """Send a text response using the Conversation Orchestrator Send API.
+
+        Reads the agent and customer participant ids stashed on the session
+        by inbound reconciliation or outbound initiation. Missing ids are a
+        misuse — send_response is only expected to be called after an inbound
+        webhook (COMMUNICATION_CREATED → reconcile) or after
+        `initiate_outbound_conversation`, both of which populate the session.
+
+        Args:
+            conversation_id: Conversation ID to send response to
+            response: Message content (must be a string)
+            role: Optional message role (unused by messaging channels)
+
+        Raises:
+            TypeError: If response is not a string
+            RuntimeError: If the session or participant ids are missing
+        """
+        channel_name = self.get_channel_name()
+        if not isinstance(response, str):
+            raise TypeError(f"{channel_name} channel only supports string responses")
+
+        session = self._conversations.get(conversation_id)
+        if session is None or not session.author_info or not session.ai_agent_info:
+            raise RuntimeError(
+                f"Unable to send {channel_name} message: send_response called without a "
+                f"reconciled session for conversation {conversation_id}. Wait for an "
+                "inbound webhook or call initiate_outbound_conversation first."
+            )
+
+        customer_participant_id = session.author_info.participant_id
+        agent_participant_id = session.ai_agent_info.participant_id
+        if not customer_participant_id or not agent_participant_id:
+            raise RuntimeError(
+                f"Unable to send {channel_name} message: session for conversation "
+                f"{conversation_id} is missing participant ids."
+            )
+
+        channel_settings = self._build_channel_settings(conversation_id, session)
+
+        try:
+            action_request = SendMessageActionRequest(
+                payload=SendMessageActionPayload(
+                    from_=ActionParticipantRef(
+                        channel=channel_name,
+                        participant_id=agent_participant_id,
+                    ),
+                    to=[
+                        ActionParticipantRef(
+                            channel=channel_name,
+                            participant_id=customer_participant_id,
+                        )
+                    ],
+                    content=ActionTextContent(text=response),
+                    channel_settings=channel_settings,
+                ),
+            )
+
+            await self.conversation_orchestrator_client.create_action(
+                conversation_id, action_request
+            )
+
+            self.logger.info(
+                f"Sent {channel_name} response via Actions API",
+                conversation_id=conversation_id,
+                to_address=mask_address(session.author_info.address),
+                channel_id=channel_settings.channel_id if channel_settings else None,
+            )
+        except Exception as e:
+            self.logger.error(
+                "Failed to create action",
+                conversation_id=conversation_id,
+                error=str(e),
+                exc_info=True,
+            )
 
     async def process_webhook(
         self, webhook_data: dict[str, Any], idempotency_token: str | None = None

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -192,11 +192,14 @@ class MessagingChannel(BaseChannel):
 
         Args:
             conversation_id: Conversation ID to send response to
-            response: Message content (must be a string)
+            response: Message content. Must be ``str`` — messaging channels send a
+                single complete message via the Conversation Orchestrator Send API
+                and do not support streaming (unlike the Voice channel).
             role: Optional message role (unused by messaging channels)
 
         Raises:
-            TypeError: If response is not a string
+            TypeError: If response is not a string (e.g. an async generator is
+                passed, since messaging channels don't support streaming)
             RuntimeError: If the session or participant ids are missing
         """
         channel_name = self.get_channel_name()

--- a/src/tac/channels/rcs.py
+++ b/src/tac/channels/rcs.py
@@ -1,25 +1,16 @@
 """RCS Channel implementation for TAC."""
 
-from collections.abc import AsyncGenerator
 from typing import Any
 
 from pydantic import Field
 
 from tac import TAC
 from tac.channels.messaging import MessagingChannel, MessagingChannelConfig
-from tac.models.conversation import (
-    ActionChannelSettings,
-    ActionParticipantRef,
-    ActionTextContent,
-    ParticipantAddress,
-    SendMessageActionPayload,
-    SendMessageActionRequest,
-)
+from tac.models.conversation import ParticipantAddress
 from tac.models.outbound import (
     InitiateConversationResult,
     InitiateMessagingConversationOptions,
 )
-from tac.utils.redaction import mask_address
 
 
 class RCSChannelConfig(MessagingChannelConfig):
@@ -81,90 +72,6 @@ class RCSChannel(MessagingChannel):
         if not self.tac.config.rcs_sender_id:
             raise RuntimeError("rcs_sender_id is required for RCS channel.")
         return ParticipantAddress(channel="RCS", address=self.tac.config.rcs_sender_id)
-
-    async def send_response(
-        self,
-        conversation_id: str,
-        response: str | AsyncGenerator[str | dict[str, Any], None],
-        role: str | None = None,
-    ) -> None:
-        """Send RCS response using the Conversation Orchestrator Send API.
-
-        Reads the agent and customer participant ids stashed on the session
-        by inbound reconciliation or outbound initiation. Missing ids are a
-        misuse — send_response is only expected to be called after an inbound
-        webhook (COMMUNICATION_CREATED → reconcile) or after
-        `initiate_outbound_conversation`, both of which populate the session.
-
-        Args:
-            conversation_id: Conversation ID to send response to
-            response: Message content (must be string for RCS)
-            role: Optional message role (not used in RCS channel)
-
-        Raises:
-            TypeError: If response is not a string
-            RuntimeError: If the session or participant ids are missing
-        """
-        if not isinstance(response, str):
-            raise TypeError("RCS channel only supports string responses")
-
-        session = self._conversations.get(conversation_id)
-        if session is None or not session.author_info or not session.ai_agent_info:
-            raise RuntimeError(
-                f"Unable to send RCS: send_response called without a reconciled "
-                f"session for conversation {conversation_id}. Wait for an inbound "
-                "webhook or call initiate_outbound_conversation first."
-            )
-
-        customer_participant_id = session.author_info.participant_id
-        agent_participant_id = session.ai_agent_info.participant_id
-        if not customer_participant_id or not agent_participant_id:
-            raise RuntimeError(
-                f"Unable to send RCS: session for conversation {conversation_id} is "
-                "missing participant ids."
-            )
-
-        channel_id = session.metadata.get("channel_id")
-        channel_settings = (
-            ActionChannelSettings(channel_id=channel_id)
-            if isinstance(channel_id, str) and channel_id
-            else None
-        )
-
-        try:
-            action_request = SendMessageActionRequest(
-                payload=SendMessageActionPayload(
-                    from_=ActionParticipantRef(
-                        channel="RCS",
-                        participant_id=agent_participant_id,
-                    ),
-                    to=[
-                        ActionParticipantRef(
-                            channel="RCS",
-                            participant_id=customer_participant_id,
-                        )
-                    ],
-                    content=ActionTextContent(text=response),
-                    channel_settings=channel_settings,
-                ),
-            )
-
-            await self.conversation_orchestrator_client.create_action(
-                conversation_id, action_request
-            )
-
-            self.logger.info(
-                "Sent RCS response via Actions API",
-                conversation_id=conversation_id,
-                to_address=mask_address(session.author_info.address),
-            )
-        except Exception as e:
-            self.logger.error(
-                "Failed to create action",
-                conversation_id=conversation_id,
-                error=str(e),
-                exc_info=True,
-            )
 
     async def initiate_outbound_conversation(
         self,

--- a/src/tac/channels/sms.py
+++ b/src/tac/channels/sms.py
@@ -1,25 +1,16 @@
 """SMS Channel implementation for TAC."""
 
-from collections.abc import AsyncGenerator
 from typing import Any
 
 from pydantic import Field
 
 from tac import TAC
 from tac.channels.messaging import MessagingChannel, MessagingChannelConfig
-from tac.models.conversation import (
-    ActionChannelSettings,
-    ActionParticipantRef,
-    ActionTextContent,
-    ParticipantAddress,
-    SendMessageActionPayload,
-    SendMessageActionRequest,
-)
+from tac.models.conversation import ParticipantAddress
 from tac.models.outbound import (
     InitiateConversationResult,
     InitiateMessagingConversationOptions,
 )
-from tac.utils.redaction import mask_phone
 
 
 class SMSChannelConfig(MessagingChannelConfig):
@@ -73,90 +64,6 @@ class SMSChannel(MessagingChannel):
 
     def get_agent_address(self, conversation_id: str) -> ParticipantAddress:
         return ParticipantAddress(channel="SMS", address=self.tac.config.phone_number)
-
-    async def send_response(
-        self,
-        conversation_id: str,
-        response: str | AsyncGenerator[str | dict[str, Any], None],
-        role: str | None = None,
-    ) -> None:
-        """Send SMS response using the Conversation Orchestrator Send API.
-
-        Reads the agent and customer participant ids stashed on the session
-        by inbound reconciliation or outbound initiation. Missing ids are a
-        misuse — send_response is only expected to be called after an inbound
-        webhook (COMMUNICATION_CREATED → reconcile) or after
-        `initiate_outbound_conversation`, both of which populate the session.
-
-        Args:
-            conversation_id: Conversation ID to send response to
-            response: Message content (must be string for SMS)
-            role: Optional message role (not used in SMS channel)
-
-        Raises:
-            TypeError: If response is not a string
-            RuntimeError: If the session or participant ids are missing
-        """
-        if not isinstance(response, str):
-            raise TypeError("SMS channel only supports string responses")
-
-        session = self._conversations.get(conversation_id)
-        if session is None or not session.author_info or not session.ai_agent_info:
-            raise RuntimeError(
-                f"Unable to send SMS: send_response called without a reconciled "
-                f"session for conversation {conversation_id}. Wait for an inbound "
-                "webhook or call initiate_outbound_conversation first."
-            )
-
-        customer_participant_id = session.author_info.participant_id
-        agent_participant_id = session.ai_agent_info.participant_id
-        if not customer_participant_id or not agent_participant_id:
-            raise RuntimeError(
-                f"Unable to send SMS: session for conversation {conversation_id} is "
-                "missing participant ids."
-            )
-
-        channel_id = session.metadata.get("channel_id")
-        channel_settings = (
-            ActionChannelSettings(channel_id=channel_id)
-            if isinstance(channel_id, str) and channel_id
-            else None
-        )
-
-        try:
-            action_request = SendMessageActionRequest(
-                payload=SendMessageActionPayload(
-                    from_=ActionParticipantRef(
-                        channel="SMS",
-                        participant_id=agent_participant_id,
-                    ),
-                    to=[
-                        ActionParticipantRef(
-                            channel="SMS",
-                            participant_id=customer_participant_id,
-                        )
-                    ],
-                    content=ActionTextContent(text=response),
-                    channel_settings=channel_settings,
-                ),
-            )
-
-            await self.conversation_orchestrator_client.create_action(
-                conversation_id, action_request
-            )
-
-            self.logger.info(
-                "Sent SMS response via Actions API",
-                conversation_id=conversation_id,
-                to_address=mask_phone(session.author_info.address),
-            )
-        except Exception as e:
-            self.logger.error(
-                "Failed to create action",
-                conversation_id=conversation_id,
-                error=str(e),
-                exc_info=True,
-            )
 
     async def initiate_outbound_conversation(
         self,

--- a/src/tac/channels/whatsapp.py
+++ b/src/tac/channels/whatsapp.py
@@ -1,25 +1,16 @@
 """WhatsApp Channel implementation for TAC."""
 
-from collections.abc import AsyncGenerator
 from typing import Any
 
 from pydantic import Field
 
 from tac import TAC
 from tac.channels.messaging import MessagingChannel, MessagingChannelConfig
-from tac.models.conversation import (
-    ActionChannelSettings,
-    ActionParticipantRef,
-    ActionTextContent,
-    ParticipantAddress,
-    SendMessageActionPayload,
-    SendMessageActionRequest,
-)
+from tac.models.conversation import ParticipantAddress
 from tac.models.outbound import (
     InitiateConversationResult,
     InitiateMessagingConversationOptions,
 )
-from tac.utils.redaction import mask_address
 
 
 class WhatsAppChannelConfig(MessagingChannelConfig):
@@ -82,90 +73,6 @@ class WhatsAppChannel(MessagingChannel):
         if not self.tac.config.whatsapp_number:
             raise RuntimeError("whatsapp_number is required for WhatsApp channel.")
         return ParticipantAddress(channel="WHATSAPP", address=self.tac.config.whatsapp_number)
-
-    async def send_response(
-        self,
-        conversation_id: str,
-        response: str | AsyncGenerator[str | dict[str, Any], None],
-        role: str | None = None,
-    ) -> None:
-        """Send WhatsApp response using the Conversation Orchestrator Send API.
-
-        Reads the agent and customer participant ids stashed on the session
-        by inbound reconciliation or outbound initiation. Missing ids are a
-        misuse — send_response is only expected to be called after an inbound
-        webhook (COMMUNICATION_CREATED → reconcile) or after
-        `initiate_outbound_conversation`, both of which populate the session.
-
-        Args:
-            conversation_id: Conversation ID to send response to
-            response: Message content (must be string for WhatsApp)
-            role: Optional message role (not used in WhatsApp channel)
-
-        Raises:
-            TypeError: If response is not a string
-            RuntimeError: If the session or participant ids are missing
-        """
-        if not isinstance(response, str):
-            raise TypeError("WhatsApp channel only supports string responses")
-
-        session = self._conversations.get(conversation_id)
-        if session is None or not session.author_info or not session.ai_agent_info:
-            raise RuntimeError(
-                f"Unable to send WhatsApp: send_response called without a reconciled "
-                f"session for conversation {conversation_id}. Wait for an inbound "
-                "webhook or call initiate_outbound_conversation first."
-            )
-
-        customer_participant_id = session.author_info.participant_id
-        agent_participant_id = session.ai_agent_info.participant_id
-        if not customer_participant_id or not agent_participant_id:
-            raise RuntimeError(
-                f"Unable to send WhatsApp: session for conversation {conversation_id} is "
-                "missing participant ids."
-            )
-
-        channel_id = session.metadata.get("channel_id")
-        channel_settings = (
-            ActionChannelSettings(channel_id=channel_id)
-            if isinstance(channel_id, str) and channel_id
-            else None
-        )
-
-        try:
-            action_request = SendMessageActionRequest(
-                payload=SendMessageActionPayload(
-                    from_=ActionParticipantRef(
-                        channel="WHATSAPP",
-                        participant_id=agent_participant_id,
-                    ),
-                    to=[
-                        ActionParticipantRef(
-                            channel="WHATSAPP",
-                            participant_id=customer_participant_id,
-                        )
-                    ],
-                    content=ActionTextContent(text=response),
-                    channel_settings=channel_settings,
-                ),
-            )
-
-            await self.conversation_orchestrator_client.create_action(
-                conversation_id, action_request
-            )
-
-            self.logger.info(
-                "Sent WhatsApp response via Actions API",
-                conversation_id=conversation_id,
-                to_address=mask_address(session.author_info.address),
-            )
-        except Exception as e:
-            self.logger.error(
-                "Failed to create action",
-                conversation_id=conversation_id,
-                error=str(e),
-                exc_info=True,
-            )
 
     async def initiate_outbound_conversation(
         self,

--- a/tests/test_chat_channel.py
+++ b/tests/test_chat_channel.py
@@ -343,7 +343,7 @@ class TestChatChannel:
     async def test_send_response_rejects_non_string(self) -> None:
         tac = TAC(get_test_config())
         channel = ChatChannel(tac)
-        with pytest.raises(TypeError, match="Chat channel only supports string responses"):
+        with pytest.raises(TypeError, match="CHAT channel only supports string responses"):
             await channel.send_response("CH123", 123)  # type: ignore[arg-type]
 
     @pytest.mark.asyncio

--- a/tests/test_whatsapp_channel.py
+++ b/tests/test_whatsapp_channel.py
@@ -370,7 +370,7 @@ async def test_conversation_updated_closed(whatsapp_channel: WhatsAppChannel) ->
 @pytest.mark.asyncio
 async def test_send_response_type_error(whatsapp_channel: WhatsAppChannel) -> None:
     """Test that send_response raises TypeError for non-string responses."""
-    with pytest.raises(TypeError, match="WhatsApp channel only supports string responses"):
+    with pytest.raises(TypeError, match="WHATSAPP channel only supports string responses"):
 
         async def async_gen():
             yield "chunk"


### PR DESCRIPTION
## Summary

SMS, RCS, WhatsApp, and Chat each had a nearly-identical `send_response()` implementation (type/session/participant validation, building `ActionChannelSettings`, constructing the `SendMessageActionRequest`, calling `create_action`, and logging). This consolidates the shared logic into `MessagingChannel.send_response()` in `src/tac/channels/messaging.py`, leaving one overridable hook — `_build_channel_settings()` — for the one real behavioral difference: Chat requires `channel_id` (raises `RuntimeError` if missing), while SMS/RCS/WhatsApp treat it as optional.

Net effect: ~370 lines of duplicated logic removed from `sms.py`/`rcs.py`/`whatsapp.py`/`chat.py`, with no changes to public API signatures.

Behavior changes (minor, non-functional):
- Error/log messages now consistently use the wire channel name (`SMS`, `RCS`, `WHATSAPP`, `CHAT`) instead of a mix of that and a display form (`WhatsApp`, `Chat`) — two test assertions were updated to match.
- The "sent response" log line now includes both `to_address` and `channel_id` for every channel (previously Chat only logged `channel_id`, others only logged `to_address`).

Also clarified the `send_response()` docstring: the shared base interface's type annotation allows `str | AsyncGenerator[...]` (to accommodate the Voice channel, which supports streaming), but messaging channels only ever accept `str` and raise `TypeError` for anything else, since they send a single complete message via the Conversation Orchestrator Send API and have no streaming path.

## How to test

- `make check` (lint + type-check + test) — all passing locally.
- No behavior change to the public `send_response()` call signature or contract; existing channel tests (`test_sms_channel.py`, `test_rcs_channel.py`, `test_whatsapp_channel.py`, `test_chat_channel.py`) cover this path.

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed) — this only reorganizes internal Python implementation, no public API or wire behavior change.