### PR TITLE
perf(voice): add latency instrumentation and parallelize memory fetch

### DIFF
--- a/VOICE_LATENCY_ANALYSIS.md
+++ b/VOICE_LATENCY_ANALYSIS.md
@@ -1,0 +1,177 @@
+# Voice Channel Latency Analysis
+
+Test notes from live phone calls against the streaming voice example
+(`voice_streaming.py`), using ad-hoc latency logging added to `VoiceChannel`
+plus Twilio ConversationRelay/Voice Insights event timelines pulled via the
+REST API. Numbers are single-sample measurements from real calls, not
+load-test averages — treat trends as directional, not statistically
+rigorous.
+
+## What was instrumented
+
+Added `time.monotonic()`-based timing logs to
+[`src/tac/channels/voice/channel.py`](src/tac/channels/voice/channel.py), all
+emitted at `INFO` level prefixed `Latency:`:
+
+| Log line | Measures | Location |
+|---|---|---|
+| `setup to first prompt (includes user speech + STT)` | Time from WebSocket `setup` message to the first `prompt` message — dominated by the caller's own speaking time plus Twilio's STT | `handle_websocket` |
+| `conversation orchestrator poll/init` | Time spent polling CO for the ConversationRelay-created conversation (first turn only) | `_initialize_conversation` |
+| `memory retrieval` | `_retrieve_memory_if_enabled` duration | `_handle_prompt` |
+| `on_message_ready callback` | Time in the app's `on_message_ready` callback (LLM call) | `_handle_prompt` |
+| `time to first token` | Streaming responses only — time from send start to first chunk written to the websocket | `send_response` |
+| `streaming response complete` / `response sent` | Total time to finish writing the response to the websocket | `send_response` |
+| `total prompt handling` | End-to-end time from prompt received to response fully sent | `_handle_prompt` |
+
+These cover everything **inside our own code**. They do not cover Twilio-side
+STT/TTS internals or PSTN audio transport — for that we pulled
+`client.insights.v1.calls(call_sid).events.list()` (ConversationRelay
+`start_of_agent_speech` / `end_of_customer_speech` / `first_token_received` /
+etc.), which required enabling Voice Insights Advanced Features on the
+account first (initially 404'd until enabled).
+
+## Test calls
+
+### 1. `memory_mode` default (`"never"`)
+
+Three calls, `CA3af7c09...`, `CA02ebb0...`, `CA856249...`:
+
+| Stage | Call A | Call B | Call C |
+|---|---|---|---|
+| setup → first prompt (speech + STT) | 5711.6 ms | — | — |
+| CO poll/init (first turn) | 1049.4 ms | — | — |
+| Memory retrieval | 0.2 ms (disabled) | 0.2 ms | 0.2 ms |
+| Time to first token | 1234.4 ms | — | — |
+| Streaming complete | 1402.5 ms | — | — |
+| Total prompt handling | 1403.1 ms | — | — |
+
+Call B and C were cross-checked against Twilio's ConversationRelay event
+timeline for a ground-truth, caller-perceived breakdown:
+
+**Call B (`CA02ebb0...`)** — good network (0 packet loss, `ashburn/us1`):
+
+```
+end_of_customer_speech  → first_token_received     1996 ms
+end_of_customer_speech  → start_of_agent_speech     2204 ms
+```
+
+**Call C (`CA856249...`)** — slightly worse network (1 packet lost, jitter
+0.143 avg, `umatilla/us2`):
+
+```
+end_of_customer_speech  → first_token_received     2273 ms
+end_of_customer_speech  → start_of_agent_speech     2463 ms
+end_of_customer_speech  → end_of_agent_speech       5685 ms
+```
+
+**Key finding**: the user reported a ~5s perceived delay on call C, which did
+not match the ~2.2–2.5s "wait before hearing anything" we could see from our
+own logs or the `start_of_agent_speech` event. The discrepancy resolved once
+we measured all the way to `end_of_agent_speech`: **5685 ms**, i.e. the user
+was judging latency as "time until the whole reply finishes playing," not
+just "time until the reply starts." That total splits into ~2.5s of actual
+wait plus ~3.2s of TTS playback (reply length).
+
+### 2. `memory_mode="once"` enabled
+
+Changed `voice_streaming.py` to
+`VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))`. Three
+calls before/after a code change (see Optimization below):
+
+| Stage | Before fix (`CA38c6d9...`) | After fix #1 (`CA689dd6...`) | After fix #2 (`CA2b666d...`) |
+|---|---|---|---|
+| Memory retrieval | 2713.4 ms | 2228.9 ms | 2546.0 ms |
+| Time to first token | 926.8 ms | 1519.6 ms | 917.9 ms |
+| Total prompt handling | 3842.4 ms | 4000.2 ms | 3812.7 ms |
+
+Also confirmed `"once"` mode's cache invalidation works as designed —
+`Invalidated cached memory on INACTIVE status` fires ~60-90s after the call
+ends, once Conversation Orchestrator marks the conversation `INACTIVE`.
+
+## Root causes identified
+
+1. **STT (setup → first prompt), ~5.7–6.2s**: entirely on Twilio's side
+   (caller's actual speaking time + ConversationRelay STT). Not something TAC
+   code affects. This is the majority of wall-clock time in every call but
+   isn't "latency" in the optimizable sense — most of it is the caller
+   talking.
+2. **LLM time-to-first-token, ~0.9–2.3s**: the primary optimizable latency on
+   the "wait" side of the experience once memory/STT are accounted for.
+3. **Memory retrieval, ~2.2–2.7s when enabled**: found that
+   `TAC.retrieve_memory()` was calling `get_profile()` then
+   `retrieve_memory()` **sequentially**, even though `retrieve_memory()` only
+   needs `profile_id` (already known) and not the `get_profile()` result. See
+   Optimization below.
+4. **User-perceived latency ≠ time-to-first-token**: users judge the delay as
+   "time until the reply is fully spoken," not "time until it starts." A
+   reply that's slow to *start* but short feels faster than one that starts
+   quickly but talks for 3+ seconds.
+
+## Optimization implemented: parallelize `get_profile` + `retrieve_memory`
+
+[`src/tac/core/tac.py`](src/tac/core/tac.py) — `TAC.retrieve_memory()` now
+fires `get_profile()` and `retrieve_memory()` concurrently via
+`asyncio.gather()` instead of awaiting them one after another, since the
+memory recall call only needs the already-known `profile_id`, not the
+profile response itself.
+
+**Result**: memory retrieval dropped from 2713ms → 2229ms → 2546ms across two
+follow-up calls — a modest, noisy improvement (not the ~50% reduction a clean
+parallelization would suggest). This points to a deeper bottleneck.
+
+## Root cause candidate, not yet fixed: no HTTP connection reuse
+
+[`src/tac/context/base.py:98-105`](src/tac/context/base.py:98) —
+`BaseAPIClient._get_client()` creates a **brand-new `httpx.AsyncClient` for
+every single API call**, used once and torn down immediately
+(`async with self._get_client() as client:`). This means every
+`get_profile()` / `retrieve_memory()` / `lookup_profile()` call pays a fresh
+TCP connection + TLS handshake with no keep-alive reuse, which likely
+explains why parallelizing the two calls didn't roughly halve latency — both
+calls independently pay the same fixed per-request connection cost, so
+running them concurrently only removes the *serial* penalty, not the
+per-request overhead itself.
+
+The existing code comment ("avoid event loop issues") suggests this was a
+deliberate tradeoff, likely to avoid sharing a client across event loops
+(e.g. test runners spinning up a new loop per test). Fixing this safely would
+mean lazily creating and caching one `httpx.AsyncClient` per
+`(client instance, running event loop)`, invalidating/recreating it if the
+loop changes — bigger blast radius than the `asyncio.gather` change since
+`BaseAPIClient` is shared by `ConversationClient`, `KnowledgeClient`, and
+`MemoryClient`. **Deferred per user request — do this next.**
+
+## Other optimization ideas discussed (not implemented)
+
+- **Prefetch memory during the STT window**: since `setup → first prompt` is
+  already ~5.7–6.2s of otherwise-idle time (the caller is just talking),
+  kicking off memory retrieval speculatively as soon as the call/conversation
+  is known (rather than waiting for the first `prompt` event) could fully
+  hide the ~2.2–2.7s memory cost behind time that's already being spent.
+- **Smaller/faster LLM model** for shorter time-to-first-token.
+- **Trim `conversation_history`** in `voice_streaming.py` to the last N turns
+  — currently unbounded, so context (and prefill time) grows every turn.
+- **Bypass Agents SDK overhead**: `Runner.run_streamed(agent, ...)` carries
+  full agent-loop framework cost (tool dispatch, guardrails) even when the
+  agent has no tools; a raw `client.responses.create(stream=True)` call might
+  shave off framework overhead.
+- **"Filler word" trick**: play a short pre-recorded "hmm, let me think…" the
+  instant the prompt is processed, before the LLM has produced anything —
+  masks perceived latency without changing actual LLM speed.
+- **Try alternate TTS providers** — `TwiMLOptions.tts_provider` /
+  `LanguageConfig.tts_provider` in
+  [`src/tac/models/voice.py:150,223`](src/tac/models/voice.py:150) can be
+  swapged per call; different providers may have different synthesis
+  latency.
+- **Reduce memory query scope** (`observations_limit` / `summaries_limit` /
+  `communications_limit` in `TACConfig.memory_config`) for a smaller/faster
+  recall query.
+
+## Open items for next session
+
+1. Implement connection reuse in `BaseAPIClient` (highest expected impact on
+   memory latency; needs care around event-loop safety).
+2. Re-test memory retrieval latency after the connection-reuse fix to see
+   how much of the ~2.2–2.7s was TLS/TCP handshake overhead vs. actual
+   Memory API processing time.
+3. Consider prefetching memory during the STT window for `"once"` mode.

--- a/getting_started/examples/features/voice_streaming.py
+++ b/getting_started/examples/features/voice_streaming.py
@@ -16,7 +16,7 @@ from agents import Agent, Runner, set_tracing_disabled
 from dotenv import load_dotenv
 
 from tac import TAC, TACConfig
-from tac.channels.voice import VoiceChannel
+from tac.channels.voice import VoiceChannel, VoiceChannelConfig
 from tac.models.session import ConversationSession
 from tac.models.tac import TACMemoryResponse
 from tac.server import TACFastAPIServer
@@ -25,7 +25,7 @@ load_dotenv()
 set_tracing_disabled(True)
 
 tac = TAC(config=TACConfig.from_env())
-voice_channel = VoiceChannel(tac)
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
 
 SYSTEM_INSTRUCTIONS = (
     "You are a voice assistant speaking with a user over the phone. "

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
@@ -363,6 +364,7 @@ class VoiceChannel(BaseChannel):
         if conversation_orchestrator_client is None:
             raise RuntimeError("_initialize_conversation called without Conversation Orchestrator")
 
+        init_start_at = time.monotonic()
         conversations: list[Any] = []
         for attempt in range(_POLL_ATTEMPTS):
             conversations = await conversation_orchestrator_client.list_conversations(
@@ -425,6 +427,13 @@ class VoiceChannel(BaseChannel):
             else None
         )
 
+        self.logger.info(
+            "Latency: conversation orchestrator poll/init",
+            call_sid=call_sid,
+            conversation_id=conv_id,
+            duration_ms=round((time.monotonic() - init_start_at) * 1000, 1),
+        )
+
         self._websocket_manager.add_websocket(conv_id, websocket)
         session = self._start_conversation(conv_id, profile_id)
 
@@ -460,10 +469,12 @@ class VoiceChannel(BaseChannel):
             websocket: Any WebSocket implementation satisfying WebSocketProtocol
         """
         await websocket.accept()
+        setup_received_at = time.monotonic()
         self.logger.debug("WebSocket connection established")
 
         conv_id: str | None = None
         session_state = None
+        first_prompt_seen = False
 
         try:
             # First message should be 'setup'
@@ -481,6 +492,13 @@ class VoiceChannel(BaseChannel):
                     msg_type = data.get("type")
 
                     if msg_type == "prompt":
+                        if not first_prompt_seen:
+                            first_prompt_seen = True
+                            self.logger.info(
+                                "Latency: setup to first prompt (includes user speech + STT)",
+                                call_sid=call_sid,
+                                duration_ms=round((time.monotonic() - setup_received_at) * 1000, 1),
+                            )
                         if not conv_id and call_sid:
                             if self.tac.is_orchestrator_enabled():
                                 conv_id, session_state = await self._initialize_conversation(
@@ -764,6 +782,8 @@ class VoiceChannel(BaseChannel):
             return
 
         full_response = ""
+        send_start_at = time.monotonic()
+        first_token_at: float | None = None
 
         try:
             # Check if response is an async generator (streaming)
@@ -783,6 +803,14 @@ class VoiceChannel(BaseChannel):
                                 token = str(chunk)
                         else:
                             token = chunk
+
+                        if first_token_at is None:
+                            first_token_at = time.monotonic()
+                            self.logger.info(
+                                "Latency: time to first token",
+                                conversation_id=conversation_id,
+                                duration_ms=round((first_token_at - send_start_at) * 1000, 1),
+                            )
 
                         full_response += token
                         json_template["token"] = token
@@ -808,12 +836,22 @@ class VoiceChannel(BaseChannel):
                                 "WebSocket closed before sending final marker",
                                 conversation_id=conversation_id,
                             )
+                    self.logger.info(
+                        "Latency: streaming response complete",
+                        conversation_id=conversation_id,
+                        duration_ms=round((time.monotonic() - send_start_at) * 1000, 1),
+                    )
                 except asyncio.CancelledError:
                     # Let Python's async generator cleanup handle closing the generator
                     raise
             else:
                 await websocket.send_text(
                     json.dumps({"type": "text", "token": response, "last": True})
+                )
+                self.logger.info(
+                    "Latency: response sent",
+                    conversation_id=conversation_id,
+                    duration_ms=round((time.monotonic() - send_start_at) * 1000, 1),
                 )
 
             # If a handoff is pending, send the WS "end" message now that the
@@ -882,15 +920,35 @@ class VoiceChannel(BaseChannel):
         message_body = message.voice_prompt or ""
         session = self._conversations[conv_id]
 
+        prompt_received_at = time.monotonic()
+
         # Retrieve memory if memory_mode is enabled and Twilio Memory is configured
         memory_response = await self._retrieve_memory_if_enabled(session, message_body, conv_id)
+        memory_done_at = time.monotonic()
+        self.logger.info(
+            "Latency: memory retrieval",
+            conversation_id=conv_id,
+            duration_ms=round((memory_done_at - prompt_received_at) * 1000, 1),
+        )
 
         # Trigger message ready callback
         try:
             response = await self.tac.trigger_message_ready(message_body, session, memory_response)
+            callback_done_at = time.monotonic()
+            self.logger.info(
+                "Latency: on_message_ready callback",
+                conversation_id=conv_id,
+                duration_ms=round((callback_done_at - memory_done_at) * 1000, 1),
+            )
             # Auto-send if callback returned a string (None = manual send_response flow)
             if response is not None:
                 await self.send_response(conv_id, response, role="assistant")
+            total_done_at = time.monotonic()
+            self.logger.info(
+                "Latency: total prompt handling",
+                conversation_id=conv_id,
+                duration_ms=round((total_done_at - prompt_received_at) * 1000, 1),
+            )
         except Exception as e:
             self.logger.error(
                 "Error in message ready callback",

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -184,25 +184,9 @@ class TAC:
                     )
                     raise ValueError("No profile_id or author_info available")
 
-            if conversation_context.profile_id and not conversation_context.profile:
-                try:
-                    profile_response = await self.conversation_memory_client.get_profile(
-                        profile_id=conversation_context.profile_id,
-                        trait_groups=self.config.memory_config.trait_groups,
-                    )
-                    conversation_context.profile = profile_response
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    self.logger.warning(
-                        f"Failed to fetch profile for {conversation_context.profile_id}: {e}. "
-                        "Continuing without profile data.",
-                        exc_info=True,
-                    )
-
             # Get memory retrieval configuration
             cfg = self.config.memory_config
-            memory_response = await self.conversation_memory_client.retrieve_memory(
+            memory_coro = self.conversation_memory_client.retrieve_memory(
                 profile_id=conversation_context.profile_id,
                 conversation_id=conversation_context.conversation_id,
                 query=query,
@@ -211,6 +195,33 @@ class TAC:
                 communications_limit=cfg.communications_limit,
                 relevance_threshold=cfg.relevance_threshold,
             )
+
+            profile_id = conversation_context.profile_id
+            memory_client = self.conversation_memory_client
+            if profile_id and not conversation_context.profile:
+                # get_profile only needs profile_id (already known here), so it's
+                # independent of retrieve_memory — run both concurrently instead of
+                # paying two sequential round trips.
+                async def _fetch_profile() -> None:
+                    try:
+                        profile_response = await memory_client.get_profile(
+                            profile_id=profile_id,
+                            trait_groups=cfg.trait_groups,
+                        )
+                        conversation_context.profile = profile_response
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        self.logger.warning(
+                            f"Failed to fetch profile for {profile_id}: "
+                            f"{e}. Continuing without profile data.",
+                            exc_info=True,
+                        )
+
+                _, memory_response = await asyncio.gather(_fetch_profile(), memory_coro)
+            else:
+                memory_response = await memory_coro
+
             return TACMemoryResponse(memory_response)
 
         except Exception as e:


### PR DESCRIPTION
## Summary

- Adds `INFO`-level latency logging across the Voice channel's per-turn pipeline (setup→first-prompt, CO poll/init, memory retrieval, LLM callback, time-to-first-token, streaming completion) so voice latency can be measured end-to-end against live calls.
- Parallelizes `TAC.retrieve_memory()`'s `get_profile()` and `retrieve_memory()` calls via `asyncio.gather`, since the memory recall call only needs the already-known `profile_id`, not the profile fetch result.
- Adds `VOICE_LATENCY_ANALYSIS.md` documenting live-call latency test results (cross-checked against Twilio ConversationRelay/Voice Insights event timelines), root causes identified, and remaining optimization ideas (notably: `BaseAPIClient` creates a new `httpx.AsyncClient` per request with no connection reuse — likely the next highest-impact fix, not yet implemented).

**Draft** — opened to snapshot in-progress latency testing work; not ready for review yet, more optimization work planned as a follow-up.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated (existing `test_tac.py` / `test_voice_channel.py` suites pass unchanged)
- [x] Documentation updated (`VOICE_LATENCY_ANALYSIS.md`)
- [x] Tested E2E (live phone calls via `voice_streaming.py` + Twilio Voice Insights)

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)