### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twilio-agent-connect"
-version = "2.1.1"
+version = "2.2.0"
 description = "A Python framework for building agentic applications with Twilio"
 authors = [{ name = "Twilio Conversation AI", email = "team_conversational-ai@twilio.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2768,7 +2768,7 @@ wheels = [
 
 [[package]]
 name = "twilio-agent-connect"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Bump version `2.1.1` → `2.2.0`.

Changes since `v2.1.1`:

**Features**
- Outbound Calls API passthrough, call events & AMD (#78) — adds `CallOptions`, `CallStatusEvent`, `AmdEvent`, `RecordingEvent`, the `on_call_status` / `on_amd` / `on_recording` handlers, `VoiceChannelConfig.default_call_options`, `TACConfig.voice_call_event_path`, and `ConversationSession.call_sid`.

**Fixes**
- Parse Memory `/Recall` response per-item so one malformed observation, summary, or communication no longer collapses the whole response to empty (#89).

**Other**
- Use uppercase channel names everywhere (#93) — `get_channel_name()` now returns `"SMS"` / `"VOICE"`, and the redundant `get_channel_type_upper()` is removed.
- Add `.worktreeinclude` to copy example `.env` files into new worktrees (#86).
- CI: adopt shared `twilio/sdk-actions/artifactory-oidc` and repin to `v1.0.0` (#91, #92).

> [!NOTE]
> #93 changes the documented return values of `get_channel_name()` and `ConversationSession.channel` from lowercase to uppercase and removes the published `get_channel_type_upper()`. Consumers comparing against `"sms"` / `"voice"`, or subclasses relying on the removed method, will need updating despite the minor bump.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Release / version bump

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E <!-- `make check`: lint + mypy strict + 860 tests passing -->

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

> **Tip:** Use the `/sync-to-ts-sdk` skill in Claude Code to automatically generate and create a TypeScript SDK PR from your changes.

- [x] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->
