### PR TITLE
perf(voice): start CO conversation lookup on setup, not first prompt

### DIFF
--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -718,6 +718,7 @@ class VoiceChannel(BaseChannel):
 
         conv_id: str | None = None
         session_state = None
+        init_task: asyncio.Task[tuple[str, SessionState | None]] | None = None
 
         try:
             # First message should be 'setup'
@@ -726,8 +727,17 @@ class VoiceChannel(BaseChannel):
                 setup_msg = SetupMessage(**data)
                 call_sid = setup_msg.call_sid
 
-                # Don't initialize conversation yet - wait for first prompt
-                # when ConversationRelay has created the conversation
+                # Kick off the CO conversation lookup now, in the background,
+                # instead of waiting for the first prompt. ConversationRelay
+                # creates the CO conversation as soon as the call connects, not
+                # when the caller speaks, so this overlaps CO's
+                # list_conversations/list_participants polling with the wait
+                # for the caller's first utterance (transcription) rather than
+                # paying that latency serially once the first prompt lands.
+                if call_sid and self.tac.is_orchestrator_enabled():
+                    init_task = asyncio.create_task(
+                        self._initialize_conversation(call_sid, setup_msg, websocket)
+                    )
 
                 # Process all subsequent messages
                 while True:
@@ -736,7 +746,10 @@ class VoiceChannel(BaseChannel):
 
                     if msg_type == "prompt":
                         if not conv_id and call_sid:
-                            if self.tac.is_orchestrator_enabled():
+                            if init_task is not None:
+                                conv_id, session_state = await init_task
+                                init_task = None
+                            elif self.tac.is_orchestrator_enabled():
                                 conv_id, session_state = await self._initialize_conversation(
                                     call_sid, setup_msg, websocket
                                 )
@@ -780,6 +793,22 @@ class VoiceChannel(BaseChannel):
         except Exception as e:
             self.logger.error(f"WebSocket error: {str(e)}")
         finally:
+            if init_task is not None:
+                # Call ended before any prompt arrived, so the background
+                # lookup was never awaited.
+                if not init_task.done():
+                    init_task.cancel()
+                result: tuple[str, SessionState | None] | None
+                try:
+                    result = await init_task
+                except (Exception, asyncio.CancelledError):
+                    result = None
+                if result is not None and conv_id is None:
+                    # The lookup finished and already registered the session
+                    # (websocket manager, self._conversations) as a side
+                    # effect before anyone claimed conv_id — adopt it here so
+                    # it gets cleaned up instead of leaking.
+                    conv_id = result[0]
             if conv_id:
                 self.logger.debug("Cleanup - removing WebSocket", conversation_id=conv_id)
                 await self._cleanup_connection(conv_id)

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -759,14 +759,11 @@ class VoiceChannel(BaseChannel):
                                 # Clear before awaiting so a failure here
                                 # doesn't leave `finally` re-awaiting (and
                                 # re-logging) this same task. If still
-                                # polling, this just waits it out.
+                                # polling, this just waits it out. (None here
+                                # only means relay-only mode — see "setup".)
                                 task_to_await = init_task
                                 init_task = None
                                 conv_id, session_state = await task_to_await
-                            elif self.tac.is_orchestrator_enabled():
-                                conv_id, session_state = await self._initialize_conversation(
-                                    call_sid, setup_msg, websocket
-                                )
                             else:
                                 conv_id = call_sid
                                 self._websocket_manager.add_websocket(conv_id, websocket)

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -45,8 +45,12 @@ from .config import (
     VoiceChannelConfig,
 )
 
-_POLL_ATTEMPTS = 5
+_POLL_ATTEMPTS = 10
 _POLL_BASE_DELAY = 0.25
+# Caps the exponential backoff so a higher _POLL_ATTEMPTS doesn't blow up the
+# total wait time — total worst case is comfortably bounded (~11s of sleep)
+# instead of growing exponentially with attempt count.
+_POLL_MAX_DELAY = 1.5
 
 DEFAULT_WELCOME_GREETING = "Hello! How can I assist you today?"
 
@@ -523,10 +527,8 @@ class VoiceChannel(BaseChannel):
     async def end_call(self, call_sid: str) -> bool:
         """Hang up a call and clean up its ConversationRelay session.
 
-        Works on ``call_sid`` alone, whether or not a session exists yet — safe
-        to call from a call-event handler that fires before the caller has
-        spoken (e.g. ``on_amd``). No-ops the session cleanup if none is
-        tracked.
+        Works on ``call_sid`` alone, whether or not a session exists yet.
+        No-ops the session cleanup if none is tracked.
 
         Does not raise — hanging up an already-ended call is routine (the callee
         hangs up while AMD is still resolving), and handlers shouldn't have to
@@ -631,7 +633,7 @@ class VoiceChannel(BaseChannel):
                     attempt=attempt + 1,
                     found=len(conversations),
                 )
-                await asyncio.sleep(_POLL_BASE_DELAY * (2**attempt))
+                await asyncio.sleep(min(_POLL_BASE_DELAY * (2**attempt), _POLL_MAX_DELAY))
 
         if len(conversations) != 1:
             raise RuntimeError(
@@ -754,8 +756,13 @@ class VoiceChannel(BaseChannel):
                     if msg_type == "prompt":
                         if not conv_id and call_sid:
                             if init_task is not None:
-                                conv_id, session_state = await init_task
+                                # Clear before awaiting so a failure here
+                                # doesn't leave `finally` re-awaiting (and
+                                # re-logging) this same task. If still
+                                # polling, this just waits it out.
+                                task_to_await = init_task
                                 init_task = None
+                                conv_id, session_state = await task_to_await
                             elif self.tac.is_orchestrator_enabled():
                                 conv_id, session_state = await self._initialize_conversation(
                                     call_sid, setup_msg, websocket
@@ -801,16 +808,20 @@ class VoiceChannel(BaseChannel):
             self.logger.error(f"WebSocket error: {str(e)}")
         finally:
             cancelled_error: asyncio.CancelledError | None = None
+            we_cancelled_it = False
             if init_task is not None:
                 # Call ended before any prompt arrived, so the background
                 # lookup was never awaited.
                 if not init_task.done():
                     init_task.cancel()
+                    we_cancelled_it = True
                 result: tuple[str, SessionState | None] | None
                 try:
                     result = await init_task
                 except asyncio.CancelledError as e:
-                    # Defer deciding whether to re-raise until after cleanup.
+                    # Defer re-raise decision until after cleanup below;
+                    # we_cancelled_it (not init_task.cancelled(), which can't
+                    # tell the two apart) decides whether to.
                     cancelled_error = e
                     result = None
                 except Exception as e:
@@ -829,9 +840,9 @@ class VoiceChannel(BaseChannel):
             if conv_id:
                 self.logger.debug("Cleanup - removing WebSocket", conversation_id=conv_id)
                 await self._cleanup_connection(conv_id)
-            if cancelled_error is not None and init_task is not None and not init_task.cancelled():
-                # Not our own cancel() above — a real external cancellation,
-                # so propagate it now that cleanup ran.
+            if cancelled_error is not None and not we_cancelled_it:
+                # A real external cancellation, not the one we caused above —
+                # propagate it now that cleanup ran.
                 raise cancelled_error
 
     def _merge_call_options(self, per_call: CallOptions | None) -> CallOptions | None:

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -523,9 +523,10 @@ class VoiceChannel(BaseChannel):
     async def end_call(self, call_sid: str) -> bool:
         """Hang up a call and clean up its ConversationRelay session.
 
-        Works on ``call_sid`` alone, in any mode and before a session exists, so
-        it's safe from a call-event handler that fires before the first prompt.
-        Session cleanup no-ops if no tracked session matches.
+        Works on ``call_sid`` alone, whether or not a session exists yet — safe
+        to call from a call-event handler that fires before the caller has
+        spoken (e.g. ``on_amd``). No-ops the session cleanup if none is
+        tracked.
 
         Does not raise — hanging up an already-ended call is routine (the callee
         hangs up while AMD is still resolving), and handlers shouldn't have to
@@ -565,11 +566,12 @@ class VoiceChannel(BaseChannel):
         which are keyed by conversation id: the Orchestrator conversation id in
         orchestrator mode, the CallSid only in ConversationRelay-only mode.
 
-        Sessions are created on the caller's first prompt, not at WebSocket
-        setup, so this returns ``None`` for a call that connected but hasn't been
-        spoken into. That includes ``on_amd`` under
-        ``machine_detection="Enable"``, which fires before the first prompt by
-        design — hang up with :meth:`end_call`, which needs no session.
+        Relay-only mode creates the session on the caller's first prompt.
+        Orchestrator mode creates it earlier — as soon as the background CO
+        lookup started at WebSocket setup finishes — so it may already exist
+        before the caller has said anything, including before ``on_amd``
+        fires. Either way, treat this as racy and use :meth:`end_call` to hang
+        up, which works whether or not a session exists yet.
 
         At the other end, orchestrator mode keeps the session until Conversation
         Orchestrator's CLOSED webhook, so it outlives the call and
@@ -592,9 +594,10 @@ class VoiceChannel(BaseChannel):
                 ``InitiateVoiceConversationResult.call_sid`` or a call event.
 
         Returns:
-            The session, or ``None`` — no first prompt yet, the call ended, or it
-            landed on another instance (see the horizontal-scaling note in
-            CLAUDE.md).
+            The session, or ``None`` — not created yet (relay-only mode, or
+            orchestrator mode where the background CO lookup hasn't finished),
+            the call ended, or it landed on another instance (see the
+            horizontal-scaling note in CLAUDE.md).
         """
         for session in self._conversations.values():
             if session.call_sid == call_sid:
@@ -718,6 +721,10 @@ class VoiceChannel(BaseChannel):
 
         conv_id: str | None = None
         session_state = None
+        # This call's background CO conversation lookup task (kicked off
+        # below on "setup"), consumed and reset to None on the first
+        # "prompt". Still non-None in `finally` means the call ended before
+        # any prompt arrived.
         init_task: asyncio.Task[tuple[str, SessionState | None]] | None = None
 
         try:
@@ -793,6 +800,7 @@ class VoiceChannel(BaseChannel):
         except Exception as e:
             self.logger.error(f"WebSocket error: {str(e)}")
         finally:
+            cancelled_error: asyncio.CancelledError | None = None
             if init_task is not None:
                 # Call ended before any prompt arrived, so the background
                 # lookup was never awaited.
@@ -801,17 +809,30 @@ class VoiceChannel(BaseChannel):
                 result: tuple[str, SessionState | None] | None
                 try:
                     result = await init_task
-                except (Exception, asyncio.CancelledError):
+                except asyncio.CancelledError as e:
+                    # Defer deciding whether to re-raise until after cleanup.
+                    cancelled_error = e
+                    result = None
+                except Exception as e:
+                    # No prompt ever arrived to surface this failure via the
+                    # outer except Exception above, so log it here instead.
+                    self.logger.error(
+                        f"Background CO conversation lookup failed: {e}",
+                        call_sid=call_sid,
+                    )
                     result = None
                 if result is not None and conv_id is None:
-                    # The lookup finished and already registered the session
-                    # (websocket manager, self._conversations) as a side
-                    # effect before anyone claimed conv_id — adopt it here so
-                    # it gets cleaned up instead of leaking.
+                    # The lookup already registered the session/websocket
+                    # before anyone claimed conv_id — adopt it so it's
+                    # cleaned up instead of leaked.
                     conv_id = result[0]
             if conv_id:
                 self.logger.debug("Cleanup - removing WebSocket", conversation_id=conv_id)
                 await self._cleanup_connection(conv_id)
+            if cancelled_error is not None and init_task is not None and not init_task.cancelled():
+                # Not our own cancel() above — a real external cancellation,
+                # so propagate it now that cleanup ran.
+                raise cancelled_error
 
     def _merge_call_options(self, per_call: CallOptions | None) -> CallOptions | None:
         """Overlay ``per_call`` onto ``VoiceChannelConfig.default_call_options``.

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -2129,34 +2129,79 @@ class TestConversationInitializationFlow:
         assert len(channel._conversations) == 0
 
     @pytest.mark.asyncio
-    async def test_setup_message_does_not_initialize_conversation(self) -> None:
-        """Test that setup message stores call_sid but doesn't initialize conversation."""
+    async def test_setup_message_starts_background_conversation_init(self) -> None:
+        """Setup kicks off the CO lookup immediately in the background — it
+        doesn't wait for the first prompt — so it overlaps with the wait for
+        the caller's first utterance instead of adding to it.
+
+        If the call disconnects before any prompt arrives to claim the
+        result, the websocket the lookup already registered (as a side
+        effect of `_initialize_conversation`) must still be cleaned up, not
+        leaked. (The conversation itself intentionally stays in
+        `_conversations` until CO's CLOSED webhook, same as any other
+        orchestrator-mode call — see `_cleanup_connection`.)
+        """
         from tac.channels.websocket_protocol import WebSocketDisconnectError
+        from tac.models.conversation import ParticipantAddress, ParticipantResponse
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(tac)
 
-        # Mock Conversation Orchestrator (should not be called during setup)
-        tac.conversation_orchestrator_client.list_conversations = AsyncMock()
-        tac.conversation_orchestrator_client.list_participants = AsyncMock()
+        mock_conversation = ConversationResponse(
+            id="CH_setup_test",
+            accountId="ACtest123",
+            configuration_id="conv_configuration_test123",
+            status="ACTIVE",
+        )
+        co_client = tac.conversation_orchestrator_client
+        co_client.list_conversations = AsyncMock(return_value=[mock_conversation])
+        mock_participant = ParticipantResponse(
+            id="PA_test",
+            conversation_id="CH_setup_test",
+            account_id="ACtest123",
+            name="Test Participant",
+            profile_id="profile_setup",
+            addresses=[ParticipantAddress(channel="VOICE", address="+15551234567")],
+        )
+        co_client.list_participants = AsyncMock(return_value=[mock_participant])
 
-        # Create mock websocket: setup -> disconnect (no prompt)
+        # Create mock websocket: setup -> disconnect (no prompt ever arrives).
+        # receive_json yields to the event loop a couple of times before
+        # raising, so the background init task gets a chance to actually run
+        # (rather than being cancelled before it starts) — this is what makes
+        # the "already registered, must be cleaned up" path deterministic.
         mock_websocket = AsyncMock()
         setup_data = {"type": "setup", "callSid": "CA_setup_test", "from": "+15551234567"}
+        call_count = 0
 
-        mock_websocket.receive_json = AsyncMock(
-            side_effect=[setup_data, WebSocketDisconnectError()]
-        )
+        async def fake_receive_json() -> dict[str, str]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return setup_data
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            raise WebSocketDisconnectError()
 
-        # Drive handle_websocket - should process setup but not initialize conversation
+        mock_websocket.receive_json = fake_receive_json
+
+        # Drive handle_websocket - should start CO lookup on setup and clean
+        # up properly when the call ends before any prompt claims it.
         await channel.handle_websocket(mock_websocket)
 
-        # Verify CO was NOT called (initialization only on first prompt)
-        tac.conversation_orchestrator_client.list_conversations.assert_not_called()
-        tac.conversation_orchestrator_client.list_participants.assert_not_called()
+        # The background lookup ran to completion (not cancelled mid-flight).
+        co_client.list_conversations.assert_called_once_with(
+            channel_id="CA_setup_test",
+            status=["ACTIVE"],
+        )
+        co_client.list_participants.assert_called_once_with("CH_setup_test")
 
-        # Verify no conversations initialized
-        assert len(channel._conversations) == 0
+        # The websocket registration is cleaned up (not leaked) even though
+        # no prompt ever arrived to claim conv_id itself.
+        assert not channel._websocket_manager.has_websocket("CH_setup_test")
+        # The conversation entry legitimately stays until CO's CLOSED
+        # webhook — same as any other orchestrator-mode call.
+        assert list(channel._conversations.keys()) == ["CH_setup_test"]
 
     @pytest.mark.asyncio
     async def test_subsequent_prompts_reuse_conversation(self) -> None:

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -2068,8 +2068,8 @@ class TestConversationInitializationFlow:
         assert "Expected exactly 1 conversation" in captured.out
         assert "but found 0" in captured.out
 
-        # Verify Conversation Orchestrator was polled (up to 5 attempts)
-        assert tac.conversation_orchestrator_client.list_conversations.call_count == 5
+        # Verify Conversation Orchestrator was polled (up to _POLL_ATTEMPTS)
+        assert tac.conversation_orchestrator_client.list_conversations.call_count == 10
 
         # Verify no conversation was initialized
         assert len(channel._conversations) == 0
@@ -2122,8 +2122,8 @@ class TestConversationInitializationFlow:
         assert "Expected exactly 1 conversation" in captured.out
         assert "but found 2" in captured.out
 
-        # Verify CO was polled (up to 5 attempts since count != 1)
-        assert co_client.list_conversations.call_count == 5
+        # Verify CO was polled (up to _POLL_ATTEMPTS since count != 1)
+        assert co_client.list_conversations.call_count == 10
 
         # Verify no conversation was initialized
         assert len(channel._conversations) == 0


### PR DESCRIPTION
## Summary

- On every voice call's first turn, the Conversation Orchestrator (CO) conversation lookup (`list_conversations` poll + `list_participants`) was only triggered once the first `"prompt"` WebSocket message arrived — i.e. **after** the caller's speech had already been transcribed. That latency (0.8s–4.1s observed locally, see data below) was paid serially, in front of memory retrieval and the LLM call, on every call.
- ConversationRelay creates the CO conversation as soon as the call connects, not when the caller speaks — there's no reason to wait for the first prompt before starting the lookup.
- This PR kicks off `_initialize_conversation` in the background as soon as the `"setup"` WS message arrives (`call_sid` is known immediately), so CO's polling overlaps with the wait for the caller's first utterance (speech + ASR) instead of adding to it. The first `"prompt"` handler now just awaits the already-running (often already-finished) task.

## Reason

Investigated first-utterance latency on a local ConversationRelay + Conversation Orchestrator + Memory setup. Breaking down the first turn end-to-end showed CO's conversation lookup was a fixed serial cost on every call, unrelated to what the caller said, entirely avoidable by starting it earlier.

## Solution

In `VoiceChannel.handle_websocket`:
- On `"setup"`, if Conversation Orchestrator is enabled, start `_initialize_conversation(...)` via `asyncio.create_task` instead of waiting.
- On the first `"prompt"`, `await` that task (instead of calling `_initialize_conversation` fresh) to get `conv_id`/`session_state`.
- In the `finally` cleanup path, handle the case where the call disconnects before any prompt arrives: cancel the task if it's still running, or — if it already completed and registered the session/websocket as a side effect — adopt its `conv_id` so cleanup still runs instead of leaking the websocket registration. (The conversation entry itself intentionally stays in `_conversations` until CO's `CLOSED` webhook, same as any other orchestrator-mode call — unrelated to this change.)
- The `finally` block's `CancelledError` handling only swallows the cancellation it caused itself (tracked via an explicit `we_cancelled_it` flag, set when we call `init_task.cancel()`); a real external cancellation (e.g. server shutdown) runs the same best-effort cleanup first, then propagates instead of being silently absorbed. (`init_task.cancelled()` looked like it could answer this without an extra flag, but it can't — cancelling this coroutine's own enclosing task while suspended on `await init_task` also cancels `init_task` as a side effect, making external cancellation indistinguishable from our own.)
- Raised `_POLL_ATTEMPTS` from 5 to 10 and capped the exponential backoff via `_POLL_MAX_DELAY` (was unbounded — 10 attempts uncapped would balloon to ~2 minutes of sleep). The CO poll window used to be measured from the first prompt (i.e. after the caller had already started speaking, giving CO plenty of time); starting it at `"setup"` instead measures the same window from call-connect, which is earlier and leaves less slack — an early transient miss could exhaust all attempts before the caller even finishes speaking. The longer, capped window on the single background poll comfortably covers the wait for the first prompt too, so `await init_task` at the first prompt just waits out whatever's left rather than needing a second poll-and-give-up phase.

## Behavior change (flagged in review, addressed via docs)

In orchestrator mode, `_initialize_conversation`'s side effects (registering the session in `self._conversations` and the websocket in `WebSocketManager`) can now happen before the caller has said anything, since they run as soon as the background CO lookup finishes rather than being gated on the first prompt. Concretely: `get_conversation_session_by_call_sid` may now return a session before `on_amd` fires (under `machine_detection="Enable"`), where it previously always returned `None` at that point. `end_call` is unaffected — it already handles both cases. Updated the docstrings on both methods to reflect this.

Given this changes a documented public-API guarantee, this should ship with a version bump.

## Tests

- Rewrote `test_setup_message_does_not_initialize_conversation` (which asserted the *old* behavior) as `test_setup_message_starts_background_conversation_init`, which verifies:
  - the CO lookup runs to completion starting from `"setup"`, not `"prompt"`
  - if the call disconnects before any prompt arrives, the websocket registration is still cleaned up (not leaked), while the conversation entry legitimately stays tracked until CO's `CLOSED` webhook, matching existing `_cleanup_connection` semantics
- `test_error_when_no_conversations_found` / `test_error_when_multiple_conversations_found` updated for the `_POLL_ATTEMPTS` bump (now assert 10 poll calls instead of 5). `test_subsequent_prompts_reuse_conversation` and other existing tests continue to pass unchanged.
- Full suite: `make check` (ruff + mypy strict + pytest) — all green, no regressions.

## Data

Measured via a temporary local logging harness (not included in this PR) across real calls against a ConversationRelay + CO + Memory + streaming OpenAI Agents SDK setup.

**Before** (CO init triggered on first prompt, fully serial):

| Stage | Duration |
|---|---|
| CO conversation poll | 452ms |
| CO list_participants | 314ms |
| `_initialize_conversation` total | 768ms — **paid in full on the critical path** |

**After** (CO init triggered on setup, in background), across 4 separate real calls, including one where the caller only said "hi" (shortest realistic case, smallest overlap margin):

| Call | `_initialize_conversation` total (background) | Added latency at first prompt |
|---|---|---|
| 1 | 4136ms | 0ms (`already_done=True`) |
| 2 | 3595ms | 0ms (`already_done=True`) |
| 3 (said "hi") | 4351ms | 0ms (`already_done=True`) |
| 4 (said "hi") | 4122ms | 0ms (`already_done=True`) |

In every case, by the time the first `"prompt"` (i.e. transcribed speech) arrived, the background CO lookup had already finished — confirmed via a direct measurement of the wait at that `await` point, not inferred from totals. Even the shortest realistic utterance ("hi") didn't erode the overlap margin enough to leak latency back onto the critical path in these tests, though the margin does shrink as the caller's first utterance gets shorter — worth keeping an eye on in production telemetry.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change (see "Behavior change" above — a documented `get_conversation_session_by_call_sid` guarantee no longer holds in orchestrator mode)
- [x] Documentation update (docstrings for `get_conversation_session_by_call_sid` / `end_call`)
- [x] Refactoring (CO lookup scheduling)
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested E2E (real phone calls against ConversationRelay + CO + Memory)

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [x] Change is Python-specific (no TypeScript update needed) — `asyncio` task-scheduling change local to `VoiceChannel`; the behavior change noted above is Python-SDK-internal and doesn't correspond to shared cross-SDK semantics
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


