### PR TITLE
chore: add wenzhu1587 to CODEOWNERS, bump pypi-publish action to v1.14.2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ryanrishi @xinghaohuang91 @ryanrouleau
+* @ryanrishi @xinghaohuang91 @ryanrouleau @wenzhu1587

--- a/.github/ci-requirements.txt
+++ b/.github/ci-requirements.txt
@@ -8,5 +8,5 @@
 # newer version is available on PyPI. Before merging such a PR, confirm the
 # new version is actually mirrored in Artifactory (re-run this workflow) —
 # Dependabot only checks PyPI, not Artifactory's mirror status.
-twine==6.2.0
+twine==7.0.0
 jaraco.functools==4.5.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,4 +80,4 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2


### PR DESCRIPTION
## Summary

- Add `@wenzhu1587` to `.github/CODEOWNERS`.
- Bump `pypa/gh-action-pypi-publish` from v1.14.0 to v1.14.2 in the release workflow. This pulls in twine v7, which adds support for core metadata v2.5 (the default since hatchling 1.32) and fixes `InvalidDistribution: '2.5' is not a valid metadata version` errors seen during publish.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated (n/a — CI config and ownership metadata only)
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)