### PR TITLE
perf(memory): parallelize recall, skip query expansion in once mode

### DIFF
--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -190,33 +190,69 @@ class TAC:
                     )
                     raise ValueError("No profile_id or author_info available")
 
-            if conversation_context.profile_id and not conversation_context.profile:
-                try:
-                    profile_response = await self.conversation_memory_client.get_profile(
-                        profile_id=conversation_context.profile_id,
-                        trait_groups=self.config.memory_config.trait_groups,
-                    )
-                    conversation_context.profile = profile_response
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    self.logger.warning(
-                        f"Failed to fetch profile for {conversation_context.profile_id}: {e}. "
-                        "Continuing without profile data.",
-                        exc_info=True,
-                    )
+            # profile_id is guaranteed non-None here: the block above either
+            # already had it, resolved it via lookup, or raised. assert makes
+            # that explicit for type checkers that don't trace the if/raise
+            # control flow above (mypy does; not all do); pulled into a
+            # local so every use below is unambiguously `str`.
+            assert conversation_context.profile_id is not None
+            profile_id: str = conversation_context.profile_id
 
             # Get memory retrieval configuration
             cfg = self.config.memory_config
-            memory_response = await self.conversation_memory_client.retrieve_memory(
-                profile_id=conversation_context.profile_id,
-                conversation_id=conversation_context.conversation_id,
+            # Per Twilio Memory docs, passing conversation_id without a query
+            # triggers server-side "query expansion" — an LLM call to infer
+            # a query from the conversation's history — which is expensive
+            # (observed 3-10s) and, in this SDK, only ever happens on "once"
+            # mode's cache-priming fetch (query=None). That fetch has no
+            # per-turn topic to rank against anyway, so omit conversation_id
+            # too when query is None: this drops relevance-based ranking in
+            # favor of most-recent-first ordering (same memory types, no
+            # data lost, per the docs), trading conversation-aware ranking
+            # for skipping the expensive expansion call. "always" mode
+            # (real per-turn query) is unaffected — conversation_id still
+            # passed whenever query is provided.
+            memory_call = self.conversation_memory_client.retrieve_memory(
+                profile_id=profile_id,
+                conversation_id=(
+                    conversation_context.conversation_id if query is not None else None
+                ),
                 query=query,
                 observations_limit=cfg.observations_limit,
                 summaries_limit=cfg.summaries_limit,
                 communications_limit=cfg.communications_limit,
                 relevance_threshold=cfg.relevance_threshold,
             )
+
+            if not conversation_context.profile:
+                # get_profile only needs profile_id, which is already
+                # resolved above — it doesn't depend on memory_call's result
+                # (or vice versa), so run them concurrently instead of
+                # paying both round trips serially.
+                profile_call = self.conversation_memory_client.get_profile(
+                    profile_id=profile_id,
+                    trait_groups=cfg.trait_groups,
+                )
+                profile_result: Any
+                memory_response: Any
+                profile_result, memory_response = await asyncio.gather(
+                    profile_call, memory_call, return_exceptions=True
+                )
+                if isinstance(profile_result, BaseException):
+                    if isinstance(profile_result, asyncio.CancelledError):
+                        raise profile_result
+                    self.logger.warning(
+                        f"Failed to fetch profile for {profile_id}: "
+                        f"{profile_result}. Continuing without profile data.",
+                        exc_info=profile_result,
+                    )
+                else:
+                    conversation_context.profile = profile_result
+                if isinstance(memory_response, BaseException):
+                    raise memory_response
+            else:
+                memory_response = await memory_call
+
             return TACMemoryResponse(memory_response)
 
         except Exception as e:

--- a/tests/test_profile_lookup_in_memory.py
+++ b/tests/test_profile_lookup_in_memory.py
@@ -179,9 +179,13 @@ class TestProfileLookupInMemoryRetrieval:
 
         # Verify first profile was used
         assert session.profile_id == "mem_profile_00000000000000000000000001"
+        # conversation_id is omitted (not "conv_test_123") when query is None:
+        # passing conversation_id without a query triggers expensive
+        # server-side query expansion, which this call has no per-turn topic
+        # to justify anyway.
         tac.conversation_memory_client.retrieve_memory.assert_called_once_with(
             profile_id="mem_profile_00000000000000000000000001",
-            conversation_id="conv_test_123",
+            conversation_id=None,
             query=None,
             observations_limit=20,
             summaries_limit=5,


### PR DESCRIPTION
## Summary

Following up on #103 (early CO conversation lookup), continued investigating first-utterance voice latency. With CO init fully hidden in the background, the remaining dominant cost on the critical path turned out to be Conversation Memory's `/Recall` call (`retrieve_memory`) — specifically, an expensive server-side "query expansion" step, not the client-side code. This PR:

1. Runs `get_profile` and `retrieve_memory` concurrently instead of sequentially (they're independent I/O).
2. Omits `conversation_id` from the `/Recall` request when `query` is `None` (i.e. `memory_mode="once"`'s cache-priming fetch), which — per Twilio Memory docs and confirmed with the Memory team — avoids triggering an expensive server-side query-expansion LLM call. Measured `query_time` dropped from **3.1–10s down to ~40ms**.

## Investigation (why, and how we got here)

Real-call testing (local ConversationRelay + CO + Memory + streaming OpenAI Agents SDK) after #103 showed first-turn latency was still dominated by memory retrieval:

| Stage | Typical duration |
|---|---|
| CO init (background, hidden — see #103) | 3-4s, but 0ms on the critical path |
| `get_profile` | 400-800ms |
| `retrieve_memory` (`/Recall`) | **2-10s+** |
| LLM generation | 0.8-2s |

**Step 1 — parallelize the two independent calls.** `get_profile` only needs `profile_id` (already resolved by that point); `retrieve_memory` doesn't depend on the profile fetch either. Ran them via `asyncio.gather` instead of sequentially — a straightforward win, same pattern as #103's CO overlap.

**Step 2 — why is `/Recall` itself so slow and so variable?** Checked the [Twilio Memory Recall API docs](https://www.twilio.com/docs/api/memory/v1/retrieval/create-fetch-profile-memory):
- `query` omitted but `conversationId` provided → *"a [query] is inferred from the conversation context"* — an expansion step.
- Both omitted → *"results are returned in most-recent order without relevance scores"* — no expansion.
- The response includes a `queryTime` field (ms) for latency monitoring, already modeled in this SDK as `MemoryRetrievalMeta.query_time` but never logged/used anywhere.

Logged `query_time` temporarily to see the actual server-side number (not just our client-side measurement, which also includes network/transport time):

| Sample | Config | `query_time_ms` |
|---|---|---|
| 1 | default (`observations_limit=20`, `summaries_limit=5`, `conversation_id` sent) | 3103 |

That's ~88% of the measured client-side `retrieve_memory` duration (3530ms) — the bottleneck is server-side, not network/connection overhead.

**Ruled out: tuning `observations_limit`/`summaries_limit`.** Hypothesized lower limits might reduce server processing. Tested `observations_limit=5`, `summaries_limit=2` (down from defaults 20/5) across 4 calls:

| Sample | `query_time_ms` |
|---|---|
| 1 | 5175 |
| 2 | 3956 |
| 3 | 10068 |
| 4 | 4531 |

Average ~5.9s — *worse* than the single default-config sample, with huge call-to-call variance (3956-10068ms even at the same limits). This ruled out limits as the lever — the variance pointed at something else entirely.

**Confirmed root cause via Memory team.** A Memory team audit of real `/Recall` requests found the OpenAI query-expansion LLM call responsible for ~92% of total recall duration (3893ms of 4235ms average), including one request that hit a 10s OpenAI timeout (reaching 10,069ms total — matching our sample #3 above almost exactly). A Memory team engineer confirmed in follow-up: the store is already on Cohere (not a vector-search backend issue), and *"the high latency is in fact from the query expansion llm call"* — triggered because, even in `once` mode, `retrieve_memory` isn't called until the first prompt, by which point the conversation already has history, so passing `conversation_id` (with no query) causes the server to try to infer one.

**Step 3 — the actual fix.** Since `once` mode already passes `query=None` (no per-turn topic to search for — see `channels/base.py`'s `"once"` branch), there's no relevance-ranking benefit being captured today, only the expansion cost. Also omitting `conversation_id` in that specific case (query is None) means neither trigger condition for expansion is met server-side, so it falls back to `most-recent order` — same memory types returned (observations/summaries/communications), just reordered by recency instead of inferred relevance. `always` mode (real per-turn `query`) is unaffected — it still sends `conversation_id`.

## Data (after the fix)

| Call | `query_time_ms` |
|---|---|
| 1 | 40 |
| 2 | 43 |

Consistent, stable, ~75-100x faster than the 3.1-10s range observed before. First-turn `_handle_prompt` total dropped from 4905-7234ms to ~2631ms in a live test call (remaining cost is `get_profile` + LLM generation, both unrelated to this fix).

As a sanity check, also tested `memory_mode="never"` (no memory at all) for comparison: first-turn total ~1652ms — confirming memory retrieval genuinely was the dominant remaining cost, and that this fix (2631ms) closes most of that gap without giving up memory entirely.

## Behavior change

For `once` mode's fetch specifically: results are now ordered most-recent-first instead of relevance-ranked (per Twilio docs, this is the documented fallback behavior when neither `query` nor `conversationId` is sent — no memory types are lost, only the ordering/relevance-scoring changes). Given `once` mode already sends no query, the practical loss is conversation-aware ranking on an otherwise-unranked fetch, traded for skipping a multi-second (occasionally 10s+, timeout-prone) LLM call server-side. `always` mode is fully unaffected.

## Solution

In `TAC.retrieve_memory` (`src/tac/core/tac.py`):
- `get_profile` and `retrieve_memory` now run via `asyncio.gather(..., return_exceptions=True)`, preserving prior error-handling semantics exactly: a `get_profile` failure logs a warning and continues without profile data; a `retrieve_memory` failure re-raises into the existing outer `except Exception` fallback (CO `list_communications`, or empty). `CancelledError` from either is re-raised, never swallowed.
- `conversation_id` is passed only when `query is not None`; omitted otherwise.
- Extracted `profile_id` to a local `str` variable (with an `assert`) once the preceding `if not profile_id: ... raise` block guarantees it's resolved — makes every use site (`retrieve_memory`, `get_profile`, the warning log) unambiguously typed, rather than relying on control-flow narrowing of an object attribute that not every type checker traces (mypy does; some IDEs don't).

## Tests

- Updated `test_retrieve_memory_lookup_uses_first_profile` (`tests/test_profile_lookup_in_memory.py`), which asserted `conversation_id` was always passed — now asserts `conversation_id=None` for the query-less path, matching the new intentional behavior.
- Full suite: `make check` (ruff + mypy strict + pytest) — all green, no regressions.
- E2E: multiple real phone calls against ConversationRelay + CO + Memory + streaming OpenAI Agents SDK, with temporary logging (not included in this PR) to capture the before/after data above.

## Type of Change

- [x] Bug fix (query expansion was firing on every `once`-mode call with no query to justify it)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring (concurrent I/O, `profile_id` narrowing)
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E (real phone calls against ConversationRelay + CO + Memory; cross-checked with the Memory team's own audit of the same latency)

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [x] Change is Python-specific (no TypeScript update needed) — internal `TAC.retrieve_memory` implementation; the underlying Memory API behavior (and the fix) is server-side and equally applicable to the TypeScript SDK's own `retrieve_memory` call, worth flagging there separately
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
