### PR TITLE
perf(memory): skip query expansion for once-mode recall

### DIFF
--- a/getting_started/examples/features/voice_streaming.py
+++ b/getting_started/examples/features/voice_streaming.py
@@ -54,9 +54,7 @@ async def handle_message_ready(
     agent_input = history + [{"role": "user", "content": user_message}]
 
     # Inject retrieved memory and profile into this turn's instructions.
-    turn_instructions = MemoryPromptBuilder.compose(
-        SYSTEM_INSTRUCTIONS, memory_response, context
-    )
+    turn_instructions = MemoryPromptBuilder.compose(SYSTEM_INSTRUCTIONS, memory_response, context)
     turn_agent = agent.clone(instructions=turn_instructions)
 
     async def stream_tokens() -> AsyncGenerator[str, None]:

--- a/getting_started/examples/features/voice_streaming.py
+++ b/getting_started/examples/features/voice_streaming.py
@@ -16,7 +16,8 @@ from agents import Agent, Runner, set_tracing_disabled
 from dotenv import load_dotenv
 
 from tac import TAC, TACConfig
-from tac.channels.voice import VoiceChannel
+from tac.adapters.prompt_builder import MemoryPromptBuilder
+from tac.channels.voice import VoiceChannel, VoiceChannelConfig
 from tac.models.session import ConversationSession
 from tac.models.tac import TACMemoryResponse
 from tac.server import TACFastAPIServer
@@ -25,7 +26,7 @@ load_dotenv()
 set_tracing_disabled(True)
 
 tac = TAC(config=TACConfig.from_env())
-voice_channel = VoiceChannel(tac)
+voice_channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
 
 SYSTEM_INSTRUCTIONS = (
     "You are a voice assistant speaking with a user over the phone. "
@@ -52,8 +53,14 @@ async def handle_message_ready(
     history = conversation_history.get(conv_id, [])
     agent_input = history + [{"role": "user", "content": user_message}]
 
+    # Inject retrieved memory and profile into this turn's instructions.
+    turn_instructions = MemoryPromptBuilder.compose(
+        SYSTEM_INSTRUCTIONS, memory_response, context
+    )
+    turn_agent = agent.clone(instructions=turn_instructions)
+
     async def stream_tokens() -> AsyncGenerator[str, None]:
-        result = Runner.run_streamed(agent, agent_input)
+        result = Runner.run_streamed(turn_agent, agent_input)
         async for event in result.stream_events():
             if event.type == "raw_response_event" and hasattr(event.data, "delta"):
                 yield event.data.delta

--- a/src/tac/channels/base.py
+++ b/src/tac/channels/base.py
@@ -302,7 +302,9 @@ class BaseChannel(ABC):
 
         if self.memory_mode == "always":
             try:
-                memory_response = await self.tac.retrieve_memory(session, query=query)
+                memory_response = await self.tac.retrieve_memory(
+                    session, query=query, conversation_id=session.conversation_id
+                )
                 self.logger.debug(
                     "Memory retrieved",
                     conversation_id=conv_id,
@@ -329,7 +331,9 @@ class BaseChannel(ABC):
                     )
                     memory_response = session.cached_memory
                 else:
-                    # First retrieval - use empty query and cache result
+                    # First retrieval - use empty query and cache result. No
+                    # per-turn topic here, so leave conversation_id unset too
+                    # (avoids an expensive server-side query-expansion step).
                     try:
                         memory_response = await self.tac.retrieve_memory(session, query=None)
                         session.cached_memory = memory_response

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -224,9 +224,7 @@ class TAC:
                 communications_limit=cfg.communications_limit,
                 relevance_threshold=cfg.relevance_threshold,
             )
-            self.logger.debug(
-                "Recall query_time", query_time_ms=memory_response.meta.query_time
-            )
+            self.logger.debug("Recall query_time", query_time_ms=memory_response.meta.query_time)
             return TACMemoryResponse(memory_response)
 
         except Exception as e:

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -138,6 +138,7 @@ class TAC:
         self,
         conversation_context: ConversationSession,
         query: str | None = None,
+        conversation_id: str | None = None,
     ) -> TACMemoryResponse:
         """Retrieve memories from Memory Store with fallback to Conversation Orchestrator.
 
@@ -149,6 +150,12 @@ class TAC:
         Args:
             conversation_context: Session containing conversation and profile information.
             query: Optional search query to filter memories.
+            conversation_id: Passed through to the /Recall request as-is; the
+                caller decides whether (and which) conversation_id to send.
+                Passing one without a query makes Twilio Memory infer a query
+                from that conversation's history — an expensive server-side
+                step — so leave this unset for fetches with no per-turn topic
+                to justify that cost (e.g. "once" mode's cache-priming fetch).
 
         Returns:
             Memory response containing conversation history and profile data.
@@ -210,12 +217,15 @@ class TAC:
             cfg = self.config.memory_config
             memory_response = await self.conversation_memory_client.retrieve_memory(
                 profile_id=conversation_context.profile_id,
-                conversation_id=conversation_context.conversation_id,
+                conversation_id=conversation_id,
                 query=query,
                 observations_limit=cfg.observations_limit,
                 summaries_limit=cfg.summaries_limit,
                 communications_limit=cfg.communications_limit,
                 relevance_threshold=cfg.relevance_threshold,
+            )
+            self.logger.debug(
+                "Recall query_time", query_time_ms=memory_response.meta.query_time
             )
             return TACMemoryResponse(memory_response)
 

--- a/tests/test_memory_fallback.py
+++ b/tests/test_memory_fallback.py
@@ -89,7 +89,9 @@ class TestMemoryFallback:
         )
 
         # Execute
-        result = await tac.retrieve_memory(context, query="test query")
+        result = await tac.retrieve_memory(
+            context, query="test query", conversation_id=context.conversation_id
+        )
 
         # Verify
         tac.conversation_memory_client.retrieve_memory.assert_called_once_with(

--- a/tests/test_memory_mode_once.py
+++ b/tests/test_memory_mode_once.py
@@ -158,6 +158,10 @@ async def test_once_mode_caches_memory_on_first_retrieval() -> None:
 
     # Verify retrieve_memory was only called once (on first message)
     assert retrieve_memory_mock.call_count == 1
+    # "once" mode's cache-priming fetch has no per-turn topic, so
+    # conversation_id is left unset to avoid triggering server-side
+    # query expansion.
+    assert retrieve_memory_mock.call_args.kwargs["conversation_id"] is None
 
     # Verify all callbacks received memory response
     assert len(captured_memory_responses) == 3

--- a/tests/test_profile_lookup_in_memory.py
+++ b/tests/test_profile_lookup_in_memory.py
@@ -61,7 +61,9 @@ class TestProfileLookupInMemoryRetrieval:
         )
 
         # Retrieve memory
-        result = await tac.retrieve_memory(session, query="test query")
+        result = await tac.retrieve_memory(
+            session, query="test query", conversation_id=session.conversation_id
+        )
 
         # Verify memory was retrieved without lookup - result is wrapped in TACMemoryResponse
         from tac.models.tac import TACMemoryResponse
@@ -114,7 +116,9 @@ class TestProfileLookupInMemoryRetrieval:
         )
 
         # Retrieve memory
-        result = await tac.retrieve_memory(session, query="test query")
+        result = await tac.retrieve_memory(
+            session, query="test query", conversation_id=session.conversation_id
+        )
 
         # Verify profile was looked up
         tac.conversation_memory_client.lookup_profile.assert_called_once_with(
@@ -175,7 +179,7 @@ class TestProfileLookupInMemoryRetrieval:
         )
 
         # Retrieve memory
-        await tac.retrieve_memory(session)
+        await tac.retrieve_memory(session, conversation_id=session.conversation_id)
 
         # Verify first profile was used
         assert session.profile_id == "mem_profile_00000000000000000000000001"


### PR DESCRIPTION
## Summary

Following up on #103 (early CO conversation lookup), continued investigating first-utterance voice latency. With CO init fully hidden in the background, the remaining dominant cost on the critical path turned out to be Conversation Memory's `/Recall` call (`retrieve_memory`) — specifically, an expensive server-side "query expansion" step triggered on `memory_mode="once"`'s cache-priming fetch, not the client-side code.

This PR adds an explicit `conversation_id` parameter to `TAC.retrieve_memory`, passed straight through to the `/Recall` request instead of always being pulled from `conversation_context`. `once` mode's fetch now omits it entirely, skipping query expansion. Measured `/Recall` server-side `query_time` dropped from **3.1–10s down to ~40ms**, consistently, across multiple calls.

## Why (the investigation)

Real-call testing (local ConversationRelay + CO + Memory + streaming OpenAI Agents SDK) after #103 showed first-turn latency was still dominated by memory retrieval — `retrieve_memory` was taking 2-10s+ per call, on the critical path.

**Checked the [Twilio Memory Recall API docs](https://www.twilio.com/docs/api/memory/v1/retrieval/create-fetch-profile-memory):**
- `query` omitted but `conversationId` provided → *"a [query] is inferred from the conversation context"* — an expansion step.
- Both omitted → *"results are returned in most-recent order without relevance scores"* — no expansion, same memory types returned either way, just reordered.
- The response includes a `queryTime` field (ms), already modeled in this SDK as `MemoryRetrievalMeta.query_time` but never logged/used anywhere.

**Logged `query_time` temporarily to see the actual server-side number** (not just client-side, which also includes network/transport time):

| Sample | Config | `query_time_ms` |
|---|---|---|
| 1 | default limits, `conversation_id` sent | 3103 |

That's ~88% of the measured client-side `retrieve_memory` duration (3530ms) at the time — the bottleneck is server-side, not network/connection overhead.

**Ruled out tuning `observations_limit`/`summaries_limit`.** Hypothesized lower limits might reduce server processing. Tested `observations_limit=5`, `summaries_limit=2` (down from defaults 20/5) across 4 calls:

| Sample | `query_time_ms` |
|---|---|
| 1 | 5175 |
| 2 | 3956 |
| 3 | 10068 |
| 4 | 4531 |

Average ~5.9s — *worse* than the single default-config sample, with huge call-to-call variance (3956-10068ms at the same limits). This ruled out limits as the lever — the variance pointed at something else entirely.

**Confirmed root cause with the Memory team.** A Memory team audit of real `/Recall` requests found the OpenAI query-expansion LLM call responsible for ~92% of total recall duration (3893ms of 4235ms average), including one request that hit a 10s OpenAI timeout (reaching 10,069ms total — matching our sample #3 above almost exactly). A Memory team engineer confirmed: the store is already on Cohere (not a vector-search backend issue), and *"the high latency is in fact from the query expansion llm call"* — triggered because, even in `once` mode, `retrieve_memory` isn't called until the first prompt, by which point the conversation already has history, so passing `conversation_id` (with no query) causes the server to try to infer one.

## How (the fix)

Since `once` mode already passes `query=None` (no per-turn topic to search for — see `channels/base.py`'s `"once"` branch), there's no relevance-ranking benefit being captured today, only the expansion cost. `TAC.retrieve_memory` gained an explicit `conversation_id: str | None = None` parameter — passed through to `/Recall` as-is, with the caller deciding whether (and which) conversation_id to send, rather than the function always reaching into `conversation_context.conversation_id` internally:

- `channels/base.py`'s `"always"` mode (real per-turn `query`) explicitly passes `conversation_id=session.conversation_id` — unaffected, same behavior as before.
- `"once"` mode's cache-priming fetch passes neither `query` nor `conversation_id` — skips expansion, falls back to most-recent-order results (same memory types, just reordered by recency instead of inferred relevance).

The two Conversation Orchestrator `list_communications` fallback calls elsewhere in `retrieve_memory` (used when Memory isn't configured, or when `/Recall` itself fails) are untouched — they're a different API with no query-expansion behavior, and always need the real `conversation_context.conversation_id` to know which conversation to ask about.

Kept a single `self.logger.debug("Recall query_time", query_time_ms=...)` log so this is directly observable in production going forward, without needing to re-add instrumentation next time.

**Out of scope, deliberately:** also parallelizing `get_profile` and `retrieve_memory` via `asyncio.gather` — a smaller, independent win identified during this investigation, left for a follow-up PR so this one stays focused on a single, fully-tested change.

## Data (after the fix)

| Call | `query_time_ms` |
|---|---|
| 1 | 40 |
| 2 | 43 |
| 3 | 40 |

Consistent, stable, ~75-100x faster than the 3.1-10s range observed before, across three separate real calls (including after further comment/docstring cleanup, re-verified once more before opening this PR).

## Solution

- `TAC.retrieve_memory` (`src/tac/core/tac.py`): added `conversation_id: str | None = None`, passed straight to the `/Recall` call; docstring explains the query-expansion tradeoff and that the caller decides what to send.
- `channels/base.py`: `"always"` mode passes `conversation_id=session.conversation_id` explicitly; `"once"` mode passes neither `query` nor `conversation_id`.
- `getting_started/examples/features/voice_streaming.py`: switched to `memory_mode="once"` and wired the retrieved memory into the LLM's instructions via `MemoryPromptBuilder`, so the example actually demonstrates memory being used (previously fetched and silently discarded).

## Tests

- `tests/test_profile_lookup_in_memory.py` / `tests/test_memory_fallback.py`: updated direct `TAC.retrieve_memory` calls to explicitly pass `conversation_id=` where the test's intent is unrelated to this change (profile lookup precedence, fallback behavior), preserving their original assertions.
- `tests/test_memory_mode_once.py`: added an assertion on the real `"once"`-mode call path confirming `conversation_id` is `None`.
- Full suite: `make check` (ruff + mypy strict + pytest) — all green, no regressions.
- E2E: multiple real phone calls against ConversationRelay + CO + Memory + streaming OpenAI Agents SDK, capturing the before/after `query_time` data above.

## Type of Change

- [x] Bug fix (query expansion was firing on every `once`-mode call with no per-turn query to justify it)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E (real phone calls against ConversationRelay + CO + Memory; cross-checked with the Memory team's own audit of the same latency)

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [x] Change is Python-specific (no TypeScript update needed) — internal `TAC.retrieve_memory` signature change; the underlying Memory API behavior (and the fix) is server-side and equally applicable to the TypeScript SDK's own `retrieve_memory` call, worth flagging there separately
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
