### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twilio-agent-connect"
-version = "2.2.0"
+version = "2.3.0"
 description = "A Python framework for building agentic applications with Twilio"
 authors = [{ name = "Twilio Conversation AI", email = "team_conversational-ai@twilio.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2768,7 +2768,7 @@ wheels = [
 
 [[package]]
 name = "twilio-agent-connect"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Bumps package version to 2.3.0 (minor) ahead of release. Since 2.2.0, main includes a new feature in addition to fixes/perf/refactor work:

- feat: Surface dropped inbound messages via new `on_error` callback (#88)
- fix(memory): batch-wrap `create_observation` and remove observation auto-creation (#90)
- refactor(channels): Deduplicate `send_response` across messaging channels (#94)
- chore: add wenzhu1587 to CODEOWNERS, bump pypi-publish action to v1.14.2 (#104)
- perf(voice): start CO conversation lookup on setup, not first prompt (#103)
- perf(memory): skip query expansion for once-mode recall (#106)

## Type of Change

- [x] Release / version bump

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)