### PR TITLE
fix(ci): revert pypa/gh-action-pypi-publish to allowlisted v1.14.0 SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,4 +80,4 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Summary

#104 bumped `pypa/gh-action-pypi-publish` to the v1.14.2 SHA (`a892a5a6...`), which is not on the org's GitHub Actions allowlist. This causes every `Deploy` workflow run to fail immediately with `startup_failure` (0 jobs scheduled) — confirmed on the `v2.3.0` release run (https://github.com/twilio/twilio-agent-connect-python/actions/runs/32156493715), which shows:

> The action `pypa/gh-action-pypi-publish@a892a5a6...` is not allowed in twilio/twilio-agent-connect-python because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: ... `pypa/gh-action-pypi-publish@4cf0fdb7e1623e99dab752bc00bab23c0b69d050`, `pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b` ...

This reverts to `cef221092ed1bacb1cc03d23a2d87d1d172e277b` (v1.14.0), the SHA that was already allowlisted and working before #104.

## Type of Change

- [x] Bug fix

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)