### PR TITLE
fix(build): pin hatchling<1.30, revert ci twine to 6.2.0

### DIFF
--- a/.github/ci-requirements.txt
+++ b/.github/ci-requirements.txt
@@ -8,5 +8,5 @@
 # newer version is available on PyPI. Before merging such a PR, confirm the
 # new version is actually mirrored in Artifactory (re-run this workflow) —
 # Dependabot only checks PyPI, not Artifactory's mirror status.
-twine==7.0.0
+twine==6.2.0
 jaraco.functools==4.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,10 @@ members = ["tac"]
 tac = { workspace = true }
 
 [build-system]
-requires = ["hatchling"]
+# hatchling>=1.30 defaults to Metadata-Version 2.5, which the org-allowlisted
+# pypa/gh-action-pypi-publish pin (v1.14.0) can't validate yet. Cap below that
+# until a newer, allowlisted publish action pin is available.
+requires = ["hatchling<1.30"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

Fully self-contained fix for the metadata-version 2.5 issue blocking PyPI publish — no dependency on the pending org allowlist change ([secure-supply-chain-domain#90](https://github.com/twilio-internal/secure-supply-chain-domain/pull/90)).

- Pin `hatchling<1.30` in `[build-system]` — hatchling >=1.30 defaults to `Metadata-Version: 2.5`, which the org-allowlisted `pypa/gh-action-pypi-publish@cef221092e...` (v1.14.0, restored in #108) can't validate with its bundled twine.
- Revert `.github/ci-requirements.txt`'s `twine` pin from `7.0.0` back to `6.2.0` — that bump (#104) was only papering over the same issue for `ci.yml`'s separate metadata-check step; no longer needed once hatchling is capped.

## Verified locally

```
$ uv build
Metadata-Version: 2.4    # confirmed via dist-info/METADATA

$ twine==6.2.0 check dist/*
Checking dist/twilio_agent_connect-2.3.0-py3-none-any.whl: PASSED
Checking dist/twilio_agent_connect-2.3.0.tar.gz: PASSED
```

## Type of Change

- [x] Bug fix

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Tested E2E

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)