### PR TITLE
Fail fast when messaging_channels contains None

### DIFF
--- a/src/tac/server/fastapi_server.py
+++ b/src/tac/server/fastapi_server.py
@@ -117,7 +117,7 @@ class TACFastAPIServer:
         if any(channel is None for channel in self.messaging_channels):
             raise TypeError(
                 "messaging_channels must not contain None — filter out any "
-                "unbuilt/optional channels before passing the list in."
+                "unbuilt/unconfigured channels before passing the list in."
             )
 
         if self.voice_channel is not None:

--- a/src/tac/server/fastapi_server.py
+++ b/src/tac/server/fastapi_server.py
@@ -114,6 +114,12 @@ class TACFastAPIServer:
         self.voice_channel = voice_channel
         self.messaging_channels: list[MessagingChannel] = messaging_channels or []
 
+        if any(channel is None for channel in self.messaging_channels):
+            raise TypeError(
+                "messaging_channels must not contain None — filter out any "
+                "unbuilt/optional channels before passing the list in."
+            )
+
         if self.voice_channel is not None:
             self._validate_voice_url_config()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -178,6 +178,36 @@ class TestVoiceUrlConfigValidationAtStartup:
         )  # no raise: /twiml vs /twiml/status, /twiml/amd, /twiml/recording
 
 
+class TestMessagingChannelsValidationAtStartup:
+    """A None entry in messaging_channels (e.g. a channel a caller only
+    conditionally builds) must fail fast at construction, not surface later
+    as an AttributeError deep in webhook dispatch."""
+
+    def test_raises_when_messaging_channels_contains_none(self) -> None:
+        from tac.channels.sms import SMSChannel
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        sms = SMSChannel(tac)
+
+        with pytest.raises(TypeError, match="messaging_channels"):
+            TACFastAPIServer(tac=tac, messaging_channels=[sms, None])  # type: ignore[list-item]
+
+    def test_passes_with_no_none_entries(self) -> None:
+        from tac.channels.sms import SMSChannel
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        sms = SMSChannel(tac)
+        TACFastAPIServer(tac=tac, messaging_channels=[sms])  # no raise
+
+    def test_passes_with_none_messaging_channels(self) -> None:
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        TACFastAPIServer(tac=tac, messaging_channels=None)  # no raise
+
+
 class TestCallEventRoutes:
     """One route per Twilio callback; the route is the event discriminator."""
 


### PR DESCRIPTION
## Summary
- `TACFastAPIServer.__init__` now raises a clear `TypeError` at construction time if `messaging_channels` contains a `None` entry, instead of silently storing it and letting it surface later as an `AttributeError` deep in webhook dispatch (`channel.process_webhook(...)` called on `None`).
- Motivated by a real case in a downstream connector: a caller conditionally builds a channel (e.g. `SMSChannel` only when some optional config is present) and passes `[maybe_channel]` — type hints say this shouldn't happen (`list[MessagingChannel]`), but nothing enforces that at runtime, and a file outside the type-checked path (or just a missed `mypy` run) lets it through silently.
- Follows the existing "fail fast at construction" precedent already used for voice URL config (`_validate_voice_url_config`).

## Test plan
- [x] `make test` — full suite passes (876 tests)
- [x] `make lint` — clean
- [x] `make type-check` — clean
- [x] New tests: raises on `[channel, None]`, passes with no `None` entries, passes with `messaging_channels=None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)