### PR TITLE
refactor(voice): compose VoiceChannel with a pluggable VoiceStrategy

### DIFF
--- a/src/tac/channels/voice/__init__.py
+++ b/src/tac/channels/voice/__init__.py
@@ -1,13 +1,22 @@
-"""Voice channel for handling voice-based conversations."""
+"""Voice channel for handling voice-based conversations.
+
+``VoiceChannel`` is the single public entry point for voice — it owns the
+Twilio Calls API lifecycle. The media transport itself is a
+``VoiceProvider``; ``ConversationRelayProvider`` (Twilio-managed ASR/TTS)
+is the only implementation today.
+"""
 
 from tac.channels.voice.channel import VoiceChannel
 from tac.channels.voice.config import (
     AmdHandler,
     CallStatusHandler,
+    ConversationRelayProviderConfig,
     InboundCallTwiMLHandler,
     RecordingHandler,
     VoiceChannelConfig,
 )
+from tac.channels.voice.conversation_relay import ConversationRelayProvider
+from tac.channels.voice.provider import VoiceProvider
 from tac.channels.voice.twiml import generate_twiml
 from tac.models.outbound import CallOptions
 from tac.models.voice import (
@@ -26,6 +35,8 @@ __all__ = [
     "CallOptions",
     "CallStatusEvent",
     "CallStatusHandler",
+    "ConversationRelayProvider",
+    "ConversationRelayProviderConfig",
     "InboundCallTwiMLHandler",
     "InterruptMode",
     "LanguageConfig",
@@ -35,5 +46,6 @@ __all__ = [
     "TwiMLRequest",
     "VoiceChannel",
     "VoiceChannelConfig",
+    "VoiceProvider",
     "generate_twiml",
 ]

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -1,42 +1,30 @@
 from __future__ import annotations
 
 import asyncio
-import json
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from twilio.rest import Client
 
-from pydantic import ValidationError
-
 from tac.channels.base import BaseChannel
-from tac.channels.websocket_manager import WebSocketManager
-from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
-from tac.core.config import CallEventKind
+from tac.channels.voice.conversation_relay import ConversationRelayProvider
+from tac.channels.voice.provider import VoiceProvider
+from tac.channels.websocket_protocol import WebSocketProtocol
 from tac.core.tac import TAC
 from tac.models.outbound import (
-    CallOptions,
     InitiateVoiceConversationOptions,
     InitiateVoiceConversationResult,
 )
-from tac.models.session import AuthorInfo, ConversationSession
+from tac.models.session import ConversationSession
 from tac.models.voice import (
     AmdEvent,
     CallStatusEvent,
-    ConversationRelayCallbackPayload,
-    InterruptMessage,
-    PromptMessage,
     RecordingEvent,
-    SetupMessage,
     TwiMLOptions,
     TwiMLRequest,
 )
-from tac.session import SessionState
-from tac.tools.handoff import studio_voice_handoff_url
-from tac.utils.redaction import mask_phone, redact_twiml_parameters
 
-from . import twiml
 from .config import (
     AmdHandler,
     CallStatusHandler,
@@ -45,63 +33,54 @@ from .config import (
     VoiceChannelConfig,
 )
 
-_POLL_ATTEMPTS = 10
-_POLL_BASE_DELAY = 0.25
-# Caps the exponential backoff so a higher _POLL_ATTEMPTS doesn't blow up the
-# total wait time — total worst case is comfortably bounded (~11s of sleep)
-# instead of growing exponentially with attempt count.
-_POLL_MAX_DELAY = 1.5
-
-DEFAULT_WELCOME_GREETING = "Hello! How can I assist you today?"
-
 
 class VoiceChannel(BaseChannel):
     """
     Voice Channel for handling voice-based conversations via WebSocket.
 
-    Key features:
-    - TwiML generation for incoming calls (see twiml module)
-    - WebSocket connection management for real-time voice streaming
-    - Conversation lifecycle management (inherited from BaseChannel)
-    - Outbound call initiation
-
-    This channel is framework-agnostic and accepts any WebSocket implementation
-    satisfying WebSocketProtocol. For a batteries-included FastAPI server, use
+    Framework-agnostic — accepts any WebSocket implementation satisfying
+    WebSocketProtocol. For a batteries-included FastAPI server, use
     tac.server.TACFastAPIServer.
+
+    The real-time media transport is a pluggable ``VoiceProvider``
+    (``ConversationRelayProvider`` by default). This class owns everything
+    shared regardless of provider: the Twilio Calls API lifecycle and
+    conversation bookkeeping inherited from ``BaseChannel``.
     """
 
     def __init__(
         self,
         tac: TAC,
-        config: VoiceChannelConfig | dict[str, Any] | None = None,
+        config: VoiceChannelConfig | dict[str, Any] | VoiceProvider | None = None,
     ):
         """
         Initialize Voice channel for websocket protocol handling.
 
         Args:
             tac: TAC instance for memory/context operations
-            config: Voice channel configuration (VoiceChannelConfig or dict).
-                If None, uses default configuration.
+            config: Either configuration for the default
+                ``ConversationRelayProvider`` (``VoiceChannelConfig`` or
+                dict), or a ``VoiceProvider`` instance to use directly.
+                Only ``ConversationRelayProvider`` supports
+                ``memory_mode``/``default_call_options`` today.
 
         Examples:
-            >>> channel = VoiceChannel(tac, config={"memory_mode": "always"})
-            >>> channel = VoiceChannel(tac, config=VoiceChannelConfig(session_manager=sm))
-            >>> channel = VoiceChannel(tac)  # Use defaults
+            >>> channel = VoiceChannel(tac)  # ConversationRelay, defaults
+            >>> channel = VoiceChannel(tac, {"memory_mode": "always"})
+            >>> channel = VoiceChannel(
+            ...     tac,
+            ...     ConversationRelayProvider(
+            ...         ConversationRelayProviderConfig(memory_mode="always")
+            ...     ),
+            ... )
         """
-        # Convert dict to config model or use defaults
-        if isinstance(config, dict):
-            config = VoiceChannelConfig(**config)
-        elif config is None:
-            config = VoiceChannelConfig()
-
-        super().__init__(tac, memory_mode=config.memory_mode)
-        self.config = config
-        self.session_manager = config.session_manager
-        self._on_inbound_call_twiml: InboundCallTwiMLHandler | None = None
+        self._provider: VoiceProvider = (
+            config if isinstance(config, VoiceProvider) else ConversationRelayProvider(config)
+        )
+        super().__init__(tac, memory_mode=self._provider.memory_mode)
         self._on_call_status: CallStatusHandler | None = None
         self._on_amd: AmdHandler | None = None
         self._on_recording: RecordingHandler | None = None
-        self._websocket_manager = WebSocketManager()
         self._twilio_client: Client | None = None
 
     def on_inbound_call_twiml(self, callback: InboundCallTwiMLHandler) -> None:
@@ -127,7 +106,7 @@ class VoiceChannel(BaseChannel):
         Outbound calls don't use this — pass per-call TwiML via
         ``InitiateVoiceConversationOptions.twiml_options`` directly.
         """
-        self._on_inbound_call_twiml = callback
+        self._provider.on_inbound_call_twiml(callback)
 
     def on_call_status(self, callback: CallStatusHandler) -> None:
         """Register a handler for Twilio ``status_callback`` webhooks.
@@ -213,26 +192,6 @@ class VoiceChannel(BaseChannel):
             "(or TACConfig.voice_public_domain)."
         )
 
-    def _resolve_default_action_url(self) -> str | None:
-        """Resolve the default ``<Connect action=...>`` cleanup URL.
-
-        Returns None if ``voice_public_domain`` isn't set; that's fine because
-        action_url has higher-priority layers (customizer, twiml_options,
-        Studio handoff) above this fallback.
-        """
-        if self.tac.config.voice_public_domain:
-            return (
-                f"https://{self.tac.config.voice_public_domain}{self.tac.config.voice_action_path}"
-            )
-        return None
-
-    @staticmethod
-    def _caller_address(setup_msg: SetupMessage) -> str | None:
-        """Return the phone number of the remote caller/callee from the setup message."""
-        if setup_msg.direction and setup_msg.direction.upper() == "OUTBOUND":
-            return setup_msg.to_number
-        return setup_msg.from_number
-
     def _get_twilio_client(self) -> Client:
         if self._twilio_client is None:
             from twilio.rest import Client
@@ -251,155 +210,22 @@ class VoiceChannel(BaseChannel):
         host_twiml_options: TwiMLOptions | None = None,
     ) -> str:
         """
-        Generate TwiML response for incoming voice calls.
-
-        ConversationRelay automatically handles conversation creation and participant
-        management via the ``conversation_configuration`` parameter.
-
-        The WebSocket URL and default session-cleanup action URL are derived
-        from ``TACConfig.voice_public_domain`` + ``TACConfig.voice_websocket_path``
-        / ``voice_action_path``.
-
-        TwiML fields are merged per-field, highest precedence first:
-          1. Output of the customizer registered via
-             ``VoiceChannel.on_inbound_call_twiml(...)`` if configured
-             and ``twiml_request`` is given. (Application-owned.)
-          2. ``VoiceChannelConfig.default_twiml_options`` — per-channel defaults.
-          3. ``host_twiml_options`` — per-call transport facts supplied by the
-             host (the code owning the route), e.g. a per-call ``websocket_url``
-             with an affinity token.
-          4. TAC defaults: a fixed default ``welcome_greeting``,
-             ``conversation_configuration`` from ``TACConfig``,
-             ``action_url`` resolved via Studio handoff (when
-             ``studio_handoff_flow_sid`` is configured), else derived from
-             ``TACConfig.voice_public_domain`` + ``voice_action_path``, and the
-             ``websocket_url`` derived from ``TACConfig.voice_public_domain`` +
-             ``voice_websocket_path``.
-
-        Fields not set at a layer fall through to lower layers. Lists
-        (``languages``) and nested models (``custom_parameters``) replace
-        wholesale when set at a higher-priority layer. ``websocket_url`` falls
-        back to the ``TACConfig``-derived URL if unset at every layer.
-
-        The two arguments are complementary, not alternatives — a custom host
-        typically passes both on the same call: ``twiml_request`` carries the
-        inbound call's data (so the application's customizer can run), and
-        ``host_twiml_options`` carries the host's own per-call overrides.
+        Generate TwiML response for incoming voice calls. Delegates entirely
+        to the active provider — see ``ConversationRelayProvider.handle_incoming_call``
+        for the full merge-order documentation (customizer, default_twiml_options,
+        TAC defaults). A non-``ConversationRelayProvider`` provider ignores
+        ``twiml_request`` and ``host_twiml_options`` beyond ``websocket_url``.
 
         Args:
             twiml_request: The incoming Twilio voice webhook, parsed into a
                 framework-neutral form (From, To, CallSid, CallerCountry, …).
-                Supplied by Twilio; forwarded to the ``on_inbound_call_twiml``
-                customizer so the application can produce per-call overrides.
             host_twiml_options: Per-call TwiML overrides supplied by the *host*
-                (the code owning the route — e.g. a custom server), for
-                transport facts the SDK can't derive, such as a per-call
-                ``websocket_url`` with an affinity token. Layered below
-                ``default_twiml_options`` and the application customizer, so a
-                developer's explicit settings still win.
+                (the code owning the route — e.g. a custom server).
 
         Returns:
             TwiML XML string for call connection.
         """
-        customized: TwiMLOptions | None = None
-        if self._on_inbound_call_twiml is not None and twiml_request is not None:
-            customized = await self._on_inbound_call_twiml(twiml_request)
-
-        merged = self._build_twiml_options(host_twiml_options, customized)
-        # merged.websocket_url is either a validated non-empty URL (set by some
-        # layer) or None; fall back to the TACConfig-derived URL only when None.
-        websocket_url = (
-            merged.websocket_url
-            if merged.websocket_url is not None
-            else self._resolve_websocket_url("handle_incoming_call")
-        )
-        return twiml.generate_twiml(websocket_url, merged)
-
-    def _build_twiml_options(
-        self,
-        host: TwiMLOptions | None,
-        per_call: TwiMLOptions | None,
-    ) -> TwiMLOptions:
-        """Layer TwiML options, lowest precedence first: TAC defaults →
-        ``host`` (calling host's per-call values) → ``default_twiml_options`` →
-        ``per_call`` (application customizer output for inbound, or
-        ``InitiateVoiceConversationOptions.twiml_options`` for outbound).
-        """
-        merged = TwiMLOptions(
-            welcome_greeting=DEFAULT_WELCOME_GREETING,
-            conversation_configuration=self.tac.config.conversation_configuration_id,
-            action_url=self._resolve_action_url(host, per_call),
-        )
-        if host is not None:
-            self._overlay_fields(merged, host)
-        if self.config.default_twiml_options is not None:
-            self._overlay_fields(merged, self.config.default_twiml_options)
-        if per_call is not None:
-            self._overlay_fields(merged, per_call)
-        return merged
-
-    @staticmethod
-    def _overlay_fields(target: TwiMLOptions, source: TwiMLOptions) -> None:
-        """Apply fields explicitly set on ``source`` onto ``target``.
-
-        Nested models (``custom_parameters``), lists (``languages``), and
-        dicts (``extra``) replace wholesale — there's no per-key merging.
-        If you add a field that should merge (e.g. a dict of headers),
-        special-case it here instead of getting the default overwrite behavior.
-
-        ``action_url`` is skipped here on purpose — it's resolved once via
-        ``_resolve_action_url`` looking at every layer at once, and that
-        resolved value is written into ``target`` before this overlay runs.
-        Letting it through here would let a higher-priority layer that didn't
-        set action_url silently clobber a lower layer that did.
-        """
-        for field in source.model_fields_set:
-            if field == "action_url":
-                continue
-            setattr(target, field, getattr(source, field))
-
-    def _resolve_action_url(
-        self,
-        host: TwiMLOptions | None,
-        customized: TwiMLOptions | None,
-    ) -> str | None:
-        """Resolve the TwiML ``<Connect action=...>`` URL.
-
-        Precedence (highest to lowest):
-          1. application customizer
-          2. channel ``default_twiml_options``
-          3. ``host`` (calling host's per-call options)
-          4. Studio handoff (when ``studio_handoff_flow_sid`` is configured)
-          5. Channel default — derived from ``TACConfig.voice_public_domain``
-             + ``TACConfig.voice_action_path``.
-
-        User-expressed intent (Studio handoff is configured explicitly on
-        ``TACConfig``) beats the SDK's generated cleanup default. If a user
-        sets both Studio handoff and runs in relay-only mode, Studio wins
-        for that call — the session-cleanup URL is skipped, same as if they
-        had set any other action_url via customizer or static options.
-
-        Explicit ``action_url=None`` on a layer suppresses
-        ``<Connect action=...>`` entirely — all lower layers are skipped.
-        Use this to disable the cleanup callback for a specific call (e.g.
-        from a customizer) or channel-wide. ``action_url`` left unset (not
-        in ``model_fields_set``) falls through to the next layer.
-        """
-        if customized is not None and "action_url" in customized.model_fields_set:
-            return customized.action_url
-        if (
-            self.config.default_twiml_options is not None
-            and "action_url" in self.config.default_twiml_options.model_fields_set
-        ):
-            return self.config.default_twiml_options.action_url
-        if host is not None and "action_url" in host.model_fields_set:
-            return host.action_url
-        if self.tac.config.studio_handoff_flow_sid:
-            return studio_voice_handoff_url(
-                self.tac.config.account_sid,
-                self.tac.config.studio_handoff_flow_sid,
-            )
-        return self._resolve_default_action_url()
+        return await self._provider.handle_incoming_call(self, twiml_request, host_twiml_options)
 
     async def handle_conversation_relay_callback(
         self,
@@ -415,32 +241,7 @@ class VoiceChannel(BaseChannel):
         Args:
             payload_dict: Raw form data dict from the webhook request.
         """
-        try:
-            payload = ConversationRelayCallbackPayload(**payload_dict)
-        except ValidationError:
-            self.logger.warning(
-                "Invalid ConversationRelay callback payload, ignoring",
-                payload_keys=list(payload_dict.keys()),
-            )
-            return
-
-        if payload.account_sid != self.tac.config.account_sid:
-            self.logger.warning(
-                "ConversationRelay callback account_sid mismatch, ignoring",
-                expected=self.tac.config.account_sid,
-                received=payload.account_sid,
-            )
-            return
-
-        self.logger.debug(
-            "ConversationRelay callback received",
-            call_sid=payload.call_sid,
-            call_status=payload.call_status,
-        )
-
-        if payload.call_status == "completed" and not self.tac.is_orchestrator_enabled():
-            if payload.call_sid in self._conversations:
-                await self._end_conversation(payload.call_sid)
+        await self._provider.handle_conversation_relay_callback(self, payload_dict)
 
     def _call_event_account_ok(self, payload_dict: dict[str, str]) -> bool:
         """Whether a call-webhook payload belongs to the configured account.
@@ -525,7 +326,7 @@ class VoiceChannel(BaseChannel):
         await self._on_recording(event)
 
     async def end_call(self, call_sid: str) -> bool:
-        """Hang up a call and clean up its ConversationRelay session.
+        """Hang up a call and clean up its session, regardless of provider.
 
         Works on ``call_sid`` alone, whether or not a session exists yet.
         No-ops the session cleanup if none is tracked.
@@ -606,290 +407,14 @@ class VoiceChannel(BaseChannel):
                 return session
         return None
 
-    async def _initialize_conversation(
-        self,
-        call_sid: str,
-        setup_msg: SetupMessage,
-        websocket: WebSocketProtocol,
-    ) -> tuple[str, SessionState | None]:
-        """Poll CO for the conversation created by ConversationRelay, resolve
-        the customer participant, and initialize the local session."""
-        conversation_orchestrator_client = self.tac.conversation_orchestrator_client
-        if conversation_orchestrator_client is None:
-            raise RuntimeError("_initialize_conversation called without Conversation Orchestrator")
-
-        conversations: list[Any] = []
-        for attempt in range(_POLL_ATTEMPTS):
-            conversations = await conversation_orchestrator_client.list_conversations(
-                channel_id=call_sid,
-                status=["ACTIVE"],
-            )
-            if len(conversations) == 1:
-                break
-            if attempt < _POLL_ATTEMPTS - 1:
-                self.logger.debug(
-                    "Conversation not ready yet, polling again",
-                    call_sid=call_sid,
-                    attempt=attempt + 1,
-                    found=len(conversations),
-                )
-                await asyncio.sleep(min(_POLL_BASE_DELAY * (2**attempt), _POLL_MAX_DELAY))
-
-        if len(conversations) != 1:
-            raise RuntimeError(
-                f"Expected exactly 1 conversation for "
-                f"call_sid {call_sid}, but found "
-                f"{len(conversations)} after "
-                f"{_POLL_ATTEMPTS} attempts."
-            )
-
-        conversation = conversations[0]
-        conv_id = conversation.id
-
-        participants = await conversation_orchestrator_client.list_participants(conv_id)
-
-        customer_participant = next(
-            (p for p in participants if p.type == "CUSTOMER"),
-            None,
-        )
-        customer_address = (
-            next(
-                (a.address for a in customer_participant.addresses if a.channel == "VOICE"),
-                None,
-            )
-            if customer_participant and customer_participant.addresses
-            else None
-        )
-        profile_lookup_address = customer_address or self._caller_address(setup_msg)
-        profile_id = customer_participant.profile_id if customer_participant else None
-
-        # Resolve the agent participant so ai_agent_info is populated on the
-        # session, matching the messaging channels. The agent is the participant
-        # that owns TAC's address (the configured phone number) on the VOICE
-        # channel and has an agent type. A HUMAN_AGENT added by a
-        # redirected/escalated call is NOT TAC and is not adopted here.
-        agent_participant = self._find_agent_participant(
-            participants, "VOICE", self.tac.config.phone_number
-        )
-        agent_address = (
-            next(
-                (a.address for a in agent_participant.addresses if a.channel == "VOICE"),
-                None,
-            )
-            if agent_participant and agent_participant.addresses
-            else None
-        )
-
-        self._websocket_manager.add_websocket(conv_id, websocket)
-        session = self._start_conversation(conv_id, profile_id)
-        # In orchestrator mode conv_id is the Orchestrator conversation id, so
-        # record the CallSid so out-of-band call webhooks can reach this session
-        # (resolved via get_conversation_session_by_call_sid).
-        session.call_sid = call_sid
-
-        session_state = None
-        if self.session_manager is not None:
-            session_state = self.session_manager.get_or_create_session(conv_id)
-
-        if profile_lookup_address:
-            session.author_info = AuthorInfo(address=profile_lookup_address)
-
-        if agent_participant:
-            # Fall back to the configured phone number we matched on — the
-            # participant owns it by definition, so it's a meaningful address
-            # even in the unlikely case it carries no explicit VOICE address.
-            session.ai_agent_info = AuthorInfo(
-                address=agent_address or self.tac.config.phone_number,
-                participant_id=agent_participant.id,
-            )
-
-        return conv_id, session_state
-
     async def handle_websocket(self, websocket: WebSocketProtocol) -> None:
         """
-        Handle voice streaming WebSocket connection lifecycle.
-
-        This method manages the entire websocket connection:
-        - Accepts the connection
-        - Processes incoming messages
-        - Tracks and cancels in-flight tasks (if session_manager provided)
-        - Cleans up on disconnect
+        Handle the per-call streaming WebSocket connection lifecycle.
 
         Args:
             websocket: Any WebSocket implementation satisfying WebSocketProtocol
         """
-        await websocket.accept()
-        self.logger.debug("WebSocket connection established")
-
-        conv_id: str | None = None
-        session_state = None
-        # This call's background CO conversation lookup task (kicked off
-        # below on "setup"), consumed and reset to None on the first
-        # "prompt". Still non-None in `finally` means the call ended before
-        # any prompt arrived.
-        init_task: asyncio.Task[tuple[str, SessionState | None]] | None = None
-
-        try:
-            # First message should be 'setup'
-            data = await websocket.receive_json()
-            if data.get("type") == "setup":
-                setup_msg = SetupMessage(**data)
-                call_sid = setup_msg.call_sid
-
-                # Kick off the CO conversation lookup now, in the background,
-                # instead of waiting for the first prompt. ConversationRelay
-                # creates the CO conversation as soon as the call connects, not
-                # when the caller speaks, so this overlaps CO's
-                # list_conversations/list_participants polling with the wait
-                # for the caller's first utterance (transcription) rather than
-                # paying that latency serially once the first prompt lands.
-                if call_sid and self.tac.is_orchestrator_enabled():
-                    init_task = asyncio.create_task(
-                        self._initialize_conversation(call_sid, setup_msg, websocket)
-                    )
-
-                # Process all subsequent messages
-                while True:
-                    data = await websocket.receive_json()
-                    msg_type = data.get("type")
-
-                    if msg_type == "prompt":
-                        if not conv_id and call_sid:
-                            if init_task is not None:
-                                # Clear before awaiting so a failure here
-                                # doesn't leave `finally` re-awaiting (and
-                                # re-logging) this same task. If still
-                                # polling, this just waits it out. (None here
-                                # only means relay-only mode — see "setup".)
-                                task_to_await = init_task
-                                init_task = None
-                                conv_id, session_state = await task_to_await
-                            else:
-                                conv_id = call_sid
-                                self._websocket_manager.add_websocket(conv_id, websocket)
-                                session = self._start_conversation(conv_id, profile_id=None)
-                                # Relay-only: conv_id == call_sid.
-                                session.call_sid = call_sid
-
-                                caller = self._caller_address(setup_msg)
-                                if caller:
-                                    self._conversations[conv_id].author_info = AuthorInfo(
-                                        address=caller,
-                                    )
-
-                                if self.session_manager is not None:
-                                    session_state = self.session_manager.get_or_create_session(
-                                        conv_id
-                                    )
-
-                        if conv_id:
-                            await self._handle_prompt_async(conv_id, data, session_state)
-                        else:
-                            self.logger.warning("Received prompt before conversation initialized")
-                    elif msg_type == "interrupt":
-                        if conv_id:
-                            await self._handle_interrupt_async(conv_id, data, session_state)
-                        else:
-                            self.logger.warning(
-                                "Received interrupt before conversation initialized"
-                            )
-                    else:
-                        self.logger.debug(f"Skip message type received: {msg_type}")
-            else:
-                self.logger.warning("First message was not 'setup'. Closing connection.")
-                await websocket.close()
-                return
-        except WebSocketDisconnectError:
-            self.logger.info("WebSocket connection closed", conversation_id=conv_id)
-        except Exception as e:
-            self.logger.error(f"WebSocket error: {str(e)}")
-        finally:
-            cancelled_error: asyncio.CancelledError | None = None
-            we_cancelled_it = False
-            if init_task is not None:
-                # Call ended before any prompt arrived, so the background
-                # lookup was never awaited.
-                if not init_task.done():
-                    init_task.cancel()
-                    we_cancelled_it = True
-                result: tuple[str, SessionState | None] | None
-                try:
-                    result = await init_task
-                except asyncio.CancelledError as e:
-                    # Defer re-raise decision until after cleanup below;
-                    # we_cancelled_it (not init_task.cancelled(), which can't
-                    # tell the two apart) decides whether to.
-                    cancelled_error = e
-                    result = None
-                except Exception as e:
-                    # No prompt ever arrived to surface this failure via the
-                    # outer except Exception above, so log it here instead.
-                    self.logger.error(
-                        f"Background CO conversation lookup failed: {e}",
-                        call_sid=call_sid,
-                    )
-                    result = None
-                if result is not None and conv_id is None:
-                    # The lookup already registered the session/websocket
-                    # before anyone claimed conv_id — adopt it so it's
-                    # cleaned up instead of leaked.
-                    conv_id = result[0]
-            if conv_id:
-                self.logger.debug("Cleanup - removing WebSocket", conversation_id=conv_id)
-                await self._cleanup_connection(conv_id)
-            if cancelled_error is not None and not we_cancelled_it:
-                # A real external cancellation, not the one we caused above —
-                # propagate it now that cleanup ran.
-                raise cancelled_error
-
-    def _merge_call_options(self, per_call: CallOptions | None) -> CallOptions | None:
-        """Overlay ``per_call`` onto ``VoiceChannelConfig.default_call_options``.
-
-        Per-field via ``model_fields_set``, same as ``_overlay_fields`` does for
-        TwiMLOptions. The merged result is re-validated so a combination only
-        reachable by layering — per-call clearing ``machine_detection`` while the
-        default set ``async_amd`` — still fails instead of reaching Twilio.
-        """
-        default = self.config.default_call_options
-        if default is None or per_call is None:
-            return per_call or default
-
-        merged = default.model_dump(by_alias=True, exclude_none=True)
-        # model_fields_set covers extras too, since CallOptions allows them.
-        for field in per_call.model_fields_set:
-            merged[field] = getattr(per_call, field)
-        return CallOptions(**merged)
-
-    def _build_call_kwargs(self, call_options: CallOptions | None) -> dict[str, Any]:
-        """Build the extra kwargs for ``client.calls.create``.
-
-        Layers, highest precedence first: this call's ``call_options``,
-        ``VoiceChannelConfig.default_call_options``, then callback URLs derived
-        from ``voice_public_domain`` + ``voice_call_event_path``.
-
-        A URL is derived only when its handler is registered. That's a deliberate
-        deviation from ``websocket_url`` / ``action_url``, which derive
-        unconditionally: those are load-bearing, so a wrong one fails loudly on
-        the first call, whereas an unwanted call-event URL fails as silent 11200
-        alerts for a feature nobody asked for. Set the URLs in
-        ``default_call_options`` when TAC isn't serving the routes.
-        """
-        merged = self._merge_call_options(call_options)
-        call_kwargs = merged.to_call_kwargs() if merged else {}
-
-        wiring: list[tuple[CallEventKind, str, Callable[..., Any] | None]] = [
-            ("status", "status_callback", self._on_call_status),
-            ("amd", "async_amd_status_callback", self._on_amd),
-            ("recording", "recording_status_callback", self._on_recording),
-        ]
-        for kind, param, handler in wiring:
-            if handler is None:
-                continue
-            url = self.tac.config.call_event_url(kind)
-            if url is not None:
-                call_kwargs.setdefault(param, url)
-
-        return call_kwargs
+        await self._provider.handle_websocket(self, websocket)
 
     async def initiate_outbound_conversation(
         self,
@@ -897,164 +422,10 @@ class VoiceChannel(BaseChannel):
     ) -> InitiateVoiceConversationResult:
         """Initiate an outbound voice conversation.
 
-        Places an outbound call with inline TwiML that connects to ConversationRelay.
-        The conversationConfiguration attribute tells CO to create and manage the
-        conversation during passive hydration. The session is initialized lazily
-        on the first prompt when the conversation is discovered by callSid.
-
-        TwiML fields are merged per-field, highest precedence first:
-          1. ``options.twiml_options`` — per-call overrides
-          2. ``VoiceChannelConfig.default_twiml_options`` — channel-wide defaults
-          3. TAC defaults: welcome greeting, ``conversation_configuration``
-             from ``TACConfig``, and ``action_url`` from Studio handoff (if
-             configured), else derived from ``TACConfig.voice_public_domain``
-             + ``voice_action_path``.
-
-        Fields not set at a layer fall through to lower layers. Lists
-        (``languages``) and nested models (``custom_parameters``) replace
-        wholesale when set at a higher-priority layer.
-
-        The WebSocket URL is derived from ``TACConfig.voice_public_domain`` +
-        ``TACConfig.voice_websocket_path``, unless overridden per-call via
-        ``options.websocket_url``.
+        Only ``ConversationRelayProvider`` supports outbound calls today —
+        raises ``NotImplementedError`` for any other provider.
         """
-        from_number = self.tac.config.phone_number
-
-        self.logger.info(
-            "Initiating outbound voice conversation",
-            to=mask_phone(options.to),
-            from_number=mask_phone(from_number),
-        )
-
-        # Outbound has no inbound customizer and no server layer; the per-call
-        # override is options.twiml_options.
-        merged = self._build_twiml_options(None, options.twiml_options)
-
-        # ``options.websocket_url`` is the dedicated per-call outbound override
-        # and wins over any websocket_url that came through the layered
-        # ``twiml_options`` merge; both fall back to the TACConfig-derived URL.
-        if options.websocket_url is not None:
-            websocket_url = options.websocket_url
-        elif merged.websocket_url is not None:
-            websocket_url = merged.websocket_url
-        else:
-            websocket_url = self._resolve_websocket_url("initiate_outbound_conversation")
-
-        call_kwargs = self._build_call_kwargs(options.call_options)
-
-        try:
-            twiml_xml = twiml.generate_twiml(websocket_url, merged)
-
-            # The inline TwiML handed to Twilio, useful for debugging the
-            # <Connect action> handoff target. custom_parameters values are
-            # masked — they're arbitrary developer data (profile IDs, caller
-            # names), unlike the WS/action URLs and conversation config.
-            self.logger.debug(
-                "Outbound call TwiML",
-                twiml=redact_twiml_parameters(twiml_xml),
-                to=mask_phone(options.to),
-            )
-
-            client = self._get_twilio_client()
-            call = await asyncio.to_thread(
-                client.calls.create,
-                to=options.to,
-                from_=from_number,
-                twiml=twiml_xml,
-                **call_kwargs,
-            )
-
-            self.logger.info(
-                "Outbound voice call placed",
-                call_sid=call.sid,
-                to=mask_phone(options.to),
-            )
-
-            return InitiateVoiceConversationResult(call_sid=call.sid)
-
-        except Exception as e:
-            self.logger.error(
-                "Failed to initiate outbound call",
-                to=mask_phone(options.to),
-                error=str(e),
-                exc_info=True,
-            )
-            raise
-
-    async def _handle_prompt_async(
-        self,
-        conv_id: str,
-        data: dict[str, Any],
-        session_state: SessionState | None,
-    ) -> None:
-        """
-        Handle prompt message asynchronously with task tracking.
-
-        Args:
-            conv_id: Conversation ID
-            data: Raw message data
-            session_state: Session state object (if session_manager provided)
-        """
-        try:
-            should_process = data.get("final", True)
-            if should_process:
-                prompt_msg = PromptMessage(**data)
-                conv_id = prompt_msg.conversation_id or conv_id
-
-                # Cancel previous stream task if session manager is enabled
-                if session_state:
-                    await session_state.cancel_stream_task()
-
-                    # Create new task using unified flow (memory retrieval + callback)
-                    session_state.stream_task = asyncio.create_task(
-                        self._handle_prompt(conv_id, prompt_msg)
-                    )
-                    # Yield to event loop to let task start
-                    await asyncio.sleep(0)
-                else:
-                    await self._handle_prompt(conv_id, prompt_msg)
-        except Exception as e:
-            self.logger.error(f"Failed to handle prompt: {str(e)}")
-
-    async def _handle_interrupt_async(
-        self,
-        conv_id: str,
-        data: dict[str, Any],
-        session_state: SessionState | None,
-    ) -> None:
-        """
-        Handle interrupt message asynchronously with task cancellation.
-
-        Args:
-            conv_id: Conversation ID
-            data: Raw message data
-            session_state: Session state object (if session_manager provided)
-        """
-        try:
-            interrupt_msg = InterruptMessage(**data)
-            conv_id = interrupt_msg.conversation_id or conv_id
-
-            # Cancel in-flight stream task if session manager is enabled
-            if session_state:
-                await session_state.cancel_stream_task()
-
-                # Send acknowledgment to Twilio after cancelling
-                websocket = self._websocket_manager.get_websocket(conv_id)
-                if websocket:
-                    try:
-                        await websocket.send_text(
-                            json.dumps({"type": "text", "token": "", "last": True})
-                        )
-                    except (WebSocketDisconnectError, RuntimeError):
-                        self.logger.debug(
-                            f"WebSocket closed before sending interrupt acknowledgment "
-                            f"for {conv_id}."
-                        )
-
-            # Call the interrupt handler
-            self._handle_interrupt(conv_id, interrupt_msg)
-        except Exception as e:
-            self.logger.error(f"Failed to handle interrupt: {str(e)}")
+        return await self._provider.initiate_outbound_conversation(self, options)
 
     async def process_webhook(
         self, webhook_data: dict[str, Any], idempotency_token: str | None = None
@@ -1122,113 +493,20 @@ class VoiceChannel(BaseChannel):
         role: str | None = None,
     ) -> None:
         """
-        Send voice response through the websocket connection for this conversation.
+        Send a response back through this channel's active provider.
 
         Supports both simple string responses and streaming async generators.
 
         Args:
             conversation_id: Conversation ID
             response: Response text (string) or async generator for streaming
-            role: Optional message role (not used in this implementation, but kept
-                  for API consistency with BaseChannel interface)
+            role: Optional message role (not used by ConversationRelayProvider, but
+                  kept for API consistency with BaseChannel interface)
         """
-        # Validate response type before processing
-        if not isinstance(response, (str, AsyncGenerator)):
-            raise TypeError("Voice channel requires string or async generator for response")
-
-        # Get WebSocket from manager
-        websocket = self._websocket_manager.get_websocket(conversation_id)
-        if not websocket:
-            self.logger.error("No websocket connection", conversation_id=conversation_id)
-            return
-
-        full_response = ""
-
-        try:
-            # Check if response is an async generator (streaming)
-            if isinstance(response, AsyncGenerator):
-                # Streaming response
-                json_template = {"type": "text", "token": "", "last": False}
-                closed = False
-                response_gen: AsyncGenerator[str | dict[str, Any], None] = response
-
-                try:
-                    async for chunk in response_gen:
-                        # Handle different chunk types (plain text or dict with metadata)
-                        if isinstance(chunk, dict):
-                            if "output" in chunk:
-                                token = chunk["output"]
-                            else:
-                                token = str(chunk)
-                        else:
-                            token = chunk
-
-                        full_response += token
-                        json_template["token"] = token
-
-                        try:
-                            await websocket.send_text(json.dumps(json_template))
-                        except (WebSocketDisconnectError, RuntimeError):
-                            self.logger.info(
-                                "WebSocket closed during streaming",
-                                conversation_id=conversation_id,
-                            )
-                            closed = True
-                            break
-
-                    # Send final message marker
-                    if not closed:
-                        try:
-                            await websocket.send_text(
-                                json.dumps({"type": "text", "token": "", "last": True})
-                            )
-                        except (WebSocketDisconnectError, RuntimeError):
-                            self.logger.info(
-                                "WebSocket closed before sending final marker",
-                                conversation_id=conversation_id,
-                            )
-                except asyncio.CancelledError:
-                    # Let Python's async generator cleanup handle closing the generator
-                    raise
-            else:
-                await websocket.send_text(
-                    json.dumps({"type": "text", "token": response, "last": True})
-                )
-
-            # If a handoff is pending, send the WS "end" message now that the
-            # LLM's final response has been delivered to the caller.
-            if conversation_id in self._conversations:
-                session = self._conversations[conversation_id]
-                if session.pending_handoff_data is not None:
-                    try:
-                        await websocket.send_text(
-                            session.pending_handoff_data.model_dump_json(by_alias=True)
-                        )
-                        session.pending_handoff_data = None
-                    except (WebSocketDisconnectError, RuntimeError):
-                        self.logger.warning(
-                            "WebSocket closed before sending handoff end message; "
-                            "caller will not be transferred",
-                            conversation_id=conversation_id,
-                        )
-
-        except asyncio.CancelledError:
-            # Re-raise to propagate cancellation up the call stack.
-            # Partial responses from interrupted streams are NOT saved to
-            # Conversation Orchestrator. Incomplete responses shouldn't be
-            # part of conversation history.
-            raise
-        except (WebSocketDisconnectError, RuntimeError):
-            self.logger.info(
-                "WebSocket closed before sending response", conversation_id=conversation_id
-            )
-        except Exception as e:
-            self.logger.error(
-                f"Error sending response: {e}", conversation_id=conversation_id, exc_info=True
-            )
+        await self._provider.send_response(self, conversation_id, response, role)
 
     def get_channel_name(self) -> str:
-        return "VOICE"
+        return self._provider.channel_name
 
     def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
         """
@@ -1240,92 +518,4 @@ class VoiceChannel(BaseChannel):
         Returns:
             WebSocket connection if exists, None otherwise
         """
-        return self._websocket_manager.get_websocket(conversation_id)
-
-    async def _handle_prompt(self, conv_id: str, message: PromptMessage) -> None:
-        """
-        Handle incoming voice prompt (user speech).
-
-        Args:
-            conv_id: Conversation ID
-            message: Parsed PromptMessage containing user's transcribed speech
-        """
-        if conv_id not in self._conversations:
-            self.logger.error(
-                f"Received prompt for unknown conversation {conv_id}. "
-                "Conversation should be initialized on first prompt.",
-                conversation_id=conv_id,
-            )
-            return
-
-        message_body = message.voice_prompt or ""
-        session = self._conversations[conv_id]
-
-        # Retrieve memory if memory_mode is enabled and Twilio Memory is configured
-        memory_response = await self._retrieve_memory_if_enabled(session, message_body, conv_id)
-
-        # Trigger message ready callback
-        try:
-            response = await self.tac.trigger_message_ready(message_body, session, memory_response)
-            # Auto-send if callback returned a string (None = manual send_response flow)
-            if response is not None:
-                await self.send_response(conv_id, response, role="assistant")
-        except Exception as e:
-            self.logger.error(
-                "Error in message ready callback",
-                conversation_id=conv_id,
-                error=str(e),
-                exc_info=True,
-            )
-
-    def _handle_interrupt(self, conv_id: str, message: InterruptMessage) -> None:
-        """
-        Handle interrupt message when user interrupts the agent.
-
-        Note: Task cancellation is handled by the async wrapper (_handle_interrupt_async)
-        when called from the WebSocket message handler. This method only triggers the
-        TAC interrupt callback.
-
-        Args:
-            conv_id: Conversation ID
-            message: Parsed InterruptMessage with interruption details
-        """
-        # Trigger interrupt callback if conversation exists
-        if conv_id in self._conversations:
-            session = self._conversations[conv_id]
-            self.tac.trigger_interrupt(session, message)
-        else:
-            self.logger.warning(
-                f"Received interrupt for unknown conversation {conv_id}, skipping callback"
-            )
-
-    async def _cleanup_connection(self, conv_id: str) -> None:
-        """
-        Clean up WebSocket and session resources when connection closes.
-
-        In orchestrated mode, the conversation remains tracked in
-        self._conversations until the CONVERSATION_UPDATED/CLOSED webhook
-        arrives from Conversation Orchestrator. In relay-only mode there is no such webhook,
-        so we also end the conversation here.
-
-        Args:
-            conv_id: Conversation ID
-        """
-        # Remove WebSocket from manager
-        if self._websocket_manager.has_websocket(conv_id):
-            self._websocket_manager.remove_websocket(conv_id)
-
-        # Cancel running stream task and cleanup session if session manager is enabled
-        if self.session_manager is not None and self.session_manager.has_session(conv_id):
-            session_state = self.session_manager.get_or_create_session(conv_id)
-            # Cancel any running task (user hung up, no point continuing)
-            await session_state.cancel_stream_task()
-            self.session_manager.remove_session(conv_id)
-
-        if not self.tac.is_orchestrator_enabled() and conv_id in self._conversations:
-            await self._end_conversation(conv_id)
-
-        self.logger.debug(
-            "Cleaned up WebSocket and session resources",
-            conversation_id=conv_id,
-        )
+        return self._provider.get_websocket(conversation_id)

--- a/src/tac/channels/voice/config.py
+++ b/src/tac/channels/voice/config.py
@@ -23,7 +23,10 @@ RecordingHandler = Callable[[RecordingEvent], Awaitable[None]]
 
 class VoiceChannelConfig(BaseModel):
     """
-    Configuration for Voice channel.
+    Configuration for ``ConversationRelayProvider`` (the default
+    ``VoiceProvider``). Only this provider supports ``memory_mode``/
+    ``default_call_options`` — no other provider integrates with memory or
+    outbound Calls API parameters.
 
     TwiML configuration layers (highest precedence first):
 
@@ -101,3 +104,8 @@ class VoiceChannelConfig(BaseModel):
         "non-default paths; they override the URLs TAC would derive from "
         "voice_public_domain + voice_call_event_path.",
     )
+
+
+# ConversationRelayProvider's config is this same class under its new name —
+# not a separate model, so this alias is the only place the two names diverge.
+ConversationRelayProviderConfig = VoiceChannelConfig

--- a/src/tac/channels/voice/conversation_relay.py
+++ b/src/tac/channels/voice/conversation_relay.py
@@ -1,0 +1,940 @@
+"""``ConversationRelayProvider``: the default ``VoiceProvider`` — Twilio
+ConversationRelay's managed setup/prompt/interrupt loop over one WebSocket,
+with Twilio doing ASR/TTS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
+
+from tac.channels.voice.config import ConversationRelayProviderConfig
+from tac.channels.voice.provider import VoiceProvider
+from tac.channels.voice.twiml import generate_twiml
+from tac.channels.websocket_manager import WebSocketManager
+from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
+from tac.core.config import CallEventKind
+from tac.models.memory import MemoryMode
+from tac.models.outbound import (
+    CallOptions,
+    InitiateVoiceConversationOptions,
+    InitiateVoiceConversationResult,
+)
+from tac.models.session import AuthorInfo
+from tac.models.voice import (
+    ConversationRelayCallbackPayload,
+    InterruptMessage,
+    PromptMessage,
+    SetupMessage,
+    TwiMLOptions,
+    TwiMLRequest,
+)
+from tac.session import SessionState
+from tac.tools.handoff import studio_voice_handoff_url
+from tac.utils.redaction import mask_phone, redact_twiml_parameters
+
+if TYPE_CHECKING:
+    from tac.channels.voice.channel import VoiceChannel
+
+DEFAULT_WELCOME_GREETING = "Hello! How can I assist you today?"
+
+_POLL_ATTEMPTS = 10
+_POLL_BASE_DELAY = 0.25
+# Caps the exponential backoff so a higher _POLL_ATTEMPTS doesn't blow up the
+# total wait time — total worst case is comfortably bounded (~11s of sleep)
+# instead of growing exponentially with attempt count.
+_POLL_MAX_DELAY = 1.5
+
+
+class ConversationRelayProvider(VoiceProvider):
+    """Twilio ConversationRelay: Twilio handles ASR/TTS and exchanges JSON
+    ``setup``/``prompt``/``interrupt`` messages over one WebSocket.
+
+    This is the default provider ``VoiceChannel`` builds when none is passed
+    explicitly.
+    """
+
+    def __init__(
+        self,
+        config: ConversationRelayProviderConfig | dict[str, Any] | None = None,
+    ) -> None:
+        if isinstance(config, dict):
+            config = ConversationRelayProviderConfig(**config)
+        elif config is None:
+            config = ConversationRelayProviderConfig()
+        self.config = config
+        self._websocket_manager = WebSocketManager()
+        self._on_inbound_call_twiml: Callable[[TwiMLRequest], Awaitable[TwiMLOptions]] | None = None
+
+    @property
+    def channel_name(self) -> str:
+        return "VOICE"
+
+    @property
+    def memory_mode(self) -> MemoryMode:
+        return self.config.memory_mode
+
+    def build_twiml(self, websocket_url: str, options: TwiMLOptions) -> str:
+        return generate_twiml(websocket_url, options)
+
+    def on_inbound_call_twiml(
+        self, callback: Callable[[TwiMLRequest], Awaitable[TwiMLOptions]]
+    ) -> None:
+        """Register a callback that produces per-call overrides for the
+        TwiML inside ``<ConversationRelay>`` on inbound calls.
+
+        The callback receives a framework-neutral ``TwiMLRequest`` (parsed
+        from the Twilio webhook form) and returns a ``TwiMLOptions``. Fields
+        the callback explicitly sets override ``default_twiml_options`` and
+        TAC defaults; unset fields fall through.
+
+        Outbound calls don't use this — pass per-call TwiML via
+        ``InitiateVoiceConversationOptions.twiml_options`` directly.
+        """
+        self._on_inbound_call_twiml = callback
+
+    async def handle_incoming_call(
+        self,
+        channel: VoiceChannel,
+        twiml_request: TwiMLRequest | None,
+        host_twiml_options: TwiMLOptions | None,
+    ) -> str:
+        """
+        Generate TwiML response for incoming voice calls.
+
+        ConversationRelay automatically handles conversation creation and participant
+        management via the ``conversation_configuration`` parameter.
+
+        The WebSocket URL and default session-cleanup action URL are derived
+        from ``TACConfig.voice_public_domain`` + ``TACConfig.voice_websocket_path``
+        / ``voice_action_path``.
+
+        TwiML fields are merged per-field, highest precedence first:
+          1. Output of the customizer registered via
+             ``on_inbound_call_twiml(...)`` if configured and ``twiml_request``
+             is given. (Application-owned.)
+          2. ``self.config.default_twiml_options`` — per-channel defaults.
+          3. ``host_twiml_options`` — per-call transport facts supplied by the
+             host (the code owning the route), e.g. a per-call ``websocket_url``
+             with an affinity token.
+          4. TAC defaults: a fixed default ``welcome_greeting``,
+             ``conversation_configuration`` from ``TACConfig``,
+             ``action_url`` resolved via Studio handoff (when
+             ``studio_handoff_flow_sid`` is configured), else derived from
+             ``TACConfig.voice_public_domain`` + ``voice_action_path``, and the
+             ``websocket_url`` derived from ``TACConfig.voice_public_domain`` +
+             ``voice_websocket_path``.
+
+        Fields not set at a layer fall through to lower layers. Lists
+        (``languages``) and nested models (``custom_parameters``) replace
+        wholesale when set at a higher-priority layer. ``websocket_url`` falls
+        back to the ``TACConfig``-derived URL if unset at every layer.
+
+        The two arguments are complementary, not alternatives — a custom host
+        typically passes both on the same call: ``twiml_request`` carries the
+        inbound call's data (so the application's customizer can run), and
+        ``host_twiml_options`` carries the host's own per-call overrides.
+        """
+        customized: TwiMLOptions | None = None
+        if self._on_inbound_call_twiml is not None and twiml_request is not None:
+            customized = await self._on_inbound_call_twiml(twiml_request)
+
+        merged = self._build_twiml_options(channel, host_twiml_options, customized)
+        # merged.websocket_url is either a validated non-empty URL (set by some
+        # layer) or None; fall back to the TACConfig-derived URL only when None.
+        websocket_url = (
+            merged.websocket_url
+            if merged.websocket_url is not None
+            else channel._resolve_websocket_url("handle_incoming_call")
+        )
+        return self.build_twiml(websocket_url, merged)
+
+    def _build_twiml_options(
+        self,
+        channel: VoiceChannel,
+        host: TwiMLOptions | None,
+        per_call: TwiMLOptions | None,
+    ) -> TwiMLOptions:
+        """Layer TwiML options, lowest precedence first: TAC defaults →
+        ``host`` (calling host's per-call values) → ``self.config.default_twiml_options``
+        → ``per_call`` (application customizer output for inbound, or
+        ``InitiateVoiceConversationOptions.twiml_options`` for outbound).
+        """
+        merged = TwiMLOptions(
+            welcome_greeting=DEFAULT_WELCOME_GREETING,
+            conversation_configuration=channel.tac.config.conversation_configuration_id,
+            action_url=self._resolve_action_url(channel, host, per_call),
+        )
+        if host is not None:
+            self._overlay_fields(merged, host)
+        if self.config.default_twiml_options is not None:
+            self._overlay_fields(merged, self.config.default_twiml_options)
+        if per_call is not None:
+            self._overlay_fields(merged, per_call)
+        return merged
+
+    @staticmethod
+    def _overlay_fields(target: TwiMLOptions, source: TwiMLOptions) -> None:
+        """Apply fields explicitly set on ``source`` onto ``target``.
+
+        Nested models (``custom_parameters``), lists (``languages``), and
+        dicts (``extra``) replace wholesale — there's no per-key merging.
+        If you add a field that should merge (e.g. a dict of headers),
+        special-case it here instead of getting the default overwrite behavior.
+
+        ``action_url`` is skipped here on purpose — it's resolved once via
+        ``_resolve_action_url`` looking at every layer at once, and that
+        resolved value is written into ``target`` before this overlay runs.
+        Letting it through here would let a higher-priority layer that didn't
+        set action_url silently clobber a lower layer that did.
+        """
+        for field in source.model_fields_set:
+            if field == "action_url":
+                continue
+            setattr(target, field, getattr(source, field))
+
+    def _resolve_action_url(
+        self,
+        channel: VoiceChannel,
+        host: TwiMLOptions | None,
+        customized: TwiMLOptions | None,
+    ) -> str | None:
+        """Resolve the TwiML ``<Connect action=...>`` URL.
+
+        Precedence (highest to lowest):
+          1. application customizer
+          2. ``self.config.default_twiml_options``
+          3. ``host`` (calling host's per-call options)
+          4. Studio handoff (when ``studio_handoff_flow_sid`` is configured)
+          5. Channel default — derived from ``TACConfig.voice_public_domain``
+             + ``TACConfig.voice_action_path``.
+
+        User-expressed intent (Studio handoff is configured explicitly on
+        ``TACConfig``) beats the SDK's generated cleanup default. If a user
+        sets both Studio handoff and runs in relay-only mode, Studio wins
+        for that call — the session-cleanup URL is skipped, same as if they
+        had set any other action_url via customizer or static options.
+
+        Explicit ``action_url=None`` on a layer suppresses
+        ``<Connect action=...>`` entirely — all lower layers are skipped.
+        Use this to disable the cleanup callback for a specific call (e.g.
+        from a customizer) or channel-wide. ``action_url`` left unset (not
+        in ``model_fields_set``) falls through to the next layer.
+        """
+        if customized is not None and "action_url" in customized.model_fields_set:
+            return customized.action_url
+        if (
+            self.config.default_twiml_options is not None
+            and "action_url" in self.config.default_twiml_options.model_fields_set
+        ):
+            return self.config.default_twiml_options.action_url
+        if host is not None and "action_url" in host.model_fields_set:
+            return host.action_url
+        if channel.tac.config.studio_handoff_flow_sid:
+            return studio_voice_handoff_url(
+                channel.tac.config.account_sid,
+                channel.tac.config.studio_handoff_flow_sid,
+            )
+        return self._resolve_default_action_url(channel)
+
+    @staticmethod
+    def _resolve_default_action_url(channel: VoiceChannel) -> str | None:
+        """Resolve the default ``<Connect action=...>`` cleanup URL.
+
+        Returns None if ``voice_public_domain`` isn't set; that's fine because
+        action_url has higher-priority layers (customizer, twiml_options,
+        Studio handoff) above this fallback.
+        """
+        if channel.tac.config.voice_public_domain:
+            return (
+                f"https://{channel.tac.config.voice_public_domain}"
+                f"{channel.tac.config.voice_action_path}"
+            )
+        return None
+
+    async def handle_conversation_relay_callback(
+        self,
+        channel: VoiceChannel,
+        payload_dict: dict[str, str],
+    ) -> None:
+        """Handle ConversationRelay callback webhook from Twilio.
+
+        In relay-only mode, this is a secondary mechanism for cleaning up
+        conversation state when a call ends (the primary mechanism is websocket
+        disconnect). In orchestrated mode, conversation lifecycle is managed by
+        CO webhooks, so this is a no-op.
+        """
+        try:
+            payload = ConversationRelayCallbackPayload(**payload_dict)
+        except ValidationError:
+            channel.logger.warning(
+                "Invalid ConversationRelay callback payload, ignoring",
+                payload_keys=list(payload_dict.keys()),
+            )
+            return
+
+        if payload.account_sid != channel.tac.config.account_sid:
+            channel.logger.warning(
+                "ConversationRelay callback account_sid mismatch, ignoring",
+                expected=channel.tac.config.account_sid,
+                received=payload.account_sid,
+            )
+            return
+
+        channel.logger.debug(
+            "ConversationRelay callback received",
+            call_sid=payload.call_sid,
+            call_status=payload.call_status,
+        )
+
+        if payload.call_status == "completed" and not channel.tac.is_orchestrator_enabled():
+            if payload.call_sid in channel._conversations:
+                await channel._end_conversation(payload.call_sid)
+
+    def _merge_call_options(self, per_call: CallOptions | None) -> CallOptions | None:
+        """Overlay ``per_call`` onto ``self.config.default_call_options``.
+
+        Per-field via ``model_fields_set``, same as ``_overlay_fields`` does for
+        TwiMLOptions. The merged result is re-validated so a combination only
+        reachable by layering — per-call clearing ``machine_detection`` while the
+        default set ``async_amd`` — still fails instead of reaching Twilio.
+        """
+        default = self.config.default_call_options
+        if default is None or per_call is None:
+            return per_call or default
+
+        merged = default.model_dump(by_alias=True, exclude_none=True)
+        # model_fields_set covers extras too, since CallOptions allows them.
+        for field in per_call.model_fields_set:
+            merged[field] = getattr(per_call, field)
+        return CallOptions(**merged)
+
+    def _build_call_kwargs(
+        self, channel: VoiceChannel, call_options: CallOptions | None
+    ) -> dict[str, Any]:
+        """Build the extra kwargs for ``client.calls.create``.
+
+        Layers, highest precedence first: this call's ``call_options``,
+        ``self.config.default_call_options``, then callback URLs derived
+        from ``voice_public_domain`` + ``voice_call_event_path``.
+
+        A URL is derived only when its handler is registered. That's a deliberate
+        deviation from ``websocket_url`` / ``action_url``, which derive
+        unconditionally: those are load-bearing, so a wrong one fails loudly on
+        the first call, whereas an unwanted call-event URL fails as silent 11200
+        alerts for a feature nobody asked for. Set the URLs in
+        ``default_call_options`` when TAC isn't serving the routes.
+        """
+        merged = self._merge_call_options(call_options)
+        call_kwargs = merged.to_call_kwargs() if merged else {}
+
+        wiring: list[tuple[CallEventKind, str, Callable[..., Any] | None]] = [
+            ("status", "status_callback", channel._on_call_status),
+            ("amd", "async_amd_status_callback", channel._on_amd),
+            ("recording", "recording_status_callback", channel._on_recording),
+        ]
+        for kind, param, handler in wiring:
+            if handler is None:
+                continue
+            url = channel.tac.config.call_event_url(kind)
+            if url is not None:
+                call_kwargs.setdefault(param, url)
+
+        return call_kwargs
+
+    async def initiate_outbound_conversation(
+        self,
+        channel: VoiceChannel,
+        options: InitiateVoiceConversationOptions,
+    ) -> InitiateVoiceConversationResult:
+        """Initiate an outbound voice conversation.
+
+        Places an outbound call with inline TwiML that connects to ConversationRelay.
+        The conversationConfiguration attribute tells CO to create and manage the
+        conversation during passive hydration. The session is initialized lazily
+        on the first prompt when the conversation is discovered by callSid.
+
+        TwiML fields are merged per-field, highest precedence first:
+          1. ``options.twiml_options`` — per-call overrides
+          2. ``self.config.default_twiml_options`` — channel-wide defaults
+          3. TAC defaults: welcome greeting, ``conversation_configuration``
+             from ``TACConfig``, and ``action_url`` from Studio handoff (if
+             configured), else derived from ``TACConfig.voice_public_domain``
+             + ``voice_action_path``.
+
+        Fields not set at a layer fall through to lower layers. Lists
+        (``languages``) and nested models (``custom_parameters``) replace
+        wholesale when set at a higher-priority layer.
+
+        The WebSocket URL is derived from ``TACConfig.voice_public_domain`` +
+        ``TACConfig.voice_websocket_path``, unless overridden per-call via
+        ``options.websocket_url``.
+        """
+        from_number = channel.tac.config.phone_number
+
+        channel.logger.info(
+            "Initiating outbound voice conversation",
+            to=mask_phone(options.to),
+            from_number=mask_phone(from_number),
+        )
+
+        # Outbound has no inbound customizer and no server layer; the per-call
+        # override is options.twiml_options.
+        merged = self._build_twiml_options(channel, None, options.twiml_options)
+
+        # ``options.websocket_url`` is the dedicated per-call outbound override
+        # and wins over any websocket_url that came through the layered
+        # ``twiml_options`` merge; both fall back to the TACConfig-derived URL.
+        if options.websocket_url is not None:
+            websocket_url = options.websocket_url
+        elif merged.websocket_url is not None:
+            websocket_url = merged.websocket_url
+        else:
+            websocket_url = channel._resolve_websocket_url("initiate_outbound_conversation")
+
+        call_kwargs = self._build_call_kwargs(channel, options.call_options)
+
+        try:
+            twiml_xml = self.build_twiml(websocket_url, merged)
+
+            # The inline TwiML handed to Twilio, useful for debugging the
+            # <Connect action> handoff target. custom_parameters values are
+            # masked — they're arbitrary developer data (profile IDs, caller
+            # names), unlike the WS/action URLs and conversation config.
+            channel.logger.debug(
+                "Outbound call TwiML",
+                twiml=redact_twiml_parameters(twiml_xml),
+                to=mask_phone(options.to),
+            )
+
+            client = channel._get_twilio_client()
+            call = await asyncio.to_thread(
+                client.calls.create,
+                to=options.to,
+                from_=from_number,
+                twiml=twiml_xml,
+                **call_kwargs,
+            )
+
+            channel.logger.info(
+                "Outbound voice call placed",
+                call_sid=call.sid,
+                to=mask_phone(options.to),
+            )
+
+            return InitiateVoiceConversationResult(call_sid=call.sid)
+
+        except Exception as e:
+            channel.logger.error(
+                "Failed to initiate outbound call",
+                to=mask_phone(options.to),
+                error=str(e),
+                exc_info=True,
+            )
+            raise
+
+    def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
+        return self._websocket_manager.get_websocket(conversation_id)
+
+    @staticmethod
+    def _caller_address(setup_msg: SetupMessage) -> str | None:
+        """Return the phone number of the remote caller/callee from the setup message."""
+        if setup_msg.direction and setup_msg.direction.upper() == "OUTBOUND":
+            return setup_msg.to_number
+        return setup_msg.from_number
+
+    async def _initialize_conversation(
+        self,
+        channel: VoiceChannel,
+        call_sid: str,
+        setup_msg: SetupMessage,
+        websocket: WebSocketProtocol,
+    ) -> tuple[str, SessionState | None]:
+        """Poll CO for the conversation created by ConversationRelay, resolve
+        the customer participant, and initialize the local session."""
+        conversation_orchestrator_client = channel.tac.conversation_orchestrator_client
+        if conversation_orchestrator_client is None:
+            raise RuntimeError("_initialize_conversation called without Conversation Orchestrator")
+
+        conversations: list[Any] = []
+        for attempt in range(_POLL_ATTEMPTS):
+            conversations = await conversation_orchestrator_client.list_conversations(
+                channel_id=call_sid,
+                status=["ACTIVE"],
+            )
+            if len(conversations) == 1:
+                break
+            if attempt < _POLL_ATTEMPTS - 1:
+                channel.logger.debug(
+                    "Conversation not ready yet, polling again",
+                    call_sid=call_sid,
+                    attempt=attempt + 1,
+                    found=len(conversations),
+                )
+                await asyncio.sleep(min(_POLL_BASE_DELAY * (2**attempt), _POLL_MAX_DELAY))
+
+        if len(conversations) != 1:
+            raise RuntimeError(
+                f"Expected exactly 1 conversation for "
+                f"call_sid {call_sid}, but found "
+                f"{len(conversations)} after "
+                f"{_POLL_ATTEMPTS} attempts."
+            )
+
+        conversation = conversations[0]
+        conv_id = conversation.id
+
+        participants = await conversation_orchestrator_client.list_participants(conv_id)
+
+        customer_participant = next(
+            (p for p in participants if p.type == "CUSTOMER"),
+            None,
+        )
+        customer_address = (
+            next(
+                (a.address for a in customer_participant.addresses if a.channel == "VOICE"),
+                None,
+            )
+            if customer_participant and customer_participant.addresses
+            else None
+        )
+        profile_lookup_address = customer_address or self._caller_address(setup_msg)
+        profile_id = customer_participant.profile_id if customer_participant else None
+
+        # Resolve the agent participant so ai_agent_info is populated on the
+        # session, matching the messaging channels. The agent is the participant
+        # that owns TAC's address (the configured phone number) on the VOICE
+        # channel and has an agent type. A HUMAN_AGENT added by a
+        # redirected/escalated call is NOT TAC and is not adopted here.
+        agent_participant = channel._find_agent_participant(
+            participants, "VOICE", channel.tac.config.phone_number
+        )
+        agent_address = (
+            next(
+                (a.address for a in agent_participant.addresses if a.channel == "VOICE"),
+                None,
+            )
+            if agent_participant and agent_participant.addresses
+            else None
+        )
+
+        self._websocket_manager.add_websocket(conv_id, websocket)
+        session = channel._start_conversation(conv_id, profile_id)
+        # In orchestrator mode conv_id is the Orchestrator conversation id, so
+        # record the CallSid so out-of-band call webhooks can reach this session
+        # (resolved via get_conversation_session_by_call_sid).
+        session.call_sid = call_sid
+
+        session_state = None
+        if self.config.session_manager is not None:
+            session_state = self.config.session_manager.get_or_create_session(conv_id)
+
+        if profile_lookup_address:
+            session.author_info = AuthorInfo(address=profile_lookup_address)
+
+        if agent_participant:
+            # Fall back to the configured phone number we matched on — the
+            # participant owns it by definition, so it's a meaningful address
+            # even in the unlikely case it carries no explicit VOICE address.
+            session.ai_agent_info = AuthorInfo(
+                address=agent_address or channel.tac.config.phone_number,
+                participant_id=agent_participant.id,
+            )
+
+        return conv_id, session_state
+
+    async def handle_websocket(self, channel: VoiceChannel, websocket: WebSocketProtocol) -> None:
+        """
+        Handle voice streaming WebSocket connection lifecycle.
+
+        This method manages the entire websocket connection:
+        - Accepts the connection
+        - Processes incoming messages
+        - Tracks and cancels in-flight tasks (if session_manager provided)
+        - Cleans up on disconnect
+        """
+        await websocket.accept()
+        channel.logger.debug("WebSocket connection established")
+
+        conv_id: str | None = None
+        session_state = None
+        # This call's background CO conversation lookup task (kicked off
+        # below on "setup"), consumed and reset to None on the first
+        # "prompt". Still non-None in `finally` means the call ended before
+        # any prompt arrived.
+        init_task: asyncio.Task[tuple[str, SessionState | None]] | None = None
+
+        try:
+            # First message should be 'setup'
+            data = await websocket.receive_json()
+            if data.get("type") == "setup":
+                setup_msg = SetupMessage(**data)
+                call_sid = setup_msg.call_sid
+
+                # Kick off the CO conversation lookup now, in the background,
+                # instead of waiting for the first prompt. ConversationRelay
+                # creates the CO conversation as soon as the call connects, not
+                # when the caller speaks, so this overlaps CO's
+                # list_conversations/list_participants polling with the wait
+                # for the caller's first utterance (transcription) rather than
+                # paying that latency serially once the first prompt lands.
+                if call_sid and channel.tac.is_orchestrator_enabled():
+                    init_task = asyncio.create_task(
+                        self._initialize_conversation(channel, call_sid, setup_msg, websocket)
+                    )
+
+                # Process all subsequent messages
+                while True:
+                    data = await websocket.receive_json()
+                    msg_type = data.get("type")
+
+                    if msg_type == "prompt":
+                        if not conv_id and call_sid:
+                            if init_task is not None:
+                                # Clear before awaiting so a failure here
+                                # doesn't leave `finally` re-awaiting (and
+                                # re-logging) this same task. If still
+                                # polling, this just waits it out. (None here
+                                # only means relay-only mode — see "setup".)
+                                task_to_await = init_task
+                                init_task = None
+                                conv_id, session_state = await task_to_await
+                            else:
+                                conv_id = call_sid
+                                self._websocket_manager.add_websocket(conv_id, websocket)
+                                session = channel._start_conversation(conv_id, profile_id=None)
+                                # Relay-only: conv_id == call_sid.
+                                session.call_sid = call_sid
+
+                                caller = self._caller_address(setup_msg)
+                                if caller:
+                                    channel._conversations[conv_id].author_info = AuthorInfo(
+                                        address=caller,
+                                    )
+
+                                if self.config.session_manager is not None:
+                                    session_state = (
+                                        self.config.session_manager.get_or_create_session(conv_id)
+                                    )
+
+                        if conv_id:
+                            await self._handle_prompt_async(channel, conv_id, data, session_state)
+                        else:
+                            channel.logger.warning(
+                                "Received prompt before conversation initialized"
+                            )
+                    elif msg_type == "interrupt":
+                        if conv_id:
+                            await self._handle_interrupt_async(
+                                channel, conv_id, data, session_state
+                            )
+                        else:
+                            channel.logger.warning(
+                                "Received interrupt before conversation initialized"
+                            )
+                    else:
+                        channel.logger.debug(f"Skip message type received: {msg_type}")
+            else:
+                channel.logger.warning("First message was not 'setup'. Closing connection.")
+                await websocket.close()
+                return
+        except WebSocketDisconnectError:
+            channel.logger.info("WebSocket connection closed", conversation_id=conv_id)
+        except Exception as e:
+            channel.logger.error(f"WebSocket error: {str(e)}")
+        finally:
+            cancelled_error: asyncio.CancelledError | None = None
+            we_cancelled_it = False
+            if init_task is not None:
+                # Call ended before any prompt arrived, so the background
+                # lookup was never awaited.
+                if not init_task.done():
+                    init_task.cancel()
+                    we_cancelled_it = True
+                result: tuple[str, SessionState | None] | None
+                try:
+                    result = await init_task
+                except asyncio.CancelledError as e:
+                    # Defer re-raise decision until after cleanup below;
+                    # we_cancelled_it (not init_task.cancelled(), which can't
+                    # tell the two apart) decides whether to.
+                    cancelled_error = e
+                    result = None
+                except Exception as e:
+                    # No prompt ever arrived to surface this failure via the
+                    # outer except Exception above, so log it here instead.
+                    channel.logger.error(
+                        f"Background CO conversation lookup failed: {e}",
+                        call_sid=call_sid,
+                    )
+                    result = None
+                if result is not None and conv_id is None:
+                    # The lookup already registered the session/websocket
+                    # before anyone claimed conv_id — adopt it so it's
+                    # cleaned up instead of leaked.
+                    conv_id = result[0]
+            if conv_id:
+                channel.logger.debug("Cleanup - removing WebSocket", conversation_id=conv_id)
+                await self._cleanup_connection(channel, conv_id)
+            if cancelled_error is not None and not we_cancelled_it:
+                # A real external cancellation, not the one we caused above —
+                # propagate it now that cleanup ran.
+                raise cancelled_error
+
+    async def _handle_prompt_async(
+        self,
+        channel: VoiceChannel,
+        conv_id: str,
+        data: dict[str, Any],
+        session_state: SessionState | None,
+    ) -> None:
+        """Handle prompt message asynchronously with task tracking."""
+        try:
+            should_process = data.get("final", True)
+            if should_process:
+                prompt_msg = PromptMessage(**data)
+                conv_id = prompt_msg.conversation_id or conv_id
+
+                # Cancel previous stream task if session manager is enabled
+                if session_state:
+                    await session_state.cancel_stream_task()
+
+                    # Create new task using unified flow (memory retrieval + callback)
+                    session_state.stream_task = asyncio.create_task(
+                        self._handle_prompt(channel, conv_id, prompt_msg)
+                    )
+                    # Yield to event loop to let task start
+                    await asyncio.sleep(0)
+                else:
+                    await self._handle_prompt(channel, conv_id, prompt_msg)
+        except Exception as e:
+            channel.logger.error(f"Failed to handle prompt: {str(e)}")
+
+    async def _handle_interrupt_async(
+        self,
+        channel: VoiceChannel,
+        conv_id: str,
+        data: dict[str, Any],
+        session_state: SessionState | None,
+    ) -> None:
+        """Handle interrupt message asynchronously with task cancellation."""
+        try:
+            interrupt_msg = InterruptMessage(**data)
+            conv_id = interrupt_msg.conversation_id or conv_id
+
+            # Cancel in-flight stream task if session manager is enabled
+            if session_state:
+                await session_state.cancel_stream_task()
+
+                # Send acknowledgment to Twilio after cancelling
+                websocket = self._websocket_manager.get_websocket(conv_id)
+                if websocket:
+                    try:
+                        await websocket.send_text(
+                            json.dumps({"type": "text", "token": "", "last": True})
+                        )
+                    except (WebSocketDisconnectError, RuntimeError):
+                        channel.logger.debug(
+                            f"WebSocket closed before sending interrupt acknowledgment "
+                            f"for {conv_id}."
+                        )
+
+            # Call the interrupt handler
+            self._handle_interrupt(channel, conv_id, interrupt_msg)
+        except Exception as e:
+            channel.logger.error(f"Failed to handle interrupt: {str(e)}")
+
+    async def send_response(
+        self,
+        channel: VoiceChannel,
+        conversation_id: str,
+        response: str | AsyncGenerator[str | dict[str, Any], None],
+        role: str | None = None,
+    ) -> None:
+        """
+        Send voice response through the websocket connection for this conversation.
+
+        Supports both simple string responses and streaming async generators.
+        """
+        # Validate response type before processing
+        if not isinstance(response, (str, AsyncGenerator)):
+            raise TypeError("Voice channel requires string or async generator for response")
+
+        # Get WebSocket from manager
+        websocket = self._websocket_manager.get_websocket(conversation_id)
+        if not websocket:
+            channel.logger.error("No websocket connection", conversation_id=conversation_id)
+            return
+
+        full_response = ""
+
+        try:
+            # Check if response is an async generator (streaming)
+            if isinstance(response, AsyncGenerator):
+                # Streaming response
+                json_template = {"type": "text", "token": "", "last": False}
+                closed = False
+                response_gen: AsyncGenerator[str | dict[str, Any], None] = response
+
+                try:
+                    async for chunk in response_gen:
+                        # Handle different chunk types (plain text or dict with metadata)
+                        if isinstance(chunk, dict):
+                            if "output" in chunk:
+                                token = chunk["output"]
+                            else:
+                                token = str(chunk)
+                        else:
+                            token = chunk
+
+                        full_response += token
+                        json_template["token"] = token
+
+                        try:
+                            await websocket.send_text(json.dumps(json_template))
+                        except (WebSocketDisconnectError, RuntimeError):
+                            channel.logger.info(
+                                "WebSocket closed during streaming",
+                                conversation_id=conversation_id,
+                            )
+                            closed = True
+                            break
+
+                    # Send final message marker
+                    if not closed:
+                        try:
+                            await websocket.send_text(
+                                json.dumps({"type": "text", "token": "", "last": True})
+                            )
+                        except (WebSocketDisconnectError, RuntimeError):
+                            channel.logger.info(
+                                "WebSocket closed before sending final marker",
+                                conversation_id=conversation_id,
+                            )
+                except asyncio.CancelledError:
+                    # Let Python's async generator cleanup handle closing the generator
+                    raise
+            else:
+                await websocket.send_text(
+                    json.dumps({"type": "text", "token": response, "last": True})
+                )
+
+            # If a handoff is pending, send the WS "end" message now that the
+            # LLM's final response has been delivered to the caller.
+            if conversation_id in channel._conversations:
+                session = channel._conversations[conversation_id]
+                if session.pending_handoff_data is not None:
+                    try:
+                        await websocket.send_text(
+                            session.pending_handoff_data.model_dump_json(by_alias=True)
+                        )
+                        session.pending_handoff_data = None
+                    except (WebSocketDisconnectError, RuntimeError):
+                        channel.logger.warning(
+                            "WebSocket closed before sending handoff end message; "
+                            "caller will not be transferred",
+                            conversation_id=conversation_id,
+                        )
+
+        except asyncio.CancelledError:
+            # Re-raise to propagate cancellation up the call stack.
+            # Partial responses from interrupted streams are NOT saved to
+            # Conversation Orchestrator. Incomplete responses shouldn't be
+            # part of conversation history.
+            raise
+        except (WebSocketDisconnectError, RuntimeError):
+            channel.logger.info(
+                "WebSocket closed before sending response", conversation_id=conversation_id
+            )
+        except Exception as e:
+            channel.logger.error(
+                f"Error sending response: {e}", conversation_id=conversation_id, exc_info=True
+            )
+
+    async def _handle_prompt(
+        self, channel: VoiceChannel, conv_id: str, message: PromptMessage
+    ) -> None:
+        """Handle incoming voice prompt (user speech)."""
+        if conv_id not in channel._conversations:
+            channel.logger.error(
+                f"Received prompt for unknown conversation {conv_id}. "
+                "Conversation should be initialized on first prompt.",
+                conversation_id=conv_id,
+            )
+            return
+
+        message_body = message.voice_prompt or ""
+        session = channel._conversations[conv_id]
+
+        # Retrieve memory if memory_mode is enabled and Twilio Memory is configured
+        memory_response = await channel._retrieve_memory_if_enabled(session, message_body, conv_id)
+
+        # Trigger message ready callback
+        try:
+            response = await channel.tac.trigger_message_ready(
+                message_body, session, memory_response
+            )
+            # Auto-send if callback returned a string (None = manual send_response flow)
+            if response is not None:
+                await self.send_response(channel, conv_id, response, role="assistant")
+        except Exception as e:
+            channel.logger.error(
+                "Error in message ready callback",
+                conversation_id=conv_id,
+                error=str(e),
+                exc_info=True,
+            )
+
+    def _handle_interrupt(
+        self, channel: VoiceChannel, conv_id: str, message: InterruptMessage
+    ) -> None:
+        """Handle interrupt message when user interrupts the agent.
+
+        Note: Task cancellation is handled by the async wrapper
+        (_handle_interrupt_async) when called from the WebSocket message
+        handler. This method only triggers the TAC interrupt callback.
+        """
+        # Trigger interrupt callback if conversation exists
+        if conv_id in channel._conversations:
+            session = channel._conversations[conv_id]
+            channel.tac.trigger_interrupt(session, message)
+        else:
+            channel.logger.warning(
+                f"Received interrupt for unknown conversation {conv_id}, skipping callback"
+            )
+
+    async def _cleanup_connection(self, channel: VoiceChannel, conv_id: str) -> None:
+        """Clean up WebSocket and session resources when connection closes.
+
+        In orchestrated mode, the conversation remains tracked in
+        channel._conversations until the CONVERSATION_UPDATED/CLOSED webhook
+        arrives from Conversation Orchestrator. In relay-only mode there is
+        no such webhook, so we also end the conversation here.
+        """
+        # Remove WebSocket from manager
+        if self._websocket_manager.has_websocket(conv_id):
+            self._websocket_manager.remove_websocket(conv_id)
+
+        # Cancel running stream task and cleanup session if session manager is enabled
+        if self.config.session_manager is not None and self.config.session_manager.has_session(
+            conv_id
+        ):
+            session_state = self.config.session_manager.get_or_create_session(conv_id)
+            # Cancel any running task (user hung up, no point continuing)
+            await session_state.cancel_stream_task()
+            self.config.session_manager.remove_session(conv_id)
+
+        if not channel.tac.is_orchestrator_enabled() and conv_id in channel._conversations:
+            await channel._end_conversation(conv_id)
+
+        channel.logger.debug(
+            "Cleaned up WebSocket and session resources",
+            conversation_id=conv_id,
+        )
+
+
+__all__ = ["ConversationRelayProvider"]

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -1,0 +1,113 @@
+"""``VoiceProvider``: the Provider interface that lets ``VoiceChannel`` host
+more than one kind of real-time media transport.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from tac.channels.websocket_protocol import WebSocketProtocol
+from tac.models.memory import MemoryMode
+from tac.models.outbound import InitiateVoiceConversationOptions, InitiateVoiceConversationResult
+from tac.models.voice import TwiMLOptions, TwiMLRequest
+
+if TYPE_CHECKING:
+    from tac.channels.voice.channel import VoiceChannel
+
+
+class VoiceProvider(ABC):
+    """Provider interface for a ``VoiceChannel``'s real-time media transport.
+
+    ``ConversationRelayProvider`` is the only implementation today.
+    """
+
+    @property
+    @abstractmethod
+    def channel_name(self) -> str:
+        """Channel name identifier, e.g. ``"VOICE"`` or ``"VOICE_GPT_LIVE"``.
+
+        Returned by ``VoiceChannel.get_channel_name()`` and stamped onto every
+        ``ConversationSession`` this provider creates.
+        """
+
+    @property
+    def memory_mode(self) -> MemoryMode:
+        """Memory retrieval mode for this provider. Default: ``"never"``.
+
+        ``ConversationRelayProvider`` overrides this to read from its config.
+        """
+        return "never"
+
+    @abstractmethod
+    def build_twiml(self, websocket_url: str, options: TwiMLOptions) -> str:
+        """Build the ``<Connect>`` TwiML that points Twilio at this provider's
+        WebSocket endpoint.
+        """
+
+    async def handle_incoming_call(
+        self,
+        channel: VoiceChannel,
+        twiml_request: TwiMLRequest | None,
+        host_twiml_options: TwiMLOptions | None,
+    ) -> str:
+        """Build the TwiML string for an inbound call.
+
+        Default: minimal — no customizer, no per-channel defaults, just
+        ``host_twiml_options`` (if any) over a channel-derived WebSocket URL.
+        ``ConversationRelayProvider`` overrides this with a fuller merge
+        (customizer, ``default_twiml_options``, TAC defaults).
+        """
+        websocket_url = (
+            host_twiml_options.websocket_url
+            if host_twiml_options is not None and host_twiml_options.websocket_url is not None
+            else channel._resolve_websocket_url("handle_incoming_call")
+        )
+        return self.build_twiml(websocket_url, host_twiml_options or TwiMLOptions())
+
+    async def initiate_outbound_conversation(
+        self,
+        channel: VoiceChannel,
+        options: InitiateVoiceConversationOptions,
+    ) -> InitiateVoiceConversationResult:
+        """Place an outbound call. Default: not supported."""
+        raise NotImplementedError(f"{type(self).__name__} does not support outbound calls.")
+
+    def on_inbound_call_twiml(
+        self, callback: Callable[[TwiMLRequest], Awaitable[TwiMLOptions]]
+    ) -> None:
+        """Register a per-call inbound TwiML customizer.
+
+        Default no-op — only ``ConversationRelayProvider`` supports this.
+        """
+        return None
+
+    @abstractmethod
+    async def handle_websocket(self, channel: VoiceChannel, websocket: WebSocketProtocol) -> None:
+        """Drive one WebSocket connection from accept to disconnect."""
+
+    @abstractmethod
+    async def send_response(
+        self,
+        channel: VoiceChannel,
+        conversation_id: str,
+        response: str | AsyncGenerator[str | dict[str, Any], None],
+        role: str | None = None,
+    ) -> None:
+        """Send a text response back through this provider's transport, if supported."""
+
+    async def handle_conversation_relay_callback(
+        self,
+        channel: VoiceChannel,
+        payload_dict: dict[str, str],
+    ) -> None:
+        """Handle the ConversationRelay callback webhook, if this provider uses one.
+
+        Default no-op — only ``ConversationRelayProvider`` receives this webhook.
+        """
+        return None
+
+    def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
+        """Return the Twilio-facing WebSocket for a conversation, if tracked."""
+        return None

--- a/src/tac/channels/voice/twiml.py
+++ b/src/tac/channels/voice/twiml.py
@@ -90,7 +90,7 @@ def generate_twiml(
 
     This is a low-level function. Most users should call
     ``VoiceChannel.handle_incoming_call`` instead — it layers in TAC defaults,
-    static ``twiml_options`` from ``VoiceChannelConfig``, and any per-call
+    static default_twiml_options from ConversationRelayProviderConfig, and any per-call
     customizer output.
 
     The WebSocket URL may be passed positionally or as ``options.websocket_url``

--- a/src/tac/models/outbound.py
+++ b/src/tac/models/outbound.py
@@ -177,7 +177,7 @@ class InitiateVoiceConversationOptions(BaseModel):
     TwiML for the outbound call is built by merging per-field, highest
     precedence first:
       1. This call's ``twiml_options`` (per-call overrides)
-      2. ``VoiceChannelConfig.default_twiml_options`` (channel-wide defaults)
+      2. the active ConversationRelayProvider's default_twiml_options (channel-wide defaults)
       3. TAC defaults (welcome greeting, conversation_configuration,
          action_url resolved via Studio handoff if configured)
 
@@ -187,7 +187,7 @@ class InitiateVoiceConversationOptions(BaseModel):
     channel config still apply.
 
     Set ``voice``, ``language``, ``interruptible``, etc. on the channel's
-    ``VoiceChannelConfig.default_twiml_options`` to apply them to every call
+    ConversationRelayProviderConfig.default_twiml_options to apply them to every call
     (both inbound and outbound). Use this model's ``twiml_options`` for
     per-call overrides (e.g. campaign-specific ``custom_parameters``).
     """
@@ -203,8 +203,8 @@ class InitiateVoiceConversationOptions(BaseModel):
     )
     twiml_options: TwiMLOptions | None = Field(
         default=None,
-        description="Per-call overrides for the TwiML inside <ConversationRelay>. "
-        "Merged over VoiceChannelConfig.default_twiml_options and TAC defaults.",
+        description="Per-call overrides for the TwiML inside <ConversationRelay>. Merged over "
+        "the active ConversationRelayProvider's default_twiml_options and TAC defaults.",
     )
     call_options: CallOptions | None = Field(
         default=None,

--- a/tests/test_outbound.py
+++ b/tests/test_outbound.py
@@ -10,7 +10,11 @@ from tac import TAC
 from tac.channels.chat import ChatChannel
 from tac.channels.rcs import RCSChannel
 from tac.channels.sms import SMSChannel
-from tac.channels.voice import VoiceChannel, VoiceChannelConfig
+from tac.channels.voice import (
+    ConversationRelayProvider,
+    ConversationRelayProviderConfig,
+    VoiceChannel,
+)
 from tac.channels.whatsapp import WhatsAppChannel
 from tac.core.config import TwilioMemoryConfig
 from tac.models.conversation import (
@@ -711,7 +715,11 @@ class TestDefaultCallOptions:
         config = {**get_test_config(), "voice_public_domain": "example.com"}
         return VoiceChannel(
             TAC(config),
-            config=VoiceChannelConfig(default_call_options=CallOptions(**default_call_options)),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_call_options=CallOptions(**default_call_options),
+                )
+            ),
         )
 
     @pytest.mark.asyncio
@@ -1071,15 +1079,19 @@ class TestVoiceOutboundErrors:
 
     @pytest.mark.asyncio
     async def test_channel_twiml_options_applied(self) -> None:
-        """VoiceChannelConfig.twiml_options flows into outbound TwiML."""
-        from tac.channels.voice import VoiceChannelConfig
+        """ConversationRelayProviderConfig.default_twiml_options flows into outbound TwiML."""
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
         from tac.models.voice import TwiMLOptions
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(voice="en-US-Journey-D", interruptible="speech"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(
+                        voice="en-US-Journey-D", interruptible="speech"
+                    ),
+                )
             ),
         )
 
@@ -1103,14 +1115,16 @@ class TestVoiceOutboundErrors:
     @pytest.mark.asyncio
     async def test_per_call_twiml_options_override_channel(self) -> None:
         """Per-call twiml_options win over channel-static twiml_options."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
         from tac.models.voice import TwiMLOptions
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(voice="en-US-Journey-D"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(voice="en-US-Journey-D"),
+                )
             ),
         )
 

--- a/tests/test_relay_only_mode.py
+++ b/tests/test_relay_only_mode.py
@@ -88,14 +88,16 @@ class TestRelayOnlyMode:
     @pytest.mark.asyncio
     async def test_handle_incoming_call_twiml_omits_conversation_configuration(self) -> None:
         """TwiML does not include conversationConfiguration in relay-only mode."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
         from tac.models.voice import TwiMLOptions
 
         tac = TAC(relay_only_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(welcome_greeting="Hello"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(welcome_greeting="Hello"),
+                )
             ),
         )
 
@@ -209,7 +211,8 @@ class TestRelayOnlyMode:
 
         from tac.models.voice import InterruptMessage
 
-        channel._handle_interrupt(
+        channel._provider._handle_interrupt(
+            channel,
             "CA_relay_int",
             InterruptMessage(
                 type="interrupt",

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from tac import TAC
-from tac.channels.voice import VoiceChannel, generate_twiml
+from tac.channels.voice import (
+    ConversationRelayProvider,
+    ConversationRelayProviderConfig,
+    VoiceChannel,
+    generate_twiml,
+)
 from tac.models.conversation import ConversationResponse
 from tac.models.handoff import PendingHandoffData
 from tac.models.memory import MemoryRetrievalResponse
@@ -42,8 +47,8 @@ class TestVoiceChannel:
         channel = VoiceChannel(tac)
 
         assert channel.tac == tac
-        assert channel._websocket_manager is not None
-        assert len(channel._websocket_manager) == 0
+        assert channel._provider._websocket_manager is not None
+        assert len(channel._provider._websocket_manager) == 0
 
     def test_get_channel_name(self) -> None:
         """Test get_channel_name returns 'voice'."""
@@ -69,7 +74,7 @@ class TestVoiceChannel:
         )
 
         # Call handler directly
-        await channel._handle_prompt("CALL123", prompt_msg)
+        await channel._provider._handle_prompt(channel, "CALL123", prompt_msg)
 
         # With memory_mode="never", memory is not fetched - test passes if no exception
 
@@ -103,7 +108,10 @@ class TestVoiceChannel:
         )
 
         # Create channel with memory_mode enabled (default is "never")
-        channel = VoiceChannel(tac, config={"memory_mode": "always"})
+        channel = VoiceChannel(
+            tac,
+            config=ConversationRelayProvider(ConversationRelayProviderConfig(memory_mode="always")),
+        )
 
         # Setup conversation with profile_id
         channel._start_conversation("CALL123", "profile_test_123")
@@ -116,7 +124,7 @@ class TestVoiceChannel:
         )
 
         # Call handler directly
-        await channel._handle_prompt("CALL123", prompt_msg)
+        await channel._provider._handle_prompt(channel, "CALL123", prompt_msg)
 
         # Verify memory retrieval was called
         tac.conversation_memory_client.retrieve_memory.assert_called_once()
@@ -163,7 +171,9 @@ class TestVoiceChannel:
 
         setup_msg = SetupMessage(type="setup", callSid="CALL123", **{"from": "+15559998888"})
 
-        conv_id, _ = await channel._initialize_conversation("CALL123", setup_msg, MagicMock())
+        conv_id, _ = await channel._provider._initialize_conversation(
+            channel, "CALL123", setup_msg, MagicMock()
+        )
 
         assert conv_id == "conv_abc"
         session = channel._conversations["conv_abc"]
@@ -215,7 +225,9 @@ class TestVoiceChannel:
 
         setup_msg = SetupMessage(type="setup", callSid="CALL456", **{"from": "+15559998888"})
 
-        conv_id, _ = await channel._initialize_conversation("CALL456", setup_msg, MagicMock())
+        conv_id, _ = await channel._provider._initialize_conversation(
+            channel, "CALL456", setup_msg, MagicMock()
+        )
 
         session = channel._conversations[conv_id]
         assert session.ai_agent_info is None
@@ -237,7 +249,7 @@ class TestVoiceChannel:
         )
 
         # Call handler directly
-        channel._handle_interrupt("CALL123", interrupt_msg)
+        channel._provider._handle_interrupt(channel, "CALL123", interrupt_msg)
 
         # Test passes if no exception is raised
 
@@ -252,7 +264,7 @@ class TestVoiceChannel:
 
         # Mock websocket and register it with the manager
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL123", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL123", mock_websocket)
 
         # Send response without role
         await channel.send_response("CALL123", "Hello there")
@@ -282,7 +294,7 @@ class TestVoiceChannel:
         )
 
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL123", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL123", mock_websocket)
 
         await channel.send_response("CALL123", "Transferring you now.")
 
@@ -320,17 +332,17 @@ class TestVoiceChannel:
 
         # Add a mock websocket to the manager
         mock_websocket = MagicMock()
-        channel._websocket_manager.add_websocket("CALL123", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL123", mock_websocket)
 
         # Verify websocket is registered
-        assert channel._websocket_manager.has_websocket("CALL123")
+        assert channel._provider._websocket_manager.has_websocket("CALL123")
         assert "CALL123" in channel._conversations
 
         # Clean up connection (WebSocket only)
-        await channel._cleanup_connection("CALL123")
+        await channel._provider._cleanup_connection(channel, "CALL123")
 
         # Verify WebSocket cleanup but conversation still tracked
-        assert not channel._websocket_manager.has_websocket("CALL123")
+        assert not channel._provider._websocket_manager.has_websocket("CALL123")
         assert "CALL123" in channel._conversations
 
     @pytest.mark.asyncio
@@ -357,11 +369,12 @@ class TestVoiceChannel:
     async def test_process_webhook_conversation_inactive(self) -> None:
         """Test that INACTIVE invalidates cached memory when memory_mode='once'."""
 
-        from tac.channels.voice.config import VoiceChannelConfig
-
         tac = TAC(get_test_config())
         # Enable "once" mode to trigger cache invalidation
-        channel = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
+        channel = VoiceChannel(
+            tac,
+            config=ConversationRelayProvider(ConversationRelayProviderConfig(memory_mode="once")),
+        )
 
         # Start a conversation
         session = channel._start_conversation("CONV123", "profile_123")
@@ -466,7 +479,7 @@ class TestVoiceChannel:
             conversationId="CALL123",
             voicePrompt="Test message",
         )
-        await channel._handle_prompt("CALL123", prompt_msg)
+        await channel._provider._handle_prompt(channel, "CALL123", prompt_msg)
 
         # Verify callback was invoked
         assert captured_context is not None
@@ -498,7 +511,7 @@ class TestVoiceChannel:
 
         # Mock websocket and register it
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL_AUTO_SEND", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL_AUTO_SEND", mock_websocket)
 
         # Create and handle prompt message
         prompt_msg = PromptMessage(
@@ -506,7 +519,7 @@ class TestVoiceChannel:
             conversationId="CALL_AUTO_SEND",
             voicePrompt="Test message",
         )
-        await channel._handle_prompt("CALL_AUTO_SEND", prompt_msg)
+        await channel._provider._handle_prompt(channel, "CALL_AUTO_SEND", prompt_msg)
 
         # Verify websocket.send_text was called once with the auto-sent response
         assert mock_websocket.send_text.call_count == 1
@@ -535,7 +548,7 @@ class TestVoiceChannel:
 
         # Mock websocket and register it
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL_NO_AUTO", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL_NO_AUTO", mock_websocket)
 
         # Create and handle prompt message
         prompt_msg = PromptMessage(
@@ -543,7 +556,7 @@ class TestVoiceChannel:
             conversationId="CALL_NO_AUTO",
             voicePrompt="Test message",
         )
-        await channel._handle_prompt("CALL_NO_AUTO", prompt_msg)
+        await channel._provider._handle_prompt(channel, "CALL_NO_AUTO", prompt_msg)
 
         # Verify websocket.send_text was NOT called (callback returned None)
         assert mock_websocket.send_text.call_count == 0
@@ -551,13 +564,15 @@ class TestVoiceChannel:
     @pytest.mark.asyncio
     async def test_handle_incoming_call(self) -> None:
         """Test handle_incoming_call generates valid TwiML with conversation_configuration."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(welcome_greeting="Welcome!"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(welcome_greeting="Welcome!"),
+                )
             ),
         )
 
@@ -593,14 +608,16 @@ class TestVoiceChannel:
         case (e.g. Azure Hosted Agents) appending a per-call token to the
         upgrade URL — done through the existing customizer, no new API surface.
         """
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
         from tac.models.voice import TwiMLRequest
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(welcome_greeting="Welcome!"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(welcome_greeting="Welcome!"),
+                )
             ),
         )
 
@@ -628,14 +645,16 @@ class TestVoiceChannel:
     @pytest.mark.asyncio
     async def test_handle_incoming_call_websocket_url_via_default_options(self) -> None:
         """Test default_twiml_options.websocket_url overrides the derived URL."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
 
         tac = TAC(get_test_config())
         override = "wss://static.example.com/socket"
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(websocket_url=override),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(websocket_url=override),
+                )
             ),
         )
 
@@ -647,14 +666,18 @@ class TestVoiceChannel:
     @pytest.mark.asyncio
     async def test_handle_incoming_call_customizer_beats_default_options(self) -> None:
         """Test customizer websocket_url wins over default_twiml_options (precedence)."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
         from tac.models.voice import TwiMLRequest
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(websocket_url="wss://static.example.com/socket"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(
+                        websocket_url="wss://static.example.com/socket"
+                    ),
+                )
             ),
         )
 
@@ -697,7 +720,7 @@ class TestVoiceChannel:
         )
 
         # Call handler directly
-        await channel._handle_prompt("CALL111", prompt_msg)
+        await channel._provider._handle_prompt(channel, "CALL111", prompt_msg)
 
         # Voice channel doesn't fetch memory - test passes if no exception raised
 
@@ -718,16 +741,16 @@ class TestVoiceChannel:
         mock_ws_3 = AsyncMock()
 
         # Register websockets with the manager
-        channel._websocket_manager.add_websocket("CALL_001", mock_ws_1)
-        channel._websocket_manager.add_websocket("CALL_002", mock_ws_2)
-        channel._websocket_manager.add_websocket("CALL_003", mock_ws_3)
+        channel._provider._websocket_manager.add_websocket("CALL_001", mock_ws_1)
+        channel._provider._websocket_manager.add_websocket("CALL_002", mock_ws_2)
+        channel._provider._websocket_manager.add_websocket("CALL_003", mock_ws_3)
 
         # Verify all conversations and websockets are tracked
         assert len(channel._conversations) == 3
-        assert len(channel._websocket_manager) == 3
-        assert channel._websocket_manager.has_websocket("CALL_001")
-        assert channel._websocket_manager.has_websocket("CALL_002")
-        assert channel._websocket_manager.has_websocket("CALL_003")
+        assert len(channel._provider._websocket_manager) == 3
+        assert channel._provider._websocket_manager.has_websocket("CALL_001")
+        assert channel._provider._websocket_manager.has_websocket("CALL_002")
+        assert channel._provider._websocket_manager.has_websocket("CALL_003")
 
         # Send responses to each conversation independently
         await channel.send_response("CALL_001", "Response to call 1")
@@ -760,35 +783,35 @@ class TestVoiceChannel:
         channel._start_conversation("CALL_C", "profile_C")
 
         # Register websockets
-        channel._websocket_manager.add_websocket("CALL_A", AsyncMock())
-        channel._websocket_manager.add_websocket("CALL_B", AsyncMock())
-        channel._websocket_manager.add_websocket("CALL_C", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CALL_A", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CALL_B", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CALL_C", AsyncMock())
 
         # Verify initial state
         assert len(channel._conversations) == 3
-        assert len(channel._websocket_manager) == 3
+        assert len(channel._provider._websocket_manager) == 3
 
         # Clean up CALL_B WebSocket only
-        await channel._cleanup_connection("CALL_B")
+        await channel._provider._cleanup_connection(channel, "CALL_B")
 
         # Verify CALL_B WebSocket is cleaned up but conversation still tracked
-        assert not channel._websocket_manager.has_websocket("CALL_B")
+        assert not channel._provider._websocket_manager.has_websocket("CALL_B")
         assert "CALL_B" in channel._conversations
         assert len(channel._conversations) == 3
-        assert len(channel._websocket_manager) == 2
+        assert len(channel._provider._websocket_manager) == 2
 
         # Verify CALL_A and CALL_C are still active
         assert "CALL_A" in channel._conversations
         assert "CALL_C" in channel._conversations
-        assert channel._websocket_manager.has_websocket("CALL_A")
-        assert channel._websocket_manager.has_websocket("CALL_C")
+        assert channel._provider._websocket_manager.has_websocket("CALL_A")
+        assert channel._provider._websocket_manager.has_websocket("CALL_C")
 
         # Clean up remaining WebSockets
-        await channel._cleanup_connection("CALL_A")
-        await channel._cleanup_connection("CALL_C")
+        await channel._provider._cleanup_connection(channel, "CALL_A")
+        await channel._provider._cleanup_connection(channel, "CALL_C")
 
         # Verify WebSockets cleaned up but conversations still tracked
-        assert len(channel._websocket_manager) == 0
+        assert len(channel._provider._websocket_manager) == 0
         assert len(channel._conversations) == 3
 
     @pytest.mark.asyncio
@@ -798,15 +821,15 @@ class TestVoiceChannel:
         channel = VoiceChannel(tac)
 
         # Initially empty
-        assert channel._websocket_manager.get_all_conversation_ids() == []
+        assert channel._provider._websocket_manager.get_all_conversation_ids() == []
 
         # Add multiple websockets
-        channel._websocket_manager.add_websocket("CONV_1", AsyncMock())
-        channel._websocket_manager.add_websocket("CONV_2", AsyncMock())
-        channel._websocket_manager.add_websocket("CONV_3", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CONV_1", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CONV_2", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CONV_3", AsyncMock())
 
         # Get all conversation IDs
-        conv_ids = channel._websocket_manager.get_all_conversation_ids()
+        conv_ids = channel._provider._websocket_manager.get_all_conversation_ids()
 
         # Verify all IDs are returned
         assert len(conv_ids) == 3
@@ -828,8 +851,8 @@ class TestVoiceChannel:
         mock_ws_x = AsyncMock()
         mock_ws_y = AsyncMock()
 
-        channel._websocket_manager.add_websocket("CONV_X", mock_ws_x)
-        channel._websocket_manager.add_websocket("CONV_Y", mock_ws_y)
+        channel._provider._websocket_manager.add_websocket("CONV_X", mock_ws_x)
+        channel._provider._websocket_manager.add_websocket("CONV_Y", mock_ws_y)
 
         # Send multiple messages to each conversation
         await channel.send_response("CONV_X", "Message 1 to X")
@@ -859,19 +882,19 @@ class TestVoiceChannel:
         channel = VoiceChannel(tac)
 
         # Add a websocket
-        channel._websocket_manager.add_websocket("CONV_Z", AsyncMock())
-        assert channel._websocket_manager.has_websocket("CONV_Z")
+        channel._provider._websocket_manager.add_websocket("CONV_Z", AsyncMock())
+        assert channel._provider._websocket_manager.has_websocket("CONV_Z")
 
         # Remove it once
-        channel._websocket_manager.remove_websocket("CONV_Z")
-        assert not channel._websocket_manager.has_websocket("CONV_Z")
+        channel._provider._websocket_manager.remove_websocket("CONV_Z")
+        assert not channel._provider._websocket_manager.has_websocket("CONV_Z")
 
         # Remove it again (should not raise error)
-        channel._websocket_manager.remove_websocket("CONV_Z")
-        assert not channel._websocket_manager.has_websocket("CONV_Z")
+        channel._provider._websocket_manager.remove_websocket("CONV_Z")
+        assert not channel._provider._websocket_manager.has_websocket("CONV_Z")
 
         # Remove non-existent websocket (should not raise error)
-        channel._websocket_manager.remove_websocket("NON_EXISTENT")
+        channel._provider._websocket_manager.remove_websocket("NON_EXISTENT")
 
     @pytest.mark.asyncio
     async def test_websocket_replacement(self) -> None:
@@ -881,23 +904,23 @@ class TestVoiceChannel:
 
         # Add first websocket
         first_ws = AsyncMock()
-        channel._websocket_manager.add_websocket("CONV_REPLACE", first_ws)
+        channel._provider._websocket_manager.add_websocket("CONV_REPLACE", first_ws)
 
         # Verify first websocket is registered
-        retrieved_ws = channel._websocket_manager.get_websocket("CONV_REPLACE")
+        retrieved_ws = channel._provider._websocket_manager.get_websocket("CONV_REPLACE")
         assert retrieved_ws is first_ws
 
         # Add second websocket with same conversation ID
         second_ws = AsyncMock()
-        channel._websocket_manager.add_websocket("CONV_REPLACE", second_ws)
+        channel._provider._websocket_manager.add_websocket("CONV_REPLACE", second_ws)
 
         # Verify second websocket replaced the first
-        retrieved_ws = channel._websocket_manager.get_websocket("CONV_REPLACE")
+        retrieved_ws = channel._provider._websocket_manager.get_websocket("CONV_REPLACE")
         assert retrieved_ws is second_ws
         assert retrieved_ws is not first_ws
 
         # Verify still only one websocket tracked
-        assert len(channel._websocket_manager) == 1
+        assert len(channel._provider._websocket_manager) == 1
 
     @pytest.mark.asyncio
     async def test_send_response_with_invalid_type_raises_error(self) -> None:
@@ -910,7 +933,7 @@ class TestVoiceChannel:
 
         # Mock websocket
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL_INVALID", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL_INVALID", mock_websocket)
 
         # Test with integer (invalid type)
         with pytest.raises(TypeError, match="Voice channel requires string or async generator"):
@@ -937,7 +960,7 @@ class TestVoiceChannel:
 
         # Mock websocket
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL_STREAM", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL_STREAM", mock_websocket)
 
         # Create async generator
         async def stream_response() -> AsyncGenerator[str, None]:
@@ -966,16 +989,16 @@ class TestVoiceChannel:
         # Start conversation and add a mock websocket
         channel._start_conversation("CALL_CB1", "prof_cb1")
         mock_ws = MagicMock()
-        channel._websocket_manager.add_websocket("CALL_CB1", mock_ws)
+        channel._provider._websocket_manager.add_websocket("CALL_CB1", mock_ws)
 
-        await channel._cleanup_connection("CALL_CB1")
+        await channel._provider._cleanup_connection(channel, "CALL_CB1")
 
         # Callback should NOT be called (conversation still tracked for webhook)
         assert len(captured) == 0
         # Conversation should still be tracked
         assert "CALL_CB1" in channel._conversations
         # WebSocket should be removed
-        assert not channel._websocket_manager.has_websocket("CALL_CB1")
+        assert not channel._provider._websocket_manager.has_websocket("CALL_CB1")
 
     @pytest.mark.asyncio
     async def test_cleanup_connection_removes_websocket_only(self) -> None:
@@ -985,14 +1008,14 @@ class TestVoiceChannel:
 
         channel._start_conversation("CALL_CB2", "prof_cb2")
         mock_ws = MagicMock()
-        channel._websocket_manager.add_websocket("CALL_CB2", mock_ws)
+        channel._provider._websocket_manager.add_websocket("CALL_CB2", mock_ws)
 
-        await channel._cleanup_connection("CALL_CB2")
+        await channel._provider._cleanup_connection(channel, "CALL_CB2")
 
         # Conversation still tracked (waiting for webhook)
         assert "CALL_CB2" in channel._conversations
         # WebSocket removed
-        assert not channel._websocket_manager.has_websocket("CALL_CB2")
+        assert not channel._provider._websocket_manager.has_websocket("CALL_CB2")
 
     @pytest.mark.asyncio
     async def test_webhook_triggers_conversation_ended_callback(self) -> None:
@@ -1030,15 +1053,15 @@ class TestVoiceChannel:
 
         channel._start_conversation("CALL_NOCB", "prof_nocb")
         mock_ws = MagicMock()
-        channel._websocket_manager.add_websocket("CALL_NOCB", mock_ws)
+        channel._provider._websocket_manager.add_websocket("CALL_NOCB", mock_ws)
 
-        await channel._cleanup_connection("CALL_NOCB")
+        await channel._provider._cleanup_connection(channel, "CALL_NOCB")
         # Second cleanup should be a no-op (websocket already removed)
-        await channel._cleanup_connection("CALL_NOCB")
+        await channel._provider._cleanup_connection(channel, "CALL_NOCB")
 
         # Conversation still tracked (only webhook removes it)
         assert "CALL_NOCB" in channel._conversations
-        assert not channel._websocket_manager.has_websocket("CALL_NOCB")
+        assert not channel._provider._websocket_manager.has_websocket("CALL_NOCB")
 
     @pytest.mark.asyncio
     async def test_task_cancellation_with_unified_workflow(self) -> None:
@@ -1085,8 +1108,12 @@ class TestVoiceChannel:
 
         # Create session manager and voice channel
         session_manager = ThreadSafeSessionManager()
+
         voice_channel = VoiceChannel(
-            tac=tac, config={"session_manager": session_manager, "memory_mode": "never"}
+            tac=tac,
+            config=ConversationRelayProvider(
+                {"memory_mode": "never", "session_manager": session_manager}
+            ),
         )
 
         # Setup conversation
@@ -1094,7 +1121,7 @@ class TestVoiceChannel:
 
         # Mock websocket
         mock_websocket = AsyncMock()
-        voice_channel._websocket_manager.add_websocket("CONV_CANCEL_TEST", mock_websocket)
+        voice_channel._provider._websocket_manager.add_websocket("CONV_CANCEL_TEST", mock_websocket)
 
         # Create prompt message
         prompt_data = {
@@ -1107,7 +1134,9 @@ class TestVoiceChannel:
         session_state = session_manager.get_or_create_session("CONV_CANCEL_TEST")
 
         # Start processing prompt (creates task but doesn't await it)
-        await voice_channel._handle_prompt_async("CONV_CANCEL_TEST", prompt_data, session_state)
+        await voice_channel._provider._handle_prompt_async(
+            voice_channel, "CONV_CANCEL_TEST", prompt_data, session_state
+        )
 
         # Verify task was created
         assert session_state.stream_task is not None
@@ -1140,7 +1169,9 @@ class TestVoiceChannel:
         assert chunks_sent > 0, "Should have sent some chunks before cancellation"
 
         # Now process new prompt
-        await voice_channel._handle_prompt_async("CONV_CANCEL_TEST", prompt_data2, session_state)
+        await voice_channel._provider._handle_prompt_async(
+            voice_channel, "CONV_CANCEL_TEST", prompt_data2, session_state
+        )
 
         # Verify new task was created
         assert session_state.stream_task is not None
@@ -1556,15 +1587,17 @@ class TestHandleIncomingCallMerge:
 
     @pytest.mark.asyncio
     async def test_static_options_override_conversation_configuration(self) -> None:
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(
-                    conversation_configuration="conv_configuration_custom"
-                ),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(
+                        conversation_configuration="conv_configuration_custom"
+                    ),
+                )
             ),
         )
         twiml = await channel.handle_incoming_call()
@@ -1614,13 +1647,15 @@ class TestHandleIncomingCallMerge:
     async def test_static_options_action_url_beats_derived_default(self) -> None:
         """A static action_url on default_twiml_options is an explicit user
         choice and wins over the derived cleanup URL."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(action_url="https://static.example.com/end"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(action_url="https://static.example.com/end"),
+                )
             ),
         )
         twiml = await channel.handle_incoming_call()
@@ -1633,7 +1668,7 @@ class TestHandleIncomingCallMerge:
         default_twiml_options.action_url. Verifies the _overlay_fields skip
         invariant — every layer's action_url is funneled through
         _resolve_action_url, never via the field overlay."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
         from tac.models.voice import TwiMLRequest
 
         async def customizer(req: TwiMLRequest) -> TwiMLOptions:
@@ -1642,8 +1677,10 @@ class TestHandleIncomingCallMerge:
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(action_url="https://static.example.com/end"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(action_url="https://static.example.com/end"),
+                )
             ),
         )
         channel.on_inbound_call_twiml(customizer)
@@ -1656,7 +1693,7 @@ class TestHandleIncomingCallMerge:
         """Explicit action_url=None on the customizer suppresses the
         <Connect action=...> attribute, even if Studio handoff or a channel
         default would otherwise populate it."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
         from tac.models.voice import TwiMLRequest
 
         async def customizer(req: TwiMLRequest) -> TwiMLOptions:
@@ -1666,8 +1703,10 @@ class TestHandleIncomingCallMerge:
         tac = TAC({**get_test_config(), "studio_handoff_flow_sid": flow_sid})
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(action_url="https://static.example.com/end"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(action_url="https://static.example.com/end"),
+                )
             ),
         )
         channel.on_inbound_call_twiml(customizer)
@@ -1678,14 +1717,16 @@ class TestHandleIncomingCallMerge:
     async def test_default_options_action_url_none_suppresses(self) -> None:
         """Explicit action_url=None on default_twiml_options suppresses
         <Connect action=...> channel-wide, even with Studio handoff configured."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
 
         flow_sid = "FW" + "a" * 32
         tac = TAC({**get_test_config(), "studio_handoff_flow_sid": flow_sid})
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(action_url=None),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(action_url=None),
+                )
             ),
         )
         twiml = await channel.handle_incoming_call()
@@ -1717,14 +1758,13 @@ class TestHandleIncomingCallMerge:
         """Precedence: the application's on_inbound_call_twiml customizer sits
         ABOVE host_twiml_options — a developer's explicit choice wins over the
         host's per-call values (for fields the dev sets)."""
-        from tac.channels.voice import VoiceChannelConfig
         from tac.models.voice import TwiMLRequest
 
         async def app_customizer(req: TwiMLRequest) -> TwiMLOptions:
             return TwiMLOptions(welcome_greeting="App wins")
 
         tac = TAC(get_test_config())
-        channel = VoiceChannel(tac, config=VoiceChannelConfig())
+        channel = VoiceChannel(tac)
         channel.on_inbound_call_twiml(app_customizer)
 
         twiml = await channel.handle_incoming_call(
@@ -1744,13 +1784,15 @@ class TestHandleIncomingCallMerge:
     @pytest.mark.asyncio
     async def test_default_options_beats_host_twiml_options(self) -> None:
         """default_twiml_options sits above host_twiml_options."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(welcome_greeting="Channel default"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(welcome_greeting="Channel default"),
+                )
             ),
         )
 
@@ -1763,17 +1805,20 @@ class TestHandleIncomingCallMerge:
 
 
 class TestStaticTwiMLOptions:
-    """VoiceChannelConfig.twiml_options applies to every call without a callback."""
+    """ConversationRelayProviderConfig.default_twiml_options applies to every call
+    without a callback."""
 
     @pytest.mark.asyncio
     async def test_static_options_applied(self) -> None:
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(voice="en-US-Journey-D", language="en-US"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(voice="en-US-Journey-D", language="en-US"),
+                )
             ),
         )
         twiml = await channel.handle_incoming_call()
@@ -1782,13 +1827,15 @@ class TestStaticTwiMLOptions:
 
     @pytest.mark.asyncio
     async def test_welcome_greeting_via_twiml_options(self) -> None:
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
 
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(welcome_greeting="Bonjour!"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(welcome_greeting="Bonjour!"),
+                )
             ),
         )
         twiml = await channel.handle_incoming_call()
@@ -1841,7 +1888,7 @@ class TestCustomizeTwiMLOptions:
 
     @pytest.mark.asyncio
     async def test_customizer_output_beats_static(self) -> None:
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
         from tac.models.voice import TwiMLRequest
 
         async def customizer(ctx: TwiMLRequest) -> TwiMLOptions:
@@ -1850,8 +1897,10 @@ class TestCustomizeTwiMLOptions:
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(voice="en-US-Journey-D"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(voice="en-US-Journey-D"),
+                )
             ),
         )
         channel.on_inbound_call_twiml(customizer)
@@ -1862,7 +1911,7 @@ class TestCustomizeTwiMLOptions:
 
     @pytest.mark.asyncio
     async def test_customizer_unset_fields_keep_lower_layers(self) -> None:
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
         from tac.models.voice import TwiMLRequest
 
         async def customizer(ctx: TwiMLRequest) -> TwiMLOptions:
@@ -1871,8 +1920,10 @@ class TestCustomizeTwiMLOptions:
         tac = TAC(get_test_config())
         channel = VoiceChannel(
             tac,
-            config=VoiceChannelConfig(
-                default_twiml_options=TwiMLOptions(welcome_greeting="Channel default"),
+            config=ConversationRelayProvider(
+                ConversationRelayProviderConfig(
+                    default_twiml_options=TwiMLOptions(welcome_greeting="Channel default"),
+                )
             ),
         )
         channel.on_inbound_call_twiml(customizer)
@@ -2038,7 +2089,7 @@ class TestConversationInitializationFlow:
         assert profile_id == "profile_voice_correct"
 
     @pytest.mark.asyncio
-    @patch("tac.channels.voice.channel._POLL_BASE_DELAY", 0)
+    @patch("tac.channels.voice.conversation_relay._POLL_BASE_DELAY", 0)
     async def test_error_when_no_conversations_found(self, capsys: pytest.CaptureFixture) -> None:
         """Test RuntimeError when ConversationRelay creates 0 conversations."""
         from tac.channels.websocket_protocol import WebSocketDisconnectError
@@ -2075,7 +2126,7 @@ class TestConversationInitializationFlow:
         assert len(channel._conversations) == 0
 
     @pytest.mark.asyncio
-    @patch("tac.channels.voice.channel._POLL_BASE_DELAY", 0)
+    @patch("tac.channels.voice.conversation_relay._POLL_BASE_DELAY", 0)
     async def test_error_when_multiple_conversations_found(
         self, capsys: pytest.CaptureFixture
     ) -> None:
@@ -2198,7 +2249,7 @@ class TestConversationInitializationFlow:
 
         # The websocket registration is cleaned up (not leaked) even though
         # no prompt ever arrived to claim conv_id itself.
-        assert not channel._websocket_manager.has_websocket("CH_setup_test")
+        assert not channel._provider._websocket_manager.has_websocket("CH_setup_test")
         # The conversation entry legitimately stays until CO's CLOSED
         # webhook — same as any other orchestrator-mode call.
         assert list(channel._conversations.keys()) == ["CH_setup_test"]
@@ -2278,7 +2329,7 @@ class TestConversationInitializationFlow:
 
 
 class TestSessionManagerDefaults:
-    """Test session_manager default behavior in VoiceChannelConfig."""
+    """Test session_manager default behavior in ConversationRelayProviderConfig."""
 
     def test_default_session_manager_is_created(self) -> None:
         """Test that VoiceChannel creates a session_manager by default."""
@@ -2288,27 +2339,29 @@ class TestSessionManagerDefaults:
         channel = VoiceChannel(tac)
 
         # Verify session_manager is created by default
-        assert channel.session_manager is not None
-        assert isinstance(channel.session_manager, ThreadSafeSessionManager)
+        assert channel._provider.config.session_manager is not None
+        assert isinstance(channel._provider.config.session_manager, ThreadSafeSessionManager)
 
     def test_session_manager_can_be_set_to_none(self) -> None:
         """Test that session_manager can be explicitly disabled."""
-        from tac.channels.voice import VoiceChannelConfig
+        from tac.channels.voice import ConversationRelayProvider, ConversationRelayProviderConfig
 
         tac = TAC(get_test_config())
-        config = VoiceChannelConfig(session_manager=None)
-        channel = VoiceChannel(tac, config=config)
+        provider = ConversationRelayProvider(ConversationRelayProviderConfig(session_manager=None))
+        channel = VoiceChannel(tac, config=provider)
 
         # Verify session_manager is None when explicitly disabled
-        assert channel.session_manager is None
+        assert channel._provider.config.session_manager is None
 
     def test_session_manager_can_be_dict_none(self) -> None:
-        """Test that session_manager can be disabled via config dict."""
+        """Test that session_manager can be disabled via a config dict."""
+        from tac.channels.voice import ConversationRelayProvider
+
         tac = TAC(get_test_config())
-        channel = VoiceChannel(tac, config={"session_manager": None})
+        channel = VoiceChannel(tac, config=ConversationRelayProvider({"session_manager": None}))
 
         # Verify session_manager is None when explicitly disabled via dict
-        assert channel.session_manager is None
+        assert channel._provider.config.session_manager is None
 
     @pytest.mark.asyncio
     async def test_cleanup_cancels_running_task(self) -> None:
@@ -2332,16 +2385,20 @@ class TestSessionManagerDefaults:
         # Start conversation
         channel._start_conversation("CONV_CLEANUP_TEST", None)
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CONV_CLEANUP_TEST", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CONV_CLEANUP_TEST", mock_websocket)
 
         # Create and start a task
-        session_state = channel.session_manager.get_or_create_session("CONV_CLEANUP_TEST")
+        session_state = channel._provider.config.session_manager.get_or_create_session(
+            "CONV_CLEANUP_TEST"
+        )
         prompt_data = {
             "type": "prompt",
             "conversationId": "CONV_CLEANUP_TEST",
             "voicePrompt": "Test",
         }
-        await channel._handle_prompt_async("CONV_CLEANUP_TEST", prompt_data, session_state)
+        await channel._provider._handle_prompt_async(
+            channel, "CONV_CLEANUP_TEST", prompt_data, session_state
+        )
 
         # Give task time to start
         await asyncio.sleep(0.05)
@@ -2349,7 +2406,7 @@ class TestSessionManagerDefaults:
         assert not session_state.stream_task.done()
 
         # Cleanup should cancel the task
-        await channel._cleanup_connection("CONV_CLEANUP_TEST")
+        await channel._provider._cleanup_connection(channel, "CONV_CLEANUP_TEST")
 
         # Verify task was cancelled
         assert task_cancelled == [True]


### PR DESCRIPTION
## Summary

Introduces a Strategy pattern for voice media transport, in preparation for upcoming speech-to-speech (S2S) model integrations. **This PR contains no S2S code** — just the architectural groundwork, split out into its own small(er) PR to make review easier.

### Design

`VoiceChannel` is the single public entry point for voice. It now owns only what's shared across every voice integration:
- The Twilio Calls API lifecycle — inbound/outbound call handling, `CallStatus`/`AMD`/`Recording` webhook registration and dispatch, hangup
- Conversation/session bookkeeping (inherited from `BaseChannel`)

A pluggable `VoiceStrategy` owns only what differs per integration:
- Building the `<Connect>` TwiML that points Twilio at the right endpoint
- Driving the per-call WebSocket
- Whether/how a response is sent back

```
VoiceChannel (Calls API lifecycle + session bookkeeping — shared)
  └── VoiceStrategy (interface)
        └── ConversationRelayStrategy (default and only implementation today)
```

`ConversationRelayStrategy` absorbs all the ConversationRelay-specific logic that used to live directly on `VoiceChannel` — inbound/outbound TwiML merging (customizer → `default_twiml_options` → host overrides → TAC defaults), the `on_inbound_call_twiml` customizer, and outbound call placement. **This is mostly relocated code, not new logic** — behavior is unchanged, only where it lives.

### Backward compatibility

`VoiceChannel`'s public constructor signature is unchanged. `VoiceChannelConfig` is now an alias for `ConversationRelayStrategyConfig`, so existing code keeps working exactly as before:

```python
# unchanged
voice = VoiceChannel(tac, config=VoiceChannelConfig(memory_mode="once"))
```

### Other design decisions

- **`VoiceStrategy.build_twiml` depends on `TwiMLOptions` directly, not a generic base** — there's only one strategy in this PR, so a generic `<Connect>`-level options type would have no real second consumer yet. Deliberately not splitting it out until a strategy that actually needs the narrower contract exists — a real second consumer will motivate the right shape better than guessing now.
- **`VoiceStrategy.handle_incoming_call`/`initiate_outbound_conversation`/`on_inbound_call_twiml` have sensible defaults** — a minimal `handle_incoming_call` default and `NotImplementedError` defaults for the other two, so a future strategy that doesn't support outbound calls or the customizer fails loudly instead of silently no-oping.

## Type of Change

- [x] Refactoring

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E (`make check` — lint, type-check, full test suite)

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)
