### PR TITLE
refactor(voice): add VoiceProviderConfig base for pluggable providers

### DIFF
--- a/src/tac/channels/voice/__init__.py
+++ b/src/tac/channels/voice/__init__.py
@@ -4,10 +4,13 @@ from tac.channels.voice.channel import VoiceChannel
 from tac.channels.voice.config import (
     AmdHandler,
     CallStatusHandler,
+    ConversationRelayProviderConfig,
     InboundCallTwiMLHandler,
     RecordingHandler,
     VoiceChannelConfig,
 )
+from tac.channels.voice.conversation_relay import ConversationRelayProvider
+from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
 from tac.channels.voice.twiml import generate_twiml
 from tac.models.outbound import CallOptions
 from tac.models.voice import (
@@ -26,6 +29,8 @@ __all__ = [
     "CallOptions",
     "CallStatusEvent",
     "CallStatusHandler",
+    "ConversationRelayProvider",
+    "ConversationRelayProviderConfig",
     "InboundCallTwiMLHandler",
     "InterruptMode",
     "LanguageConfig",
@@ -35,5 +40,7 @@ __all__ = [
     "TwiMLRequest",
     "VoiceChannel",
     "VoiceChannelConfig",
+    "VoiceProvider",
+    "VoiceProviderConfig",
     "generate_twiml",
 ]

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncGenerator, Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from twilio.rest import Client
@@ -43,6 +43,7 @@ from .config import (
     RecordingHandler,
     VoiceChannelConfig,
 )
+from .provider import VoiceProviderConfig
 
 _POLL_ATTEMPTS = 10
 _POLL_BASE_DELAY = 0.25
@@ -70,30 +71,39 @@ class VoiceChannel(BaseChannel):
     def __init__(
         self,
         tac: TAC,
-        config: VoiceChannelConfig | dict[str, Any] | None = None,
+        config: VoiceProviderConfig | dict[str, Any] | None = None,
     ):
         """
         Initialize Voice channel for websocket protocol handling.
 
         Args:
             tac: TAC instance for memory/context operations
-            config: Voice channel configuration (VoiceChannelConfig or dict).
-                If None, uses default configuration.
+            config: Voice channel configuration (a ``VoiceProviderConfig`` —
+                ``VoiceChannelConfig`` today — or dict). If None, uses default
+                configuration.
 
         Examples:
             >>> channel = VoiceChannel(tac, config={"memory_mode": "always"})
             >>> channel = VoiceChannel(tac, config=VoiceChannelConfig(session_manager=sm))
             >>> channel = VoiceChannel(tac)  # Use defaults
         """
-        # Convert dict to config model or use defaults
+        # Convert dict to config model or use defaults. VoiceChannelConfig is
+        # the only VoiceProviderConfig implementation today, so this cast is
+        # accurate — it'll need to become an isinstance check once a second
+        # one exists.
         if isinstance(config, dict):
             config = VoiceChannelConfig(**config)
         elif config is None:
             config = VoiceChannelConfig()
+        config = cast(VoiceChannelConfig, config)
 
         super().__init__(tac, memory_mode=config.memory_mode)
         self.config = config
         self.session_manager = config.session_manager
+        # TODO: not used yet — VoiceChannel still owns ConversationRelay logic
+        # directly. A follow-up PR moves that logic onto self._provider and
+        # drops the cast above in favor of self._provider's own attributes.
+        self._provider = config.create_provider()
         self._on_inbound_call_twiml: InboundCallTwiMLHandler | None = None
         self._on_call_status: CallStatusHandler | None = None
         self._on_amd: AmdHandler | None = None

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -103,7 +103,7 @@ class VoiceChannel(BaseChannel):
         # TODO: not used yet — VoiceChannel still owns ConversationRelay logic
         # directly. A follow-up PR moves that logic onto self._provider and
         # drops the cast above in favor of self._provider's own attributes.
-        self._provider = config.create_provider(tac.config)
+        self._provider = config.create_provider(self, tac.config)
         self._on_inbound_call_twiml: InboundCallTwiMLHandler | None = None
         self._on_call_status: CallStatusHandler | None = None
         self._on_amd: AmdHandler | None = None

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -103,7 +103,7 @@ class VoiceChannel(BaseChannel):
         # TODO: not used yet — VoiceChannel still owns ConversationRelay logic
         # directly. A follow-up PR moves that logic onto self._provider and
         # drops the cast above in favor of self._provider's own attributes.
-        self._provider = config.create_provider()
+        self._provider = config.create_provider(tac.config)
         self._on_inbound_call_twiml: InboundCallTwiMLHandler | None = None
         self._on_call_status: CallStatusHandler | None = None
         self._on_amd: AmdHandler | None = None

--- a/src/tac/channels/voice/config.py
+++ b/src/tac/channels/voice/config.py
@@ -2,8 +2,10 @@
 
 from collections.abc import Awaitable, Callable
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from tac.channels.voice.conversation_relay import ConversationRelayProvider
+from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
 from tac.models.memory import MemoryMode
 from tac.models.outbound import CallOptions
 from tac.models.voice import (
@@ -21,7 +23,7 @@ AmdHandler = Callable[[AmdEvent], Awaitable[None]]
 RecordingHandler = Callable[[RecordingEvent], Awaitable[None]]
 
 
-class VoiceChannelConfig(BaseModel):
+class ConversationRelayProviderConfig(VoiceProviderConfig):
     """
     Configuration for Voice channel.
 
@@ -102,3 +104,11 @@ class VoiceChannelConfig(BaseModel):
         "non-default paths; they override the URLs TAC would derive from "
         "voice_public_domain + voice_call_event_path.",
     )
+
+    def create_provider(self) -> VoiceProvider:
+        return ConversationRelayProvider(self)
+
+
+# VoiceChannelConfig is this same class under its pre-provider-split name —
+# not a separate model, so this alias is the only place the two names diverge.
+VoiceChannelConfig = ConversationRelayProviderConfig

--- a/src/tac/channels/voice/config.py
+++ b/src/tac/channels/voice/config.py
@@ -1,12 +1,18 @@
 """Voice channel configuration."""
 
+from __future__ import annotations
+
 from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
 
 from pydantic import Field
 
 from tac.channels.voice.conversation_relay import ConversationRelayProvider
 from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
 from tac.core.config import TACConfig
+
+if TYPE_CHECKING:
+    from tac.channels.voice.channel import VoiceChannel
 from tac.models.memory import MemoryMode
 from tac.models.outbound import CallOptions
 from tac.models.voice import (
@@ -106,8 +112,8 @@ class ConversationRelayProviderConfig(VoiceProviderConfig):
         "voice_public_domain + voice_call_event_path.",
     )
 
-    def create_provider(self, tac_config: TACConfig) -> VoiceProvider:
-        return ConversationRelayProvider(tac_config, self)
+    def create_provider(self, channel: VoiceChannel, tac_config: TACConfig) -> VoiceProvider:
+        return ConversationRelayProvider(channel, tac_config, self)
 
 
 # VoiceChannelConfig is this same class under its pre-provider-split name —

--- a/src/tac/channels/voice/config.py
+++ b/src/tac/channels/voice/config.py
@@ -6,6 +6,7 @@ from pydantic import Field
 
 from tac.channels.voice.conversation_relay import ConversationRelayProvider
 from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
+from tac.core.config import TACConfig
 from tac.models.memory import MemoryMode
 from tac.models.outbound import CallOptions
 from tac.models.voice import (
@@ -105,8 +106,8 @@ class ConversationRelayProviderConfig(VoiceProviderConfig):
         "voice_public_domain + voice_call_event_path.",
     )
 
-    def create_provider(self) -> VoiceProvider:
-        return ConversationRelayProvider(self)
+    def create_provider(self, tac_config: TACConfig) -> VoiceProvider:
+        return ConversationRelayProvider(tac_config, self)
 
 
 # VoiceChannelConfig is this same class under its pre-provider-split name —

--- a/src/tac/channels/voice/conversation_relay.py
+++ b/src/tac/channels/voice/conversation_relay.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from tac.channels.voice.provider import VoiceProvider
+from tac.core.config import TACConfig
 
 if TYPE_CHECKING:
     from tac.channels.voice.config import ConversationRelayProviderConfig
@@ -24,5 +25,5 @@ class ConversationRelayProvider(VoiceProvider):
     explicitly.
     """
 
-    def __init__(self, config: ConversationRelayProviderConfig) -> None:
+    def __init__(self, tac_config: TACConfig, config: ConversationRelayProviderConfig) -> None:
         self.config = config

--- a/src/tac/channels/voice/conversation_relay.py
+++ b/src/tac/channels/voice/conversation_relay.py
@@ -14,6 +14,7 @@ from tac.channels.voice.provider import VoiceProvider
 from tac.core.config import TACConfig
 
 if TYPE_CHECKING:
+    from tac.channels.voice.channel import VoiceChannel
     from tac.channels.voice.config import ConversationRelayProviderConfig
 
 
@@ -25,5 +26,11 @@ class ConversationRelayProvider(VoiceProvider):
     explicitly.
     """
 
-    def __init__(self, tac_config: TACConfig, config: ConversationRelayProviderConfig) -> None:
+    def __init__(
+        self,
+        channel: VoiceChannel,
+        tac_config: TACConfig,
+        config: ConversationRelayProviderConfig,
+    ) -> None:
+        super().__init__(channel)
         self.config = config

--- a/src/tac/channels/voice/conversation_relay.py
+++ b/src/tac/channels/voice/conversation_relay.py
@@ -1,0 +1,28 @@
+"""``ConversationRelayProvider``: the default ``VoiceProvider``.
+
+Empty for now — a placeholder. ``VoiceChannel`` still owns all
+ConversationRelay-specific logic directly; a follow-up PR moves it here
+(TwiML building via ``twiml.TwiMLBuilderConversationRelay``, WebSocket
+protocol handling, outbound calls).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tac.channels.voice.provider import VoiceProvider
+
+if TYPE_CHECKING:
+    from tac.channels.voice.config import ConversationRelayProviderConfig
+
+
+class ConversationRelayProvider(VoiceProvider):
+    """Twilio ConversationRelay: Twilio handles ASR/TTS and exchanges JSON
+    ``setup``/``prompt``/``interrupt`` messages over one WebSocket.
+
+    This is the default provider ``VoiceChannel`` builds when none is passed
+    explicitly.
+    """
+
+    def __init__(self, config: ConversationRelayProviderConfig) -> None:
+        self.config = config

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -1,0 +1,30 @@
+"""``VoiceProvider``: the interface that lets ``VoiceChannel`` host more than
+one kind of real-time media provider.
+
+Empty for now — a placeholder for the follow-up PR that moves
+``VoiceChannel``'s ConversationRelay-specific logic (TwiML, WebSocket
+protocol handling, outbound calls) behind this interface.
+``ConversationRelayProvider`` is the only implementation today.
+"""
+
+from pydantic import BaseModel
+
+
+class VoiceProvider:
+    """Base class for a ``VoiceChannel``'s real-time media provider."""
+
+
+class VoiceProviderConfig(BaseModel):
+    """Base configuration for a ``VoiceChannel``'s real-time media provider.
+
+    ``ConversationRelayProviderConfig`` is the only subclass today. Lives
+    here (not in ``config.py``) so a future provider's config only needs to
+    import this module, not anything ConversationRelay-specific.
+    """
+
+    def create_provider(self) -> VoiceProvider:
+        """Build the ``VoiceProvider`` this config configures."""
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement create_provider() to be usable "
+            "as a VoiceChannel config."
+        )

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel
 
 from tac.core.config import TACConfig
+from tac.core.logging import get_logger
 
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
@@ -24,11 +25,15 @@ class VoiceProvider:
 
     Holds the owning ``channel`` so a provider can reach the generic,
     transport-agnostic functionality ``VoiceChannel`` still owns directly
-    (Calls API lifecycle, conversation bookkeeping, ``TAC``).
+    (Calls API lifecycle, conversation bookkeeping, ``TAC``). Has its own
+    ``logger`` (named after the concrete provider's module, same convention
+    as ``BaseChannel``) rather than borrowing ``channel.logger``, so log
+    lines are attributed to the provider that actually emitted them.
     """
 
     def __init__(self, channel: VoiceChannel) -> None:
         self.channel = channel
+        self.logger = get_logger(self.__class__.__module__)
 
 
 class VoiceProviderConfig(BaseModel):

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -9,6 +9,8 @@ protocol handling, outbound calls) behind this interface.
 
 from pydantic import BaseModel
 
+from tac.core.config import TACConfig
+
 
 class VoiceProvider:
     """Base class for a ``VoiceChannel``'s real-time media provider."""
@@ -22,8 +24,13 @@ class VoiceProviderConfig(BaseModel):
     import this module, not anything ConversationRelay-specific.
     """
 
-    def create_provider(self) -> VoiceProvider:
-        """Build the ``VoiceProvider`` this config configures."""
+    def create_provider(self, tac_config: TACConfig) -> VoiceProvider:
+        """Build the ``VoiceProvider`` this config configures.
+
+        Args:
+            tac_config: ``TACConfig`` — providers that talk TwiML need it to
+                derive default URLs (``voice_public_domain`` etc.).
+        """
         raise NotImplementedError(
             f"{type(self).__name__} must implement create_provider() to be usable "
             "as a VoiceChannel config."

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -7,13 +7,28 @@ protocol handling, outbound calls) behind this interface.
 ``ConversationRelayProvider`` is the only implementation today.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel
 
 from tac.core.config import TACConfig
 
+if TYPE_CHECKING:
+    from tac.channels.voice.channel import VoiceChannel
+
 
 class VoiceProvider:
-    """Base class for a ``VoiceChannel``'s real-time media provider."""
+    """Base class for a ``VoiceChannel``'s real-time media provider.
+
+    Holds the owning ``channel`` so a provider can reach the generic,
+    transport-agnostic functionality ``VoiceChannel`` still owns directly
+    (Calls API lifecycle, conversation bookkeeping, ``TAC``).
+    """
+
+    def __init__(self, channel: VoiceChannel) -> None:
+        self.channel = channel
 
 
 class VoiceProviderConfig(BaseModel):
@@ -24,10 +39,12 @@ class VoiceProviderConfig(BaseModel):
     import this module, not anything ConversationRelay-specific.
     """
 
-    def create_provider(self, tac_config: TACConfig) -> VoiceProvider:
+    def create_provider(self, channel: VoiceChannel, tac_config: TACConfig) -> VoiceProvider:
         """Build the ``VoiceProvider`` this config configures.
 
         Args:
+            channel: The owning ``VoiceChannel`` — stored on the provider so
+                it can reach the generic functionality the channel still owns.
             tac_config: ``TACConfig`` — providers that talk TwiML need it to
                 derive default URLs (``voice_public_domain`` etc.).
         """

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -23,12 +23,8 @@ if TYPE_CHECKING:
 class VoiceProvider:
     """Base class for a ``VoiceChannel``'s real-time media provider.
 
-    Holds the owning ``channel`` so a provider can reach the generic,
-    transport-agnostic functionality ``VoiceChannel`` still owns directly
-    (Calls API lifecycle, conversation bookkeeping, ``TAC``). Has its own
-    ``logger`` (named after the concrete provider's module, same convention
-    as ``BaseChannel``) rather than borrowing ``channel.logger``, so log
-    lines are attributed to the provider that actually emitted them.
+    Holds the owning ``channel`` (Calls API lifecycle, conversation
+    bookkeeping, ``TAC``).
     """
 
     def __init__(self, channel: VoiceChannel) -> None:


### PR DESCRIPTION
## Summary
- Stacked on #113 — merge that one first.
- Adds a `VoiceProviderConfig` base (empty for now) and makes `ConversationRelayProviderConfig` (née `VoiceChannelConfig`) inherit it.
- Widens `VoiceChannel.__init__`'s `config` parameter to `VoiceProviderConfig | dict[str, Any] | None`, so a future provider's config class can be passed without widening the channel's type signature again.
- `ConversationRelayProviderConfig` is the only implementation today, so `VoiceChannel` casts to it after normalizing dict/None input rather than adding an `isinstance` check — that check becomes necessary (and a `create_provider()` factory method replaces the cast entirely) once a second provider config exists, in a follow-up PR.
- No behavior changes — this is pure type-signature groundwork for the provider split.

## Test plan
- [x] `make lint` / `make type-check` / `make check` all pass
- [x] 876 existing tests pass unmodified
- [x] `tests/` and `getting_started/` have zero diff — public API and examples untouched