### PR TITLE
refactor(voice): move ConversationRelay logic onto ConversationRelayProvider

### DIFF
--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -1,41 +1,28 @@
 from __future__ import annotations
 
 import asyncio
-import json
-from collections.abc import AsyncGenerator, Callable
-from typing import TYPE_CHECKING, Any, cast
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from twilio.rest import Client
 
-from pydantic import ValidationError
-
 from tac.channels.base import BaseChannel
-from tac.channels.websocket_manager import WebSocketManager
-from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
-from tac.core.config import CallEventKind
+from tac.channels.websocket_protocol import WebSocketProtocol
 from tac.core.tac import TAC
 from tac.models.outbound import (
-    CallOptions,
     InitiateVoiceConversationOptions,
     InitiateVoiceConversationResult,
 )
-from tac.models.session import AuthorInfo, ConversationSession
+from tac.models.session import ConversationSession
 from tac.models.voice import (
     AmdEvent,
     CallStatusEvent,
-    ConversationRelayCallbackPayload,
-    InterruptMessage,
-    PromptMessage,
     RecordingEvent,
-    SetupMessage,
     TwiMLOptions,
     TwiMLRequest,
 )
-from tac.session import SessionState
-from tac.utils.redaction import mask_phone, redact_twiml_parameters
 
-from . import twiml
 from .config import (
     AmdHandler,
     CallStatusHandler,
@@ -45,23 +32,16 @@ from .config import (
 )
 from .provider import VoiceProviderConfig
 
-_POLL_ATTEMPTS = 10
-_POLL_BASE_DELAY = 0.25
-# Caps the exponential backoff so a higher _POLL_ATTEMPTS doesn't blow up the
-# total wait time — total worst case is comfortably bounded (~11s of sleep)
-# instead of growing exponentially with attempt count.
-_POLL_MAX_DELAY = 1.5
-
 
 class VoiceChannel(BaseChannel):
     """
     Voice Channel for handling voice-based conversations via WebSocket.
 
-    Key features:
-    - TwiML generation for incoming calls (see twiml module)
-    - WebSocket connection management for real-time voice streaming
-    - Conversation lifecycle management (inherited from BaseChannel)
-    - Outbound call initiation
+    Owns the Twilio Calls API lifecycle and conversation bookkeeping
+    (inherited from BaseChannel). The real-time media transport itself —
+    TwiML generation, WebSocket protocol handling, outbound call
+    initiation — is delegated to a pluggable ``VoiceProvider``
+    (``ConversationRelayProvider`` is the only implementation today).
 
     This channel is framework-agnostic and accepts any WebSocket implementation
     satisfying WebSocketProtocol. For a batteries-included FastAPI server, use
@@ -87,30 +67,19 @@ class VoiceChannel(BaseChannel):
             >>> channel = VoiceChannel(tac, config=VoiceChannelConfig(session_manager=sm))
             >>> channel = VoiceChannel(tac)  # Use defaults
         """
-        # Convert dict to config model or use defaults. VoiceChannelConfig is
-        # the only VoiceProviderConfig implementation today, so this cast is
-        # accurate — it'll need to become an isinstance check once a second
-        # one exists.
+        # Convert dict to config model or use defaults.
         if isinstance(config, dict):
             config = VoiceChannelConfig(**config)
         elif config is None:
             config = VoiceChannelConfig()
-        config = cast(VoiceChannelConfig, config)
 
-        super().__init__(tac, memory_mode=config.memory_mode)
-        self.config = config
-        self.session_manager = config.session_manager
-        # TODO: not used yet — VoiceChannel still owns ConversationRelay logic
-        # directly. A follow-up PR moves that logic onto self._provider and
-        # drops the cast above in favor of self._provider's own attributes.
         self._provider = config.create_provider(self, tac.config)
+        super().__init__(tac, memory_mode=self._provider.memory_mode)
         self._on_inbound_call_twiml: InboundCallTwiMLHandler | None = None
         self._on_call_status: CallStatusHandler | None = None
         self._on_amd: AmdHandler | None = None
         self._on_recording: RecordingHandler | None = None
-        self._websocket_manager = WebSocketManager()
         self._twilio_client: Client | None = None
-        self._twiml = twiml.TwiMLBuilderConversationRelay(tac.config, config)
 
     def on_inbound_call_twiml(self, callback: InboundCallTwiMLHandler) -> None:
         """Register a callback that produces per-call overrides for the
@@ -141,8 +110,8 @@ class VoiceChannel(BaseChannel):
         """Register a handler for Twilio ``status_callback`` webhooks.
 
         This is the Calls-API status callback (call disposition), not the
-        ConversationRelay session callback — see
-        :meth:`handle_conversation_relay_callback`.
+        active provider's own out-of-band lifecycle webhook — see
+        :meth:`handle_twilio_provider_callback`.
 
         Registering does two things: it stores the handler, and it makes later
         outbound calls pass ``status_callback`` to ``calls.create``. With no
@@ -207,13 +176,6 @@ class VoiceChannel(BaseChannel):
         """
         self._on_recording = callback
 
-    @staticmethod
-    def _caller_address(setup_msg: SetupMessage) -> str | None:
-        """Return the phone number of the remote caller/callee from the setup message."""
-        if setup_msg.direction and setup_msg.direction.upper() == "OUTBOUND":
-            return setup_msg.to_number
-        return setup_msg.from_number
-
     def _get_twilio_client(self) -> Client:
         if self._twilio_client is None:
             from twilio.rest import Client
@@ -231,107 +193,34 @@ class VoiceChannel(BaseChannel):
         *,
         host_twiml_options: TwiMLOptions | None = None,
     ) -> str:
+        """Generate TwiML response for incoming voice calls. Delegates to the
+        active provider — see ``ConversationRelayProvider.handle_incoming_call``
+        for the full merge/precedence rules (only meaningful for that provider;
+        a non-TwiML provider ignores ``host_twiml_options``).
         """
-        Generate TwiML response for incoming voice calls.
-
-        ConversationRelay automatically handles conversation creation and participant
-        management via the ``conversation_configuration`` parameter.
-
-        The WebSocket URL and default session-cleanup action URL are derived
-        from ``TACConfig.voice_public_domain`` + ``TACConfig.voice_websocket_path``
-        / ``voice_action_path``.
-
-        TwiML fields are merged per-field, highest precedence first:
-          1. Output of the customizer registered via
-             ``VoiceChannel.on_inbound_call_twiml(...)`` if configured
-             and ``twiml_request`` is given. (Application-owned.)
-          2. ``VoiceChannelConfig.default_twiml_options`` — per-channel defaults.
-          3. ``host_twiml_options`` — per-call transport facts supplied by the
-             host (the code owning the route), e.g. a per-call ``websocket_url``
-             with an affinity token.
-          4. TAC defaults: a fixed default ``welcome_greeting``,
-             ``conversation_configuration`` from ``TACConfig``,
-             ``action_url`` resolved via Studio handoff (when
-             ``studio_handoff_flow_sid`` is configured), else derived from
-             ``TACConfig.voice_public_domain`` + ``voice_action_path``, and the
-             ``websocket_url`` derived from ``TACConfig.voice_public_domain`` +
-             ``voice_websocket_path``.
-
-        Fields not set at a layer fall through to lower layers. Lists
-        (``languages``) and nested models (``custom_parameters``) replace
-        wholesale when set at a higher-priority layer. ``websocket_url`` falls
-        back to the ``TACConfig``-derived URL if unset at every layer.
-
-        The two arguments are complementary, not alternatives — a custom host
-        typically passes both on the same call: ``twiml_request`` carries the
-        inbound call's data (so the application's customizer can run), and
-        ``host_twiml_options`` carries the host's own per-call overrides.
-
-        Args:
-            twiml_request: The incoming Twilio voice webhook, parsed into a
-                framework-neutral form (From, To, CallSid, CallerCountry, …).
-                Supplied by Twilio; forwarded to the ``on_inbound_call_twiml``
-                customizer so the application can produce per-call overrides.
-            host_twiml_options: Per-call TwiML overrides supplied by the *host*
-                (the code owning the route — e.g. a custom server), for
-                transport facts the SDK can't derive, such as a per-call
-                ``websocket_url`` with an affinity token. Layered below
-                ``default_twiml_options`` and the application customizer, so a
-                developer's explicit settings still win.
-
-        Returns:
-            TwiML XML string for call connection.
-        """
-        customized: TwiMLOptions | None = None
-        if self._on_inbound_call_twiml is not None and twiml_request is not None:
-            customized = await self._on_inbound_call_twiml(twiml_request)
-
-        return self._twiml.build(
-            "handle_incoming_call",
-            host=host_twiml_options,
-            per_call=customized,
+        return await self._provider.handle_incoming_call(
+            twiml_request, host_twiml_options=host_twiml_options
         )
 
-    async def handle_conversation_relay_callback(
+    async def handle_twilio_provider_callback(
         self,
         payload_dict: dict[str, str],
     ) -> None:
-        """Handle ConversationRelay callback webhook from Twilio.
+        """Handle the active provider's own out-of-band lifecycle webhook, if
+        it has one — e.g. ConversationRelay's ``<Connect action=...>`` callback.
 
         In relay-only mode, this is a secondary mechanism for cleaning up
         conversation state when a call ends (the primary mechanism is websocket
         disconnect). In orchestrated mode, conversation lifecycle is managed by
         CO webhooks, so this is a no-op.
 
+        Not every provider has an equivalent webhook — see
+        ``VoiceProvider.handle_twilio_provider_callback``.
+
         Args:
             payload_dict: Raw form data dict from the webhook request.
         """
-        try:
-            payload = ConversationRelayCallbackPayload(**payload_dict)
-        except ValidationError:
-            self.logger.warning(
-                "Invalid ConversationRelay callback payload, ignoring",
-                payload_keys=list(payload_dict.keys()),
-            )
-            return
-
-        if payload.account_sid != self.tac.config.account_sid:
-            self.logger.warning(
-                "ConversationRelay callback account_sid mismatch, ignoring",
-                expected=self.tac.config.account_sid,
-                received=payload.account_sid,
-            )
-            return
-
-        self.logger.debug(
-            "ConversationRelay callback received",
-            call_sid=payload.call_sid,
-            call_status=payload.call_status,
-        )
-
-        if payload.call_status == "completed" and not self.tac.is_orchestrator_enabled():
-            if payload.call_sid in self._conversations:
-                await self._end_conversation(payload.call_sid)
+        await self._provider.handle_twilio_provider_callback(payload_dict)
 
     def _call_event_account_ok(self, payload_dict: dict[str, str]) -> bool:
         """Whether a call-webhook payload belongs to the configured account.
@@ -497,290 +386,15 @@ class VoiceChannel(BaseChannel):
                 return session
         return None
 
-    async def _initialize_conversation(
-        self,
-        call_sid: str,
-        setup_msg: SetupMessage,
-        websocket: WebSocketProtocol,
-    ) -> tuple[str, SessionState | None]:
-        """Poll CO for the conversation created by ConversationRelay, resolve
-        the customer participant, and initialize the local session."""
-        conversation_orchestrator_client = self.tac.conversation_orchestrator_client
-        if conversation_orchestrator_client is None:
-            raise RuntimeError("_initialize_conversation called without Conversation Orchestrator")
-
-        conversations: list[Any] = []
-        for attempt in range(_POLL_ATTEMPTS):
-            conversations = await conversation_orchestrator_client.list_conversations(
-                channel_id=call_sid,
-                status=["ACTIVE"],
-            )
-            if len(conversations) == 1:
-                break
-            if attempt < _POLL_ATTEMPTS - 1:
-                self.logger.debug(
-                    "Conversation not ready yet, polling again",
-                    call_sid=call_sid,
-                    attempt=attempt + 1,
-                    found=len(conversations),
-                )
-                await asyncio.sleep(min(_POLL_BASE_DELAY * (2**attempt), _POLL_MAX_DELAY))
-
-        if len(conversations) != 1:
-            raise RuntimeError(
-                f"Expected exactly 1 conversation for "
-                f"call_sid {call_sid}, but found "
-                f"{len(conversations)} after "
-                f"{_POLL_ATTEMPTS} attempts."
-            )
-
-        conversation = conversations[0]
-        conv_id = conversation.id
-
-        participants = await conversation_orchestrator_client.list_participants(conv_id)
-
-        customer_participant = next(
-            (p for p in participants if p.type == "CUSTOMER"),
-            None,
-        )
-        customer_address = (
-            next(
-                (a.address for a in customer_participant.addresses if a.channel == "VOICE"),
-                None,
-            )
-            if customer_participant and customer_participant.addresses
-            else None
-        )
-        profile_lookup_address = customer_address or self._caller_address(setup_msg)
-        profile_id = customer_participant.profile_id if customer_participant else None
-
-        # Resolve the agent participant so ai_agent_info is populated on the
-        # session, matching the messaging channels. The agent is the participant
-        # that owns TAC's address (the configured phone number) on the VOICE
-        # channel and has an agent type. A HUMAN_AGENT added by a
-        # redirected/escalated call is NOT TAC and is not adopted here.
-        agent_participant = self._find_agent_participant(
-            participants, "VOICE", self.tac.config.phone_number
-        )
-        agent_address = (
-            next(
-                (a.address for a in agent_participant.addresses if a.channel == "VOICE"),
-                None,
-            )
-            if agent_participant and agent_participant.addresses
-            else None
-        )
-
-        self._websocket_manager.add_websocket(conv_id, websocket)
-        session = self._start_conversation(conv_id, profile_id)
-        # In orchestrator mode conv_id is the Orchestrator conversation id, so
-        # record the CallSid so out-of-band call webhooks can reach this session
-        # (resolved via get_conversation_session_by_call_sid).
-        session.call_sid = call_sid
-
-        session_state = None
-        if self.session_manager is not None:
-            session_state = self.session_manager.get_or_create_session(conv_id)
-
-        if profile_lookup_address:
-            session.author_info = AuthorInfo(address=profile_lookup_address)
-
-        if agent_participant:
-            # Fall back to the configured phone number we matched on — the
-            # participant owns it by definition, so it's a meaningful address
-            # even in the unlikely case it carries no explicit VOICE address.
-            session.ai_agent_info = AuthorInfo(
-                address=agent_address or self.tac.config.phone_number,
-                participant_id=agent_participant.id,
-            )
-
-        return conv_id, session_state
-
     async def handle_websocket(self, websocket: WebSocketProtocol) -> None:
         """
-        Handle voice streaming WebSocket connection lifecycle.
-
-        This method manages the entire websocket connection:
-        - Accepts the connection
-        - Processes incoming messages
-        - Tracks and cancels in-flight tasks (if session_manager provided)
-        - Cleans up on disconnect
+        Handle voice streaming WebSocket connection lifecycle. Delegates to
+        the active provider.
 
         Args:
             websocket: Any WebSocket implementation satisfying WebSocketProtocol
         """
-        await websocket.accept()
-        self.logger.debug("WebSocket connection established")
-
-        conv_id: str | None = None
-        session_state = None
-        # This call's background CO conversation lookup task (kicked off
-        # below on "setup"), consumed and reset to None on the first
-        # "prompt". Still non-None in `finally` means the call ended before
-        # any prompt arrived.
-        init_task: asyncio.Task[tuple[str, SessionState | None]] | None = None
-
-        try:
-            # First message should be 'setup'
-            data = await websocket.receive_json()
-            if data.get("type") == "setup":
-                setup_msg = SetupMessage(**data)
-                call_sid = setup_msg.call_sid
-
-                # Kick off the CO conversation lookup now, in the background,
-                # instead of waiting for the first prompt. ConversationRelay
-                # creates the CO conversation as soon as the call connects, not
-                # when the caller speaks, so this overlaps CO's
-                # list_conversations/list_participants polling with the wait
-                # for the caller's first utterance (transcription) rather than
-                # paying that latency serially once the first prompt lands.
-                if call_sid and self.tac.is_orchestrator_enabled():
-                    init_task = asyncio.create_task(
-                        self._initialize_conversation(call_sid, setup_msg, websocket)
-                    )
-
-                # Process all subsequent messages
-                while True:
-                    data = await websocket.receive_json()
-                    msg_type = data.get("type")
-
-                    if msg_type == "prompt":
-                        if not conv_id and call_sid:
-                            if init_task is not None:
-                                # Clear before awaiting so a failure here
-                                # doesn't leave `finally` re-awaiting (and
-                                # re-logging) this same task. If still
-                                # polling, this just waits it out. (None here
-                                # only means relay-only mode — see "setup".)
-                                task_to_await = init_task
-                                init_task = None
-                                conv_id, session_state = await task_to_await
-                            else:
-                                conv_id = call_sid
-                                self._websocket_manager.add_websocket(conv_id, websocket)
-                                session = self._start_conversation(conv_id, profile_id=None)
-                                # Relay-only: conv_id == call_sid.
-                                session.call_sid = call_sid
-
-                                caller = self._caller_address(setup_msg)
-                                if caller:
-                                    self._conversations[conv_id].author_info = AuthorInfo(
-                                        address=caller,
-                                    )
-
-                                if self.session_manager is not None:
-                                    session_state = self.session_manager.get_or_create_session(
-                                        conv_id
-                                    )
-
-                        if conv_id:
-                            await self._handle_prompt_async(conv_id, data, session_state)
-                        else:
-                            self.logger.warning("Received prompt before conversation initialized")
-                    elif msg_type == "interrupt":
-                        if conv_id:
-                            await self._handle_interrupt_async(conv_id, data, session_state)
-                        else:
-                            self.logger.warning(
-                                "Received interrupt before conversation initialized"
-                            )
-                    else:
-                        self.logger.debug(f"Skip message type received: {msg_type}")
-            else:
-                self.logger.warning("First message was not 'setup'. Closing connection.")
-                await websocket.close()
-                return
-        except WebSocketDisconnectError:
-            self.logger.info("WebSocket connection closed", conversation_id=conv_id)
-        except Exception as e:
-            self.logger.error(f"WebSocket error: {str(e)}")
-        finally:
-            cancelled_error: asyncio.CancelledError | None = None
-            we_cancelled_it = False
-            if init_task is not None:
-                # Call ended before any prompt arrived, so the background
-                # lookup was never awaited.
-                if not init_task.done():
-                    init_task.cancel()
-                    we_cancelled_it = True
-                result: tuple[str, SessionState | None] | None
-                try:
-                    result = await init_task
-                except asyncio.CancelledError as e:
-                    # Defer re-raise decision until after cleanup below;
-                    # we_cancelled_it (not init_task.cancelled(), which can't
-                    # tell the two apart) decides whether to.
-                    cancelled_error = e
-                    result = None
-                except Exception as e:
-                    # No prompt ever arrived to surface this failure via the
-                    # outer except Exception above, so log it here instead.
-                    self.logger.error(
-                        f"Background CO conversation lookup failed: {e}",
-                        call_sid=call_sid,
-                    )
-                    result = None
-                if result is not None and conv_id is None:
-                    # The lookup already registered the session/websocket
-                    # before anyone claimed conv_id — adopt it so it's
-                    # cleaned up instead of leaked.
-                    conv_id = result[0]
-            if conv_id:
-                self.logger.debug("Cleanup - removing WebSocket", conversation_id=conv_id)
-                await self._cleanup_connection(conv_id)
-            if cancelled_error is not None and not we_cancelled_it:
-                # A real external cancellation, not the one we caused above —
-                # propagate it now that cleanup ran.
-                raise cancelled_error
-
-    def _merge_call_options(self, per_call: CallOptions | None) -> CallOptions | None:
-        """Overlay ``per_call`` onto ``VoiceChannelConfig.default_call_options``.
-
-        Per-field via ``model_fields_set``, same as ``_overlay_fields`` does for
-        TwiMLOptions. The merged result is re-validated so a combination only
-        reachable by layering — per-call clearing ``machine_detection`` while the
-        default set ``async_amd`` — still fails instead of reaching Twilio.
-        """
-        default = self.config.default_call_options
-        if default is None or per_call is None:
-            return per_call or default
-
-        merged = default.model_dump(by_alias=True, exclude_none=True)
-        # model_fields_set covers extras too, since CallOptions allows them.
-        for field in per_call.model_fields_set:
-            merged[field] = getattr(per_call, field)
-        return CallOptions(**merged)
-
-    def _build_call_kwargs(self, call_options: CallOptions | None) -> dict[str, Any]:
-        """Build the extra kwargs for ``client.calls.create``.
-
-        Layers, highest precedence first: this call's ``call_options``,
-        ``VoiceChannelConfig.default_call_options``, then callback URLs derived
-        from ``voice_public_domain`` + ``voice_call_event_path``.
-
-        A URL is derived only when its handler is registered. That's a deliberate
-        deviation from ``websocket_url`` / ``action_url``, which derive
-        unconditionally: those are load-bearing, so a wrong one fails loudly on
-        the first call, whereas an unwanted call-event URL fails as silent 11200
-        alerts for a feature nobody asked for. Set the URLs in
-        ``default_call_options`` when TAC isn't serving the routes.
-        """
-        merged = self._merge_call_options(call_options)
-        call_kwargs = merged.to_call_kwargs() if merged else {}
-
-        wiring: list[tuple[CallEventKind, str, Callable[..., Any] | None]] = [
-            ("status", "status_callback", self._on_call_status),
-            ("amd", "async_amd_status_callback", self._on_amd),
-            ("recording", "recording_status_callback", self._on_recording),
-        ]
-        for kind, param, handler in wiring:
-            if handler is None:
-                continue
-            url = self.tac.config.call_event_url(kind)
-            if url is not None:
-                call_kwargs.setdefault(param, url)
-
-        return call_kwargs
+        await self._provider.handle_websocket(websocket)
 
     async def initiate_outbound_conversation(
         self,
@@ -788,158 +402,10 @@ class VoiceChannel(BaseChannel):
     ) -> InitiateVoiceConversationResult:
         """Initiate an outbound voice conversation.
 
-        Places an outbound call with inline TwiML that connects to ConversationRelay.
-        The conversationConfiguration attribute tells CO to create and manage the
-        conversation during passive hydration. The session is initialized lazily
-        on the first prompt when the conversation is discovered by callSid.
-
-        TwiML fields are merged per-field, highest precedence first:
-          1. ``options.twiml_options`` — per-call overrides
-          2. ``VoiceChannelConfig.default_twiml_options`` — channel-wide defaults
-          3. TAC defaults: welcome greeting, ``conversation_configuration``
-             from ``TACConfig``, and ``action_url`` from Studio handoff (if
-             configured), else derived from ``TACConfig.voice_public_domain``
-             + ``voice_action_path``.
-
-        Fields not set at a layer fall through to lower layers. Lists
-        (``languages``) and nested models (``custom_parameters``) replace
-        wholesale when set at a higher-priority layer.
-
-        The WebSocket URL is derived from ``TACConfig.voice_public_domain`` +
-        ``TACConfig.voice_websocket_path``, unless overridden per-call via
-        ``options.websocket_url``.
+        Only ``ConversationRelayProvider`` supports outbound calls today —
+        raises ``NotImplementedError`` for any other provider.
         """
-        from_number = self.tac.config.phone_number
-
-        self.logger.info(
-            "Initiating outbound voice conversation",
-            to=mask_phone(options.to),
-            from_number=mask_phone(from_number),
-        )
-
-        # Outbound has no inbound customizer and no server layer; the per-call
-        # override is options.twiml_options. ``options.websocket_url`` is the
-        # dedicated per-call override and wins over any websocket_url that came
-        # through the layered merge; both fall back to the TACConfig-derived URL.
-        twiml_xml = self._twiml.build(
-            "initiate_outbound_conversation",
-            per_call=options.twiml_options,
-            websocket_url=options.websocket_url,
-        )
-
-        call_kwargs = self._build_call_kwargs(options.call_options)
-
-        try:
-            # The inline TwiML handed to Twilio, useful for debugging the
-            # <Connect action> handoff target. custom_parameters values are
-            # masked — they're arbitrary developer data (profile IDs, caller
-            # names), unlike the WS/action URLs and conversation config.
-            self.logger.debug(
-                "Outbound call TwiML",
-                twiml=redact_twiml_parameters(twiml_xml),
-                to=mask_phone(options.to),
-            )
-
-            client = self._get_twilio_client()
-            call = await asyncio.to_thread(
-                client.calls.create,
-                to=options.to,
-                from_=from_number,
-                twiml=twiml_xml,
-                **call_kwargs,
-            )
-
-            self.logger.info(
-                "Outbound voice call placed",
-                call_sid=call.sid,
-                to=mask_phone(options.to),
-            )
-
-            return InitiateVoiceConversationResult(call_sid=call.sid)
-
-        except Exception as e:
-            self.logger.error(
-                "Failed to initiate outbound call",
-                to=mask_phone(options.to),
-                error=str(e),
-                exc_info=True,
-            )
-            raise
-
-    async def _handle_prompt_async(
-        self,
-        conv_id: str,
-        data: dict[str, Any],
-        session_state: SessionState | None,
-    ) -> None:
-        """
-        Handle prompt message asynchronously with task tracking.
-
-        Args:
-            conv_id: Conversation ID
-            data: Raw message data
-            session_state: Session state object (if session_manager provided)
-        """
-        try:
-            should_process = data.get("final", True)
-            if should_process:
-                prompt_msg = PromptMessage(**data)
-                conv_id = prompt_msg.conversation_id or conv_id
-
-                # Cancel previous stream task if session manager is enabled
-                if session_state:
-                    await session_state.cancel_stream_task()
-
-                    # Create new task using unified flow (memory retrieval + callback)
-                    session_state.stream_task = asyncio.create_task(
-                        self._handle_prompt(conv_id, prompt_msg)
-                    )
-                    # Yield to event loop to let task start
-                    await asyncio.sleep(0)
-                else:
-                    await self._handle_prompt(conv_id, prompt_msg)
-        except Exception as e:
-            self.logger.error(f"Failed to handle prompt: {str(e)}")
-
-    async def _handle_interrupt_async(
-        self,
-        conv_id: str,
-        data: dict[str, Any],
-        session_state: SessionState | None,
-    ) -> None:
-        """
-        Handle interrupt message asynchronously with task cancellation.
-
-        Args:
-            conv_id: Conversation ID
-            data: Raw message data
-            session_state: Session state object (if session_manager provided)
-        """
-        try:
-            interrupt_msg = InterruptMessage(**data)
-            conv_id = interrupt_msg.conversation_id or conv_id
-
-            # Cancel in-flight stream task if session manager is enabled
-            if session_state:
-                await session_state.cancel_stream_task()
-
-                # Send acknowledgment to Twilio after cancelling
-                websocket = self._websocket_manager.get_websocket(conv_id)
-                if websocket:
-                    try:
-                        await websocket.send_text(
-                            json.dumps({"type": "text", "token": "", "last": True})
-                        )
-                    except (WebSocketDisconnectError, RuntimeError):
-                        self.logger.debug(
-                            f"WebSocket closed before sending interrupt acknowledgment "
-                            f"for {conv_id}."
-                        )
-
-            # Call the interrupt handler
-            self._handle_interrupt(conv_id, interrupt_msg)
-        except Exception as e:
-            self.logger.error(f"Failed to handle interrupt: {str(e)}")
+        return await self._provider.initiate_outbound_conversation(options)
 
     async def process_webhook(
         self, webhook_data: dict[str, Any], idempotency_token: str | None = None
@@ -1007,113 +473,18 @@ class VoiceChannel(BaseChannel):
         role: str | None = None,
     ) -> None:
         """
-        Send voice response through the websocket connection for this conversation.
-
-        Supports both simple string responses and streaming async generators.
+        Send a response back through this channel's active provider.
 
         Args:
             conversation_id: Conversation ID
             response: Response text (string) or async generator for streaming
-            role: Optional message role (not used in this implementation, but kept
-                  for API consistency with BaseChannel interface)
+            role: Optional message role (not used by ConversationRelayProvider, but
+                  kept for API consistency with BaseChannel interface)
         """
-        # Validate response type before processing
-        if not isinstance(response, (str, AsyncGenerator)):
-            raise TypeError("Voice channel requires string or async generator for response")
-
-        # Get WebSocket from manager
-        websocket = self._websocket_manager.get_websocket(conversation_id)
-        if not websocket:
-            self.logger.error("No websocket connection", conversation_id=conversation_id)
-            return
-
-        full_response = ""
-
-        try:
-            # Check if response is an async generator (streaming)
-            if isinstance(response, AsyncGenerator):
-                # Streaming response
-                json_template = {"type": "text", "token": "", "last": False}
-                closed = False
-                response_gen: AsyncGenerator[str | dict[str, Any], None] = response
-
-                try:
-                    async for chunk in response_gen:
-                        # Handle different chunk types (plain text or dict with metadata)
-                        if isinstance(chunk, dict):
-                            if "output" in chunk:
-                                token = chunk["output"]
-                            else:
-                                token = str(chunk)
-                        else:
-                            token = chunk
-
-                        full_response += token
-                        json_template["token"] = token
-
-                        try:
-                            await websocket.send_text(json.dumps(json_template))
-                        except (WebSocketDisconnectError, RuntimeError):
-                            self.logger.info(
-                                "WebSocket closed during streaming",
-                                conversation_id=conversation_id,
-                            )
-                            closed = True
-                            break
-
-                    # Send final message marker
-                    if not closed:
-                        try:
-                            await websocket.send_text(
-                                json.dumps({"type": "text", "token": "", "last": True})
-                            )
-                        except (WebSocketDisconnectError, RuntimeError):
-                            self.logger.info(
-                                "WebSocket closed before sending final marker",
-                                conversation_id=conversation_id,
-                            )
-                except asyncio.CancelledError:
-                    # Let Python's async generator cleanup handle closing the generator
-                    raise
-            else:
-                await websocket.send_text(
-                    json.dumps({"type": "text", "token": response, "last": True})
-                )
-
-            # If a handoff is pending, send the WS "end" message now that the
-            # LLM's final response has been delivered to the caller.
-            if conversation_id in self._conversations:
-                session = self._conversations[conversation_id]
-                if session.pending_handoff_data is not None:
-                    try:
-                        await websocket.send_text(
-                            session.pending_handoff_data.model_dump_json(by_alias=True)
-                        )
-                        session.pending_handoff_data = None
-                    except (WebSocketDisconnectError, RuntimeError):
-                        self.logger.warning(
-                            "WebSocket closed before sending handoff end message; "
-                            "caller will not be transferred",
-                            conversation_id=conversation_id,
-                        )
-
-        except asyncio.CancelledError:
-            # Re-raise to propagate cancellation up the call stack.
-            # Partial responses from interrupted streams are NOT saved to
-            # Conversation Orchestrator. Incomplete responses shouldn't be
-            # part of conversation history.
-            raise
-        except (WebSocketDisconnectError, RuntimeError):
-            self.logger.info(
-                "WebSocket closed before sending response", conversation_id=conversation_id
-            )
-        except Exception as e:
-            self.logger.error(
-                f"Error sending response: {e}", conversation_id=conversation_id, exc_info=True
-            )
+        await self._provider.send_response(conversation_id, response, role)
 
     def get_channel_name(self) -> str:
-        return "VOICE"
+        return self._provider.channel_name
 
     def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
         """
@@ -1125,92 +496,4 @@ class VoiceChannel(BaseChannel):
         Returns:
             WebSocket connection if exists, None otherwise
         """
-        return self._websocket_manager.get_websocket(conversation_id)
-
-    async def _handle_prompt(self, conv_id: str, message: PromptMessage) -> None:
-        """
-        Handle incoming voice prompt (user speech).
-
-        Args:
-            conv_id: Conversation ID
-            message: Parsed PromptMessage containing user's transcribed speech
-        """
-        if conv_id not in self._conversations:
-            self.logger.error(
-                f"Received prompt for unknown conversation {conv_id}. "
-                "Conversation should be initialized on first prompt.",
-                conversation_id=conv_id,
-            )
-            return
-
-        message_body = message.voice_prompt or ""
-        session = self._conversations[conv_id]
-
-        # Retrieve memory if memory_mode is enabled and Twilio Memory is configured
-        memory_response = await self._retrieve_memory_if_enabled(session, message_body, conv_id)
-
-        # Trigger message ready callback
-        try:
-            response = await self.tac.trigger_message_ready(message_body, session, memory_response)
-            # Auto-send if callback returned a string (None = manual send_response flow)
-            if response is not None:
-                await self.send_response(conv_id, response, role="assistant")
-        except Exception as e:
-            self.logger.error(
-                "Error in message ready callback",
-                conversation_id=conv_id,
-                error=str(e),
-                exc_info=True,
-            )
-
-    def _handle_interrupt(self, conv_id: str, message: InterruptMessage) -> None:
-        """
-        Handle interrupt message when user interrupts the agent.
-
-        Note: Task cancellation is handled by the async wrapper (_handle_interrupt_async)
-        when called from the WebSocket message handler. This method only triggers the
-        TAC interrupt callback.
-
-        Args:
-            conv_id: Conversation ID
-            message: Parsed InterruptMessage with interruption details
-        """
-        # Trigger interrupt callback if conversation exists
-        if conv_id in self._conversations:
-            session = self._conversations[conv_id]
-            self.tac.trigger_interrupt(session, message)
-        else:
-            self.logger.warning(
-                f"Received interrupt for unknown conversation {conv_id}, skipping callback"
-            )
-
-    async def _cleanup_connection(self, conv_id: str) -> None:
-        """
-        Clean up WebSocket and session resources when connection closes.
-
-        In orchestrated mode, the conversation remains tracked in
-        self._conversations until the CONVERSATION_UPDATED/CLOSED webhook
-        arrives from Conversation Orchestrator. In relay-only mode there is no such webhook,
-        so we also end the conversation here.
-
-        Args:
-            conv_id: Conversation ID
-        """
-        # Remove WebSocket from manager
-        if self._websocket_manager.has_websocket(conv_id):
-            self._websocket_manager.remove_websocket(conv_id)
-
-        # Cancel running stream task and cleanup session if session manager is enabled
-        if self.session_manager is not None and self.session_manager.has_session(conv_id):
-            session_state = self.session_manager.get_or_create_session(conv_id)
-            # Cancel any running task (user hung up, no point continuing)
-            await session_state.cancel_stream_task()
-            self.session_manager.remove_session(conv_id)
-
-        if not self.tac.is_orchestrator_enabled() and conv_id in self._conversations:
-            await self._end_conversation(conv_id)
-
-        self.logger.debug(
-            "Cleaned up WebSocket and session resources",
-            conversation_id=conv_id,
-        )
+        return self._provider.get_websocket(conversation_id)

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -73,8 +73,8 @@ class VoiceChannel(BaseChannel):
         elif config is None:
             config = VoiceChannelConfig()
 
+        super().__init__(tac, memory_mode=config.memory_mode)
         self._provider = config.create_provider(self, tac.config)
-        super().__init__(tac, memory_mode=self._provider.memory_mode)
         self._on_inbound_call_twiml: InboundCallTwiMLHandler | None = None
         self._on_call_status: CallStatusHandler | None = None
         self._on_amd: AmdHandler | None = None

--- a/src/tac/channels/voice/config.py
+++ b/src/tac/channels/voice/config.py
@@ -13,7 +13,6 @@ from tac.core.config import TACConfig
 
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
-from tac.models.memory import MemoryMode
 from tac.models.outbound import CallOptions
 from tac.models.voice import (
     AmdEvent,
@@ -89,10 +88,6 @@ class ConversationRelayProviderConfig(VoiceProviderConfig):
             "SessionManager for task cancellation. Defaults to ThreadSafeSessionManager. "
             "Set to None only for debugging/testing."
         ),
-    )
-    memory_mode: MemoryMode = Field(
-        default="never",
-        description="Memory retrieval mode for this channel",
     )
     default_twiml_options: TwiMLOptions | None = Field(
         default=None,

--- a/src/tac/channels/voice/conversation_relay.py
+++ b/src/tac/channels/voice/conversation_relay.py
@@ -17,7 +17,6 @@ from tac.channels.voice.provider import VoiceProvider
 from tac.channels.websocket_manager import WebSocketManager
 from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
 from tac.core.config import CallEventKind, TACConfig
-from tac.models.memory import MemoryMode
 from tac.models.outbound import (
     CallOptions,
     InitiateVoiceConversationOptions,
@@ -72,10 +71,6 @@ class ConversationRelayProvider(VoiceProvider):
     @property
     def channel_name(self) -> str:
         return "VOICE"
-
-    @property
-    def memory_mode(self) -> MemoryMode:
-        return self.config.memory_mode
 
     @staticmethod
     def _caller_address(setup_msg: SetupMessage) -> str | None:

--- a/src/tac/channels/voice/conversation_relay.py
+++ b/src/tac/channels/voice/conversation_relay.py
@@ -1,21 +1,52 @@
 """``ConversationRelayProvider``: the default ``VoiceProvider``.
 
-Empty for now — a placeholder. ``VoiceChannel`` still owns all
-ConversationRelay-specific logic directly; a follow-up PR moves it here
-(TwiML building via ``twiml.TwiMLBuilderConversationRelay``, WebSocket
-protocol handling, outbound calls).
+Twilio ConversationRelay's managed setup/prompt/interrupt loop over one
+WebSocket, with Twilio doing ASR/TTS.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+import json
+from collections.abc import AsyncGenerator, Callable
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
 
 from tac.channels.voice.provider import VoiceProvider
-from tac.core.config import TACConfig
+from tac.channels.websocket_manager import WebSocketManager
+from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
+from tac.core.config import CallEventKind, TACConfig
+from tac.models.memory import MemoryMode
+from tac.models.outbound import (
+    CallOptions,
+    InitiateVoiceConversationOptions,
+    InitiateVoiceConversationResult,
+)
+from tac.models.session import AuthorInfo
+from tac.models.voice import (
+    ConversationRelayCallbackPayload,
+    InterruptMessage,
+    PromptMessage,
+    SetupMessage,
+    TwiMLOptions,
+    TwiMLRequest,
+)
+from tac.session import SessionState
+from tac.utils.redaction import mask_phone, redact_twiml_parameters
+
+from . import twiml
 
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
     from tac.channels.voice.config import ConversationRelayProviderConfig
+
+_POLL_ATTEMPTS = 10
+_POLL_BASE_DELAY = 0.25
+# Caps the exponential backoff so a higher _POLL_ATTEMPTS doesn't blow up the
+# total wait time — total worst case is comfortably bounded (~11s of sleep)
+# instead of growing exponentially with attempt count.
+_POLL_MAX_DELAY = 1.5
 
 
 class ConversationRelayProvider(VoiceProvider):
@@ -34,3 +65,792 @@ class ConversationRelayProvider(VoiceProvider):
     ) -> None:
         super().__init__(channel)
         self.config = config
+        self.session_manager = config.session_manager
+        self._websocket_manager = WebSocketManager()
+        self._twiml = twiml.TwiMLBuilderConversationRelay(tac_config, config)
+
+    @property
+    def channel_name(self) -> str:
+        return "VOICE"
+
+    @property
+    def memory_mode(self) -> MemoryMode:
+        return self.config.memory_mode
+
+    @staticmethod
+    def _caller_address(setup_msg: SetupMessage) -> str | None:
+        """Return the phone number of the remote caller/callee from the setup message."""
+        if setup_msg.direction and setup_msg.direction.upper() == "OUTBOUND":
+            return setup_msg.to_number
+        return setup_msg.from_number
+
+    async def handle_incoming_call(
+        self,
+        twiml_request: TwiMLRequest | None = None,
+        *,
+        host_twiml_options: TwiMLOptions | None = None,
+    ) -> str:
+        """
+        Generate TwiML response for incoming voice calls.
+
+        ConversationRelay automatically handles conversation creation and participant
+        management via the ``conversation_configuration`` parameter.
+
+        The WebSocket URL and default session-cleanup action URL are derived
+        from ``TACConfig.voice_public_domain`` + ``TACConfig.voice_websocket_path``
+        / ``voice_action_path``.
+
+        TwiML fields are merged per-field, highest precedence first:
+          1. Output of the customizer registered via
+             ``VoiceChannel.on_inbound_call_twiml(...)`` if configured
+             and ``twiml_request`` is given. (Application-owned.)
+          2. ``VoiceChannelConfig.default_twiml_options`` — per-channel defaults.
+          3. ``host_twiml_options`` — per-call transport facts supplied by the
+             host (the code owning the route), e.g. a per-call ``websocket_url``
+             with an affinity token.
+          4. TAC defaults: a fixed default ``welcome_greeting``,
+             ``conversation_configuration`` from ``TACConfig``,
+             ``action_url`` resolved via Studio handoff (when
+             ``studio_handoff_flow_sid`` is configured), else derived from
+             ``TACConfig.voice_public_domain`` + ``voice_action_path``, and the
+             ``websocket_url`` derived from ``TACConfig.voice_public_domain`` +
+             ``voice_websocket_path``.
+
+        Fields not set at a layer fall through to lower layers. Lists
+        (``languages``) and nested models (``custom_parameters``) replace
+        wholesale when set at a higher-priority layer. ``websocket_url`` falls
+        back to the ``TACConfig``-derived URL if unset at every layer.
+
+        The two arguments are complementary, not alternatives — a custom host
+        typically passes both on the same call: ``twiml_request`` carries the
+        inbound call's data (so the application's customizer can run), and
+        ``host_twiml_options`` carries the host's own per-call overrides.
+
+        Args:
+            twiml_request: The incoming Twilio voice webhook, parsed into a
+                framework-neutral form (From, To, CallSid, CallerCountry, …).
+                Supplied by Twilio; forwarded to the ``on_inbound_call_twiml``
+                customizer so the application can produce per-call overrides.
+            host_twiml_options: Per-call TwiML overrides supplied by the *host*
+                (the code owning the route — e.g. a custom server), for
+                transport facts the SDK can't derive, such as a per-call
+                ``websocket_url`` with an affinity token. Layered below
+                ``default_twiml_options`` and the application customizer, so a
+                developer's explicit settings still win.
+
+        Returns:
+            TwiML XML string for call connection.
+        """
+        customized: TwiMLOptions | None = None
+        if self.channel._on_inbound_call_twiml is not None and twiml_request is not None:
+            customized = await self.channel._on_inbound_call_twiml(twiml_request)
+
+        return self._twiml.build(
+            "handle_incoming_call",
+            host=host_twiml_options,
+            per_call=customized,
+        )
+
+    async def handle_twilio_provider_callback(
+        self,
+        payload_dict: dict[str, str],
+    ) -> None:
+        """Handle ConversationRelay callback webhook from Twilio.
+
+        In relay-only mode, this is a secondary mechanism for cleaning up
+        conversation state when a call ends (the primary mechanism is websocket
+        disconnect). In orchestrated mode, conversation lifecycle is managed by
+        CO webhooks, so this is a no-op.
+
+        Args:
+            payload_dict: Raw form data dict from the webhook request.
+        """
+        try:
+            payload = ConversationRelayCallbackPayload(**payload_dict)
+        except ValidationError:
+            self.logger.warning(
+                "Invalid ConversationRelay callback payload, ignoring",
+                payload_keys=list(payload_dict.keys()),
+            )
+            return
+
+        if payload.account_sid != self.channel.tac.config.account_sid:
+            self.logger.warning(
+                "ConversationRelay callback account_sid mismatch, ignoring",
+                expected=self.channel.tac.config.account_sid,
+                received=payload.account_sid,
+            )
+            return
+
+        self.logger.debug(
+            "ConversationRelay callback received",
+            call_sid=payload.call_sid,
+            call_status=payload.call_status,
+        )
+
+        if payload.call_status == "completed" and not self.channel.tac.is_orchestrator_enabled():
+            if payload.call_sid in self.channel._conversations:
+                await self.channel._end_conversation(payload.call_sid)
+
+    async def _initialize_conversation(
+        self,
+        call_sid: str,
+        setup_msg: SetupMessage,
+        websocket: WebSocketProtocol,
+    ) -> tuple[str, SessionState | None]:
+        """Poll CO for the conversation created by ConversationRelay, resolve
+        the customer participant, and initialize the local session."""
+        conversation_orchestrator_client = self.channel.tac.conversation_orchestrator_client
+        if conversation_orchestrator_client is None:
+            raise RuntimeError("_initialize_conversation called without Conversation Orchestrator")
+
+        conversations: list[Any] = []
+        for attempt in range(_POLL_ATTEMPTS):
+            conversations = await conversation_orchestrator_client.list_conversations(
+                channel_id=call_sid,
+                status=["ACTIVE"],
+            )
+            if len(conversations) == 1:
+                break
+            if attempt < _POLL_ATTEMPTS - 1:
+                self.logger.debug(
+                    "Conversation not ready yet, polling again",
+                    call_sid=call_sid,
+                    attempt=attempt + 1,
+                    found=len(conversations),
+                )
+                await asyncio.sleep(min(_POLL_BASE_DELAY * (2**attempt), _POLL_MAX_DELAY))
+
+        if len(conversations) != 1:
+            raise RuntimeError(
+                f"Expected exactly 1 conversation for "
+                f"call_sid {call_sid}, but found "
+                f"{len(conversations)} after "
+                f"{_POLL_ATTEMPTS} attempts."
+            )
+
+        conversation = conversations[0]
+        conv_id = conversation.id
+
+        participants = await conversation_orchestrator_client.list_participants(conv_id)
+
+        customer_participant = next(
+            (p for p in participants if p.type == "CUSTOMER"),
+            None,
+        )
+        customer_address = (
+            next(
+                (a.address for a in customer_participant.addresses if a.channel == "VOICE"),
+                None,
+            )
+            if customer_participant and customer_participant.addresses
+            else None
+        )
+        profile_lookup_address = customer_address or self._caller_address(setup_msg)
+        profile_id = customer_participant.profile_id if customer_participant else None
+
+        # Resolve the agent participant so ai_agent_info is populated on the
+        # session, matching the messaging channels. The agent is the participant
+        # that owns TAC's address (the configured phone number) on the VOICE
+        # channel and has an agent type. A HUMAN_AGENT added by a
+        # redirected/escalated call is NOT TAC and is not adopted here.
+        agent_participant = self.channel._find_agent_participant(
+            participants, "VOICE", self.channel.tac.config.phone_number
+        )
+        agent_address = (
+            next(
+                (a.address for a in agent_participant.addresses if a.channel == "VOICE"),
+                None,
+            )
+            if agent_participant and agent_participant.addresses
+            else None
+        )
+
+        self._websocket_manager.add_websocket(conv_id, websocket)
+        session = self.channel._start_conversation(conv_id, profile_id)
+        # In orchestrator mode conv_id is the Orchestrator conversation id, so
+        # record the CallSid so out-of-band call webhooks can reach this session
+        # (resolved via get_conversation_session_by_call_sid).
+        session.call_sid = call_sid
+
+        session_state = None
+        if self.session_manager is not None:
+            session_state = self.session_manager.get_or_create_session(conv_id)
+
+        if profile_lookup_address:
+            session.author_info = AuthorInfo(address=profile_lookup_address)
+
+        if agent_participant:
+            # Fall back to the configured phone number we matched on — the
+            # participant owns it by definition, so it's a meaningful address
+            # even in the unlikely case it carries no explicit VOICE address.
+            session.ai_agent_info = AuthorInfo(
+                address=agent_address or self.channel.tac.config.phone_number,
+                participant_id=agent_participant.id,
+            )
+
+        return conv_id, session_state
+
+    async def handle_websocket(self, websocket: WebSocketProtocol) -> None:
+        """
+        Handle voice streaming WebSocket connection lifecycle.
+
+        This method manages the entire websocket connection:
+        - Accepts the connection
+        - Processes incoming messages
+        - Tracks and cancels in-flight tasks (if session_manager provided)
+        - Cleans up on disconnect
+
+        Args:
+            websocket: Any WebSocket implementation satisfying WebSocketProtocol
+        """
+        await websocket.accept()
+        self.logger.debug("WebSocket connection established")
+
+        conv_id: str | None = None
+        session_state = None
+        # This call's background CO conversation lookup task (kicked off
+        # below on "setup"), consumed and reset to None on the first
+        # "prompt". Still non-None in `finally` means the call ended before
+        # any prompt arrived.
+        init_task: asyncio.Task[tuple[str, SessionState | None]] | None = None
+
+        try:
+            # First message should be 'setup'
+            data = await websocket.receive_json()
+            if data.get("type") == "setup":
+                setup_msg = SetupMessage(**data)
+                call_sid = setup_msg.call_sid
+
+                # Kick off the CO conversation lookup now, in the background,
+                # instead of waiting for the first prompt. ConversationRelay
+                # creates the CO conversation as soon as the call connects, not
+                # when the caller speaks, so this overlaps CO's
+                # list_conversations/list_participants polling with the wait
+                # for the caller's first utterance (transcription) rather than
+                # paying that latency serially once the first prompt lands.
+                if call_sid and self.channel.tac.is_orchestrator_enabled():
+                    init_task = asyncio.create_task(
+                        self._initialize_conversation(call_sid, setup_msg, websocket)
+                    )
+
+                # Process all subsequent messages
+                while True:
+                    data = await websocket.receive_json()
+                    msg_type = data.get("type")
+
+                    if msg_type == "prompt":
+                        if not conv_id and call_sid:
+                            if init_task is not None:
+                                # Clear before awaiting so a failure here
+                                # doesn't leave `finally` re-awaiting (and
+                                # re-logging) this same task. If still
+                                # polling, this just waits it out. (None here
+                                # only means relay-only mode — see "setup".)
+                                task_to_await = init_task
+                                init_task = None
+                                conv_id, session_state = await task_to_await
+                            else:
+                                conv_id = call_sid
+                                self._websocket_manager.add_websocket(conv_id, websocket)
+                                session = self.channel._start_conversation(conv_id, profile_id=None)
+                                # Relay-only: conv_id == call_sid.
+                                session.call_sid = call_sid
+
+                                caller = self._caller_address(setup_msg)
+                                if caller:
+                                    self.channel._conversations[conv_id].author_info = AuthorInfo(
+                                        address=caller,
+                                    )
+
+                                if self.session_manager is not None:
+                                    session_state = self.session_manager.get_or_create_session(
+                                        conv_id
+                                    )
+
+                        if conv_id:
+                            await self._handle_prompt_async(conv_id, data, session_state)
+                        else:
+                            self.logger.warning("Received prompt before conversation initialized")
+                    elif msg_type == "interrupt":
+                        if conv_id:
+                            await self._handle_interrupt_async(conv_id, data, session_state)
+                        else:
+                            self.logger.warning(
+                                "Received interrupt before conversation initialized"
+                            )
+                    else:
+                        self.logger.debug(f"Skip message type received: {msg_type}")
+            else:
+                self.logger.warning("First message was not 'setup'. Closing connection.")
+                await websocket.close()
+                return
+        except WebSocketDisconnectError:
+            self.logger.info("WebSocket connection closed", conversation_id=conv_id)
+        except Exception as e:
+            self.logger.error(f"WebSocket error: {str(e)}")
+        finally:
+            cancelled_error: asyncio.CancelledError | None = None
+            we_cancelled_it = False
+            if init_task is not None:
+                # Call ended before any prompt arrived, so the background
+                # lookup was never awaited.
+                if not init_task.done():
+                    init_task.cancel()
+                    we_cancelled_it = True
+                result: tuple[str, SessionState | None] | None
+                try:
+                    result = await init_task
+                except asyncio.CancelledError as e:
+                    # Defer re-raise decision until after cleanup below;
+                    # we_cancelled_it (not init_task.cancelled(), which can't
+                    # tell the two apart) decides whether to.
+                    cancelled_error = e
+                    result = None
+                except Exception as e:
+                    # No prompt ever arrived to surface this failure via the
+                    # outer except Exception above, so log it here instead.
+                    self.logger.error(
+                        f"Background CO conversation lookup failed: {e}",
+                        call_sid=call_sid,
+                    )
+                    result = None
+                if result is not None and conv_id is None:
+                    # The lookup already registered the session/websocket
+                    # before anyone claimed conv_id — adopt it so it's
+                    # cleaned up instead of leaked.
+                    conv_id = result[0]
+            if conv_id:
+                self.logger.debug("Cleanup - removing WebSocket", conversation_id=conv_id)
+                await self._cleanup_connection(conv_id)
+            if cancelled_error is not None and not we_cancelled_it:
+                # A real external cancellation, not the one we caused above —
+                # propagate it now that cleanup ran.
+                raise cancelled_error
+
+    def _merge_call_options(self, per_call: CallOptions | None) -> CallOptions | None:
+        """Overlay ``per_call`` onto ``VoiceChannelConfig.default_call_options``.
+
+        Per-field via ``model_fields_set``, same as ``_overlay_fields`` does for
+        TwiMLOptions. The merged result is re-validated so a combination only
+        reachable by layering — per-call clearing ``machine_detection`` while the
+        default set ``async_amd`` — still fails instead of reaching Twilio.
+        """
+        default = self.config.default_call_options
+        if default is None or per_call is None:
+            return per_call or default
+
+        merged = default.model_dump(by_alias=True, exclude_none=True)
+        # model_fields_set covers extras too, since CallOptions allows them.
+        for field in per_call.model_fields_set:
+            merged[field] = getattr(per_call, field)
+        return CallOptions(**merged)
+
+    def _build_call_kwargs(self, call_options: CallOptions | None) -> dict[str, Any]:
+        """Build the extra kwargs for ``client.calls.create``.
+
+        Layers, highest precedence first: this call's ``call_options``,
+        ``VoiceChannelConfig.default_call_options``, then callback URLs derived
+        from ``voice_public_domain`` + ``voice_call_event_path``.
+
+        A URL is derived only when its handler is registered. That's a deliberate
+        deviation from ``websocket_url`` / ``action_url``, which derive
+        unconditionally: those are load-bearing, so a wrong one fails loudly on
+        the first call, whereas an unwanted call-event URL fails as silent 11200
+        alerts for a feature nobody asked for. Set the URLs in
+        ``default_call_options`` when TAC isn't serving the routes.
+        """
+        merged = self._merge_call_options(call_options)
+        call_kwargs = merged.to_call_kwargs() if merged else {}
+
+        wiring: list[tuple[CallEventKind, str, Callable[..., Any] | None]] = [
+            ("status", "status_callback", self.channel._on_call_status),
+            ("amd", "async_amd_status_callback", self.channel._on_amd),
+            ("recording", "recording_status_callback", self.channel._on_recording),
+        ]
+        for kind, param, handler in wiring:
+            if handler is None:
+                continue
+            url = self.channel.tac.config.call_event_url(kind)
+            if url is not None:
+                call_kwargs.setdefault(param, url)
+
+        return call_kwargs
+
+    async def initiate_outbound_conversation(
+        self,
+        options: InitiateVoiceConversationOptions,
+    ) -> InitiateVoiceConversationResult:
+        """Initiate an outbound voice conversation.
+
+        Places an outbound call with inline TwiML that connects to ConversationRelay.
+        The conversationConfiguration attribute tells CO to create and manage the
+        conversation during passive hydration. The session is initialized lazily
+        on the first prompt when the conversation is discovered by callSid.
+
+        TwiML fields are merged per-field, highest precedence first:
+          1. ``options.twiml_options`` — per-call overrides
+          2. ``VoiceChannelConfig.default_twiml_options`` — channel-wide defaults
+          3. TAC defaults: welcome greeting, ``conversation_configuration``
+             from ``TACConfig``, and ``action_url`` from Studio handoff (if
+             configured), else derived from ``TACConfig.voice_public_domain``
+             + ``voice_action_path``.
+
+        Fields not set at a layer fall through to lower layers. Lists
+        (``languages``) and nested models (``custom_parameters``) replace
+        wholesale when set at a higher-priority layer.
+
+        The WebSocket URL is derived from ``TACConfig.voice_public_domain`` +
+        ``TACConfig.voice_websocket_path``, unless overridden per-call via
+        ``options.websocket_url``.
+        """
+        from_number = self.channel.tac.config.phone_number
+
+        self.logger.info(
+            "Initiating outbound voice conversation",
+            to=mask_phone(options.to),
+            from_number=mask_phone(from_number),
+        )
+
+        # Outbound has no inbound customizer and no server layer; the per-call
+        # override is options.twiml_options. ``options.websocket_url`` is the
+        # dedicated per-call override and wins over any websocket_url that came
+        # through the layered merge; both fall back to the TACConfig-derived URL.
+        twiml_xml = self._twiml.build(
+            "initiate_outbound_conversation",
+            per_call=options.twiml_options,
+            websocket_url=options.websocket_url,
+        )
+
+        call_kwargs = self._build_call_kwargs(options.call_options)
+
+        try:
+            # The inline TwiML handed to Twilio, useful for debugging the
+            # <Connect action> handoff target. custom_parameters values are
+            # masked — they're arbitrary developer data (profile IDs, caller
+            # names), unlike the WS/action URLs and conversation config.
+            self.logger.debug(
+                "Outbound call TwiML",
+                twiml=redact_twiml_parameters(twiml_xml),
+                to=mask_phone(options.to),
+            )
+
+            client = self.channel._get_twilio_client()
+            call = await asyncio.to_thread(
+                client.calls.create,
+                to=options.to,
+                from_=from_number,
+                twiml=twiml_xml,
+                **call_kwargs,
+            )
+
+            self.logger.info(
+                "Outbound voice call placed",
+                call_sid=call.sid,
+                to=mask_phone(options.to),
+            )
+
+            return InitiateVoiceConversationResult(call_sid=call.sid)
+
+        except Exception as e:
+            self.logger.error(
+                "Failed to initiate outbound call",
+                to=mask_phone(options.to),
+                error=str(e),
+                exc_info=True,
+            )
+            raise
+
+    async def _handle_prompt_async(
+        self,
+        conv_id: str,
+        data: dict[str, Any],
+        session_state: SessionState | None,
+    ) -> None:
+        """
+        Handle prompt message asynchronously with task tracking.
+
+        Args:
+            conv_id: Conversation ID
+            data: Raw message data
+            session_state: Session state object (if session_manager provided)
+        """
+        try:
+            should_process = data.get("final", True)
+            if should_process:
+                prompt_msg = PromptMessage(**data)
+                conv_id = prompt_msg.conversation_id or conv_id
+
+                # Cancel previous stream task if session manager is enabled
+                if session_state:
+                    await session_state.cancel_stream_task()
+
+                    # Create new task using unified flow (memory retrieval + callback)
+                    session_state.stream_task = asyncio.create_task(
+                        self._handle_prompt(conv_id, prompt_msg)
+                    )
+                    # Yield to event loop to let task start
+                    await asyncio.sleep(0)
+                else:
+                    await self._handle_prompt(conv_id, prompt_msg)
+        except Exception as e:
+            self.logger.error(f"Failed to handle prompt: {str(e)}")
+
+    async def _handle_interrupt_async(
+        self,
+        conv_id: str,
+        data: dict[str, Any],
+        session_state: SessionState | None,
+    ) -> None:
+        """
+        Handle interrupt message asynchronously with task cancellation.
+
+        Args:
+            conv_id: Conversation ID
+            data: Raw message data
+            session_state: Session state object (if session_manager provided)
+        """
+        try:
+            interrupt_msg = InterruptMessage(**data)
+            conv_id = interrupt_msg.conversation_id or conv_id
+
+            # Cancel in-flight stream task if session manager is enabled
+            if session_state:
+                await session_state.cancel_stream_task()
+
+                # Send acknowledgment to Twilio after cancelling
+                websocket = self._websocket_manager.get_websocket(conv_id)
+                if websocket:
+                    try:
+                        await websocket.send_text(
+                            json.dumps({"type": "text", "token": "", "last": True})
+                        )
+                    except (WebSocketDisconnectError, RuntimeError):
+                        self.logger.debug(
+                            f"WebSocket closed before sending interrupt acknowledgment "
+                            f"for {conv_id}."
+                        )
+
+            # Call the interrupt handler
+            self._handle_interrupt(conv_id, interrupt_msg)
+        except Exception as e:
+            self.logger.error(f"Failed to handle interrupt: {str(e)}")
+
+    async def send_response(
+        self,
+        conversation_id: str,
+        response: str | AsyncGenerator[str | dict[str, Any], None],
+        role: str | None = None,
+    ) -> None:
+        """
+        Send voice response through the websocket connection for this conversation.
+
+        Supports both simple string responses and streaming async generators.
+
+        Args:
+            conversation_id: Conversation ID
+            response: Response text (string) or async generator for streaming
+            role: Optional message role (not used in this implementation, but kept
+                  for API consistency with BaseChannel interface)
+        """
+        # Validate response type before processing
+        if not isinstance(response, (str, AsyncGenerator)):
+            raise TypeError("Voice channel requires string or async generator for response")
+
+        # Get WebSocket from manager
+        websocket = self._websocket_manager.get_websocket(conversation_id)
+        if not websocket:
+            self.logger.error("No websocket connection", conversation_id=conversation_id)
+            return
+
+        full_response = ""
+
+        try:
+            # Check if response is an async generator (streaming)
+            if isinstance(response, AsyncGenerator):
+                # Streaming response
+                json_template = {"type": "text", "token": "", "last": False}
+                closed = False
+                response_gen: AsyncGenerator[str | dict[str, Any], None] = response
+
+                try:
+                    async for chunk in response_gen:
+                        # Handle different chunk types (plain text or dict with metadata)
+                        if isinstance(chunk, dict):
+                            if "output" in chunk:
+                                token = chunk["output"]
+                            else:
+                                token = str(chunk)
+                        else:
+                            token = chunk
+
+                        full_response += token
+                        json_template["token"] = token
+
+                        try:
+                            await websocket.send_text(json.dumps(json_template))
+                        except (WebSocketDisconnectError, RuntimeError):
+                            self.logger.info(
+                                "WebSocket closed during streaming",
+                                conversation_id=conversation_id,
+                            )
+                            closed = True
+                            break
+
+                    # Send final message marker
+                    if not closed:
+                        try:
+                            await websocket.send_text(
+                                json.dumps({"type": "text", "token": "", "last": True})
+                            )
+                        except (WebSocketDisconnectError, RuntimeError):
+                            self.logger.info(
+                                "WebSocket closed before sending final marker",
+                                conversation_id=conversation_id,
+                            )
+                except asyncio.CancelledError:
+                    # Let Python's async generator cleanup handle closing the generator
+                    raise
+            else:
+                await websocket.send_text(
+                    json.dumps({"type": "text", "token": response, "last": True})
+                )
+
+            # If a handoff is pending, send the WS "end" message now that the
+            # LLM's final response has been delivered to the caller.
+            if conversation_id in self.channel._conversations:
+                session = self.channel._conversations[conversation_id]
+                if session.pending_handoff_data is not None:
+                    try:
+                        await websocket.send_text(
+                            session.pending_handoff_data.model_dump_json(by_alias=True)
+                        )
+                        session.pending_handoff_data = None
+                    except (WebSocketDisconnectError, RuntimeError):
+                        self.logger.warning(
+                            "WebSocket closed before sending handoff end message; "
+                            "caller will not be transferred",
+                            conversation_id=conversation_id,
+                        )
+
+        except asyncio.CancelledError:
+            # Re-raise to propagate cancellation up the call stack.
+            # Partial responses from interrupted streams are NOT saved to
+            # Conversation Orchestrator. Incomplete responses shouldn't be
+            # part of conversation history.
+            raise
+        except (WebSocketDisconnectError, RuntimeError):
+            self.logger.info(
+                "WebSocket closed before sending response", conversation_id=conversation_id
+            )
+        except Exception as e:
+            self.logger.error(
+                f"Error sending response: {e}", conversation_id=conversation_id, exc_info=True
+            )
+
+    def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
+        """
+        Get the WebSocket connection for a specific conversation.
+
+        Args:
+            conversation_id: Conversation ID
+
+        Returns:
+            WebSocket connection if exists, None otherwise
+        """
+        return self._websocket_manager.get_websocket(conversation_id)
+
+    async def _handle_prompt(self, conv_id: str, message: PromptMessage) -> None:
+        """
+        Handle incoming voice prompt (user speech).
+
+        Args:
+            conv_id: Conversation ID
+            message: Parsed PromptMessage containing user's transcribed speech
+        """
+        if conv_id not in self.channel._conversations:
+            self.logger.error(
+                f"Received prompt for unknown conversation {conv_id}. "
+                "Conversation should be initialized on first prompt.",
+                conversation_id=conv_id,
+            )
+            return
+
+        message_body = message.voice_prompt or ""
+        session = self.channel._conversations[conv_id]
+
+        # Retrieve memory if memory_mode is enabled and Twilio Memory is configured
+        memory_response = await self.channel._retrieve_memory_if_enabled(
+            session, message_body, conv_id
+        )
+
+        # Trigger message ready callback
+        try:
+            response = await self.channel.tac.trigger_message_ready(
+                message_body, session, memory_response
+            )
+            # Auto-send if callback returned a string (None = manual send_response flow)
+            if response is not None:
+                await self.send_response(conv_id, response, role="assistant")
+        except Exception as e:
+            self.logger.error(
+                "Error in message ready callback",
+                conversation_id=conv_id,
+                error=str(e),
+                exc_info=True,
+            )
+
+    def _handle_interrupt(self, conv_id: str, message: InterruptMessage) -> None:
+        """
+        Handle interrupt message when user interrupts the agent.
+
+        Note: Task cancellation is handled by the async wrapper (_handle_interrupt_async)
+        when called from the WebSocket message handler. This method only triggers the
+        TAC interrupt callback.
+
+        Args:
+            conv_id: Conversation ID
+            message: Parsed InterruptMessage with interruption details
+        """
+        # Trigger interrupt callback if conversation exists
+        if conv_id in self.channel._conversations:
+            session = self.channel._conversations[conv_id]
+            self.channel.tac.trigger_interrupt(session, message)
+        else:
+            self.logger.warning(
+                f"Received interrupt for unknown conversation {conv_id}, skipping callback"
+            )
+
+    async def _cleanup_connection(self, conv_id: str) -> None:
+        """
+        Clean up WebSocket and session resources when connection closes.
+
+        In orchestrated mode, the conversation remains tracked in
+        self.channel._conversations until the CONVERSATION_UPDATED/CLOSED webhook
+        arrives from Conversation Orchestrator. In relay-only mode there is no such webhook,
+        so we also end the conversation here.
+
+        Args:
+            conv_id: Conversation ID
+        """
+        # Remove WebSocket from manager
+        if self._websocket_manager.has_websocket(conv_id):
+            self._websocket_manager.remove_websocket(conv_id)
+
+        # Cancel running stream task and cleanup session if session manager is enabled
+        if self.session_manager is not None and self.session_manager.has_session(conv_id):
+            session_state = self.session_manager.get_or_create_session(conv_id)
+            # Cancel any running task (user hung up, no point continuing)
+            await session_state.cancel_stream_task()
+            self.session_manager.remove_session(conv_id)
+
+        if (
+            not self.channel.tac.is_orchestrator_enabled()
+            and conv_id in self.channel._conversations
+        ):
+            await self.channel._end_conversation(conv_id)
+
+        self.logger.debug(
+            "Cleaned up WebSocket and session resources",
+            conversation_id=conv_id,
+        )

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -1,20 +1,22 @@
 """``VoiceProvider``: the interface that lets ``VoiceChannel`` host more than
 one kind of real-time media provider.
 
-Empty for now — a placeholder for the follow-up PR that moves
-``VoiceChannel``'s ConversationRelay-specific logic (TwiML, WebSocket
-protocol handling, outbound calls) behind this interface.
 ``ConversationRelayProvider`` is the only implementation today.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
+from tac.channels.websocket_protocol import WebSocketProtocol
 from tac.core.config import TACConfig
 from tac.core.logging import get_logger
+from tac.models.memory import MemoryMode
+from tac.models.outbound import InitiateVoiceConversationOptions, InitiateVoiceConversationResult
+from tac.models.voice import TwiMLOptions, TwiMLRequest
 
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
@@ -31,6 +33,71 @@ class VoiceProvider:
         self.channel = channel
         self.logger = get_logger(self.__class__.__module__)
 
+    @property
+    def channel_name(self) -> str:
+        """Channel name identifier, e.g. ``"VOICE"``.
+
+        Returned by ``VoiceChannel.get_channel_name()`` and stamped onto every
+        ``ConversationSession`` this provider creates.
+        """
+        return "VOICE"
+
+    @property
+    def memory_mode(self) -> MemoryMode:
+        """Memory retrieval mode for this provider. Default: ``"never"``.
+
+        ``ConversationRelayProvider`` overrides this to read from its config.
+        """
+        return "never"
+
+    async def handle_incoming_call(
+        self,
+        twiml_request: TwiMLRequest | None = None,
+        *,
+        host_twiml_options: TwiMLOptions | None = None,
+    ) -> str:
+        """Build the response for an inbound call. Default: not supported."""
+        raise NotImplementedError(f"{type(self).__name__} does not support inbound calls.")
+
+    async def handle_twilio_provider_callback(
+        self,
+        payload_dict: dict[str, str],
+    ) -> None:
+        """Handle this provider's own out-of-band lifecycle webhook, if it has one.
+
+        Not every provider has an equivalent — Twilio's ConversationRelay posts to
+        ``<Connect action=...>`` when the session ends (``ConversationRelayProvider``
+        uses this as a WebSocket-disconnect backup); Media Streams instead has its
+        own independent ``statusCallback`` (``stream-started``/``stream-stopped``/
+        ``stream-error``), which is purely informational and doesn't gate call flow.
+        Default no-op for providers with nothing to do here.
+        """
+        return None
+
+    async def handle_websocket(self, websocket: WebSocketProtocol) -> None:
+        """Drive one WebSocket connection from accept to disconnect."""
+        raise NotImplementedError(f"{type(self).__name__} does not support WebSocket connections.")
+
+    async def initiate_outbound_conversation(
+        self,
+        options: InitiateVoiceConversationOptions,
+    ) -> InitiateVoiceConversationResult:
+        """Place an outbound call. Default: not supported."""
+        raise NotImplementedError(f"{type(self).__name__} does not support outbound calls.")
+
+    async def send_response(
+        self,
+        conversation_id: str,
+        response: str | AsyncGenerator[str | dict[str, Any], None],
+        role: str | None = None,
+    ) -> None:
+        """Send a text response back through this provider's transport, if supported."""
+        raise NotImplementedError(f"{type(self).__name__} does not support send_response.")
+
+    def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
+        """Return the Twilio-facing WebSocket for a conversation, if tracked."""
+        return None
+
 
 class VoiceProviderConfig(BaseModel):
     """Base configuration for a ``VoiceChannel``'s real-time media provider.
@@ -44,8 +111,7 @@ class VoiceProviderConfig(BaseModel):
         """Build the ``VoiceProvider`` this config configures.
 
         Args:
-            channel: The owning ``VoiceChannel`` — stored on the provider so
-                it can reach the generic functionality the channel still owns.
+            channel: The owning ``VoiceChannel``.
             tac_config: ``TACConfig`` — providers that talk TwiML need it to
                 derive default URLs (``voice_public_domain`` etc.).
         """

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from tac.channels.websocket_protocol import WebSocketProtocol
 from tac.core.config import TACConfig
@@ -41,14 +41,6 @@ class VoiceProvider:
         ``ConversationSession`` this provider creates.
         """
         return "VOICE"
-
-    @property
-    def memory_mode(self) -> MemoryMode:
-        """Memory retrieval mode for this provider. Default: ``"never"``.
-
-        ``ConversationRelayProvider`` overrides this to read from its config.
-        """
-        return "never"
 
     async def handle_incoming_call(
         self,
@@ -106,6 +98,10 @@ class VoiceProviderConfig(BaseModel):
     here (not in ``config.py``) so a future provider's config only needs to
     import this module, not anything ConversationRelay-specific.
     """
+
+    memory_mode: MemoryMode = Field(
+        default="never", description="Memory retrieval mode for this channel"
+    )
 
     def create_provider(self, channel: VoiceChannel, tac_config: TACConfig) -> VoiceProvider:
         """Build the ``VoiceProvider`` this config configures.

--- a/src/tac/channels/voice/twiml.py
+++ b/src/tac/channels/voice/twiml.py
@@ -1,6 +1,8 @@
 """TwiML generation for voice channel."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 from twilio.twiml.voice_response import VoiceResponse
@@ -9,7 +11,8 @@ from tac.core.config import TACConfig
 from tac.models.voice import TwiMLOptions
 from tac.tools.handoff import studio_voice_handoff_url
 
-from .config import VoiceChannelConfig
+if TYPE_CHECKING:
+    from .config import VoiceChannelConfig
 
 # Fields on TwiMLOptions that map to <ConversationRelay> attributes and are
 # emitted via the snake_case → camelCase conversion done by twilio's SDK.

--- a/src/tac/server/fastapi_server.py
+++ b/src/tac/server/fastapi_server.py
@@ -274,7 +274,7 @@ class TACFastAPIServer:
                 try:
                     form_data = await request.form()
                     payload_dict = {k: v for k, v in form_data.items() if isinstance(v, str)}
-                    await vc.handle_conversation_relay_callback(payload_dict)
+                    await vc.handle_twilio_provider_callback(payload_dict)
                 except Exception:
                     logger.error("Failed to process ConversationRelay callback", exc_info=True)
                     return Response(content="", media_type="text/plain", status_code=400)

--- a/tests/test_relay_only_mode.py
+++ b/tests/test_relay_only_mode.py
@@ -164,7 +164,7 @@ class TestRelayOnlyMode:
         ).model_dump(by_alias=True, exclude_none=True)
         payload = {k: str(v) for k, v in payload.items()}
 
-        await channel.handle_conversation_relay_callback(payload)
+        await channel.handle_twilio_provider_callback(payload)
 
         assert "CA_relay_xyz" not in channel._conversations
         assert ended == ["CA_relay_xyz"]
@@ -187,7 +187,7 @@ class TestRelayOnlyMode:
         ).model_dump(by_alias=True, exclude_none=True)
         payload = {k: str(v) for k, v in payload.items()}
 
-        await channel.handle_conversation_relay_callback(payload)
+        await channel.handle_twilio_provider_callback(payload)
 
         assert "CA_relay_mismatch" in channel._conversations
 
@@ -209,7 +209,7 @@ class TestRelayOnlyMode:
 
         from tac.models.voice import InterruptMessage
 
-        channel._handle_interrupt(
+        channel._provider._handle_interrupt(
             "CA_relay_int",
             InterruptMessage(
                 type="interrupt",

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -42,8 +42,8 @@ class TestVoiceChannel:
         channel = VoiceChannel(tac)
 
         assert channel.tac == tac
-        assert channel._websocket_manager is not None
-        assert len(channel._websocket_manager) == 0
+        assert channel._provider._websocket_manager is not None
+        assert len(channel._provider._websocket_manager) == 0
 
     def test_get_channel_name(self) -> None:
         """Test get_channel_name returns 'voice'."""
@@ -69,7 +69,7 @@ class TestVoiceChannel:
         )
 
         # Call handler directly
-        await channel._handle_prompt("CALL123", prompt_msg)
+        await channel._provider._handle_prompt("CALL123", prompt_msg)
 
         # With memory_mode="never", memory is not fetched - test passes if no exception
 
@@ -116,7 +116,7 @@ class TestVoiceChannel:
         )
 
         # Call handler directly
-        await channel._handle_prompt("CALL123", prompt_msg)
+        await channel._provider._handle_prompt("CALL123", prompt_msg)
 
         # Verify memory retrieval was called
         tac.conversation_memory_client.retrieve_memory.assert_called_once()
@@ -163,7 +163,9 @@ class TestVoiceChannel:
 
         setup_msg = SetupMessage(type="setup", callSid="CALL123", **{"from": "+15559998888"})
 
-        conv_id, _ = await channel._initialize_conversation("CALL123", setup_msg, MagicMock())
+        conv_id, _ = await channel._provider._initialize_conversation(
+            "CALL123", setup_msg, MagicMock()
+        )
 
         assert conv_id == "conv_abc"
         session = channel._conversations["conv_abc"]
@@ -215,7 +217,9 @@ class TestVoiceChannel:
 
         setup_msg = SetupMessage(type="setup", callSid="CALL456", **{"from": "+15559998888"})
 
-        conv_id, _ = await channel._initialize_conversation("CALL456", setup_msg, MagicMock())
+        conv_id, _ = await channel._provider._initialize_conversation(
+            "CALL456", setup_msg, MagicMock()
+        )
 
         session = channel._conversations[conv_id]
         assert session.ai_agent_info is None
@@ -237,7 +241,7 @@ class TestVoiceChannel:
         )
 
         # Call handler directly
-        channel._handle_interrupt("CALL123", interrupt_msg)
+        channel._provider._handle_interrupt("CALL123", interrupt_msg)
 
         # Test passes if no exception is raised
 
@@ -252,7 +256,7 @@ class TestVoiceChannel:
 
         # Mock websocket and register it with the manager
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL123", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL123", mock_websocket)
 
         # Send response without role
         await channel.send_response("CALL123", "Hello there")
@@ -282,7 +286,7 @@ class TestVoiceChannel:
         )
 
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL123", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL123", mock_websocket)
 
         await channel.send_response("CALL123", "Transferring you now.")
 
@@ -320,17 +324,17 @@ class TestVoiceChannel:
 
         # Add a mock websocket to the manager
         mock_websocket = MagicMock()
-        channel._websocket_manager.add_websocket("CALL123", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL123", mock_websocket)
 
         # Verify websocket is registered
-        assert channel._websocket_manager.has_websocket("CALL123")
+        assert channel._provider._websocket_manager.has_websocket("CALL123")
         assert "CALL123" in channel._conversations
 
         # Clean up connection (WebSocket only)
-        await channel._cleanup_connection("CALL123")
+        await channel._provider._cleanup_connection("CALL123")
 
         # Verify WebSocket cleanup but conversation still tracked
-        assert not channel._websocket_manager.has_websocket("CALL123")
+        assert not channel._provider._websocket_manager.has_websocket("CALL123")
         assert "CALL123" in channel._conversations
 
     @pytest.mark.asyncio
@@ -466,7 +470,7 @@ class TestVoiceChannel:
             conversationId="CALL123",
             voicePrompt="Test message",
         )
-        await channel._handle_prompt("CALL123", prompt_msg)
+        await channel._provider._handle_prompt("CALL123", prompt_msg)
 
         # Verify callback was invoked
         assert captured_context is not None
@@ -498,7 +502,7 @@ class TestVoiceChannel:
 
         # Mock websocket and register it
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL_AUTO_SEND", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL_AUTO_SEND", mock_websocket)
 
         # Create and handle prompt message
         prompt_msg = PromptMessage(
@@ -506,7 +510,7 @@ class TestVoiceChannel:
             conversationId="CALL_AUTO_SEND",
             voicePrompt="Test message",
         )
-        await channel._handle_prompt("CALL_AUTO_SEND", prompt_msg)
+        await channel._provider._handle_prompt("CALL_AUTO_SEND", prompt_msg)
 
         # Verify websocket.send_text was called once with the auto-sent response
         assert mock_websocket.send_text.call_count == 1
@@ -535,7 +539,7 @@ class TestVoiceChannel:
 
         # Mock websocket and register it
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL_NO_AUTO", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL_NO_AUTO", mock_websocket)
 
         # Create and handle prompt message
         prompt_msg = PromptMessage(
@@ -543,7 +547,7 @@ class TestVoiceChannel:
             conversationId="CALL_NO_AUTO",
             voicePrompt="Test message",
         )
-        await channel._handle_prompt("CALL_NO_AUTO", prompt_msg)
+        await channel._provider._handle_prompt("CALL_NO_AUTO", prompt_msg)
 
         # Verify websocket.send_text was NOT called (callback returned None)
         assert mock_websocket.send_text.call_count == 0
@@ -697,7 +701,7 @@ class TestVoiceChannel:
         )
 
         # Call handler directly
-        await channel._handle_prompt("CALL111", prompt_msg)
+        await channel._provider._handle_prompt("CALL111", prompt_msg)
 
         # Voice channel doesn't fetch memory - test passes if no exception raised
 
@@ -718,16 +722,16 @@ class TestVoiceChannel:
         mock_ws_3 = AsyncMock()
 
         # Register websockets with the manager
-        channel._websocket_manager.add_websocket("CALL_001", mock_ws_1)
-        channel._websocket_manager.add_websocket("CALL_002", mock_ws_2)
-        channel._websocket_manager.add_websocket("CALL_003", mock_ws_3)
+        channel._provider._websocket_manager.add_websocket("CALL_001", mock_ws_1)
+        channel._provider._websocket_manager.add_websocket("CALL_002", mock_ws_2)
+        channel._provider._websocket_manager.add_websocket("CALL_003", mock_ws_3)
 
         # Verify all conversations and websockets are tracked
         assert len(channel._conversations) == 3
-        assert len(channel._websocket_manager) == 3
-        assert channel._websocket_manager.has_websocket("CALL_001")
-        assert channel._websocket_manager.has_websocket("CALL_002")
-        assert channel._websocket_manager.has_websocket("CALL_003")
+        assert len(channel._provider._websocket_manager) == 3
+        assert channel._provider._websocket_manager.has_websocket("CALL_001")
+        assert channel._provider._websocket_manager.has_websocket("CALL_002")
+        assert channel._provider._websocket_manager.has_websocket("CALL_003")
 
         # Send responses to each conversation independently
         await channel.send_response("CALL_001", "Response to call 1")
@@ -760,35 +764,35 @@ class TestVoiceChannel:
         channel._start_conversation("CALL_C", "profile_C")
 
         # Register websockets
-        channel._websocket_manager.add_websocket("CALL_A", AsyncMock())
-        channel._websocket_manager.add_websocket("CALL_B", AsyncMock())
-        channel._websocket_manager.add_websocket("CALL_C", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CALL_A", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CALL_B", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CALL_C", AsyncMock())
 
         # Verify initial state
         assert len(channel._conversations) == 3
-        assert len(channel._websocket_manager) == 3
+        assert len(channel._provider._websocket_manager) == 3
 
         # Clean up CALL_B WebSocket only
-        await channel._cleanup_connection("CALL_B")
+        await channel._provider._cleanup_connection("CALL_B")
 
         # Verify CALL_B WebSocket is cleaned up but conversation still tracked
-        assert not channel._websocket_manager.has_websocket("CALL_B")
+        assert not channel._provider._websocket_manager.has_websocket("CALL_B")
         assert "CALL_B" in channel._conversations
         assert len(channel._conversations) == 3
-        assert len(channel._websocket_manager) == 2
+        assert len(channel._provider._websocket_manager) == 2
 
         # Verify CALL_A and CALL_C are still active
         assert "CALL_A" in channel._conversations
         assert "CALL_C" in channel._conversations
-        assert channel._websocket_manager.has_websocket("CALL_A")
-        assert channel._websocket_manager.has_websocket("CALL_C")
+        assert channel._provider._websocket_manager.has_websocket("CALL_A")
+        assert channel._provider._websocket_manager.has_websocket("CALL_C")
 
         # Clean up remaining WebSockets
-        await channel._cleanup_connection("CALL_A")
-        await channel._cleanup_connection("CALL_C")
+        await channel._provider._cleanup_connection("CALL_A")
+        await channel._provider._cleanup_connection("CALL_C")
 
         # Verify WebSockets cleaned up but conversations still tracked
-        assert len(channel._websocket_manager) == 0
+        assert len(channel._provider._websocket_manager) == 0
         assert len(channel._conversations) == 3
 
     @pytest.mark.asyncio
@@ -798,15 +802,15 @@ class TestVoiceChannel:
         channel = VoiceChannel(tac)
 
         # Initially empty
-        assert channel._websocket_manager.get_all_conversation_ids() == []
+        assert channel._provider._websocket_manager.get_all_conversation_ids() == []
 
         # Add multiple websockets
-        channel._websocket_manager.add_websocket("CONV_1", AsyncMock())
-        channel._websocket_manager.add_websocket("CONV_2", AsyncMock())
-        channel._websocket_manager.add_websocket("CONV_3", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CONV_1", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CONV_2", AsyncMock())
+        channel._provider._websocket_manager.add_websocket("CONV_3", AsyncMock())
 
         # Get all conversation IDs
-        conv_ids = channel._websocket_manager.get_all_conversation_ids()
+        conv_ids = channel._provider._websocket_manager.get_all_conversation_ids()
 
         # Verify all IDs are returned
         assert len(conv_ids) == 3
@@ -828,8 +832,8 @@ class TestVoiceChannel:
         mock_ws_x = AsyncMock()
         mock_ws_y = AsyncMock()
 
-        channel._websocket_manager.add_websocket("CONV_X", mock_ws_x)
-        channel._websocket_manager.add_websocket("CONV_Y", mock_ws_y)
+        channel._provider._websocket_manager.add_websocket("CONV_X", mock_ws_x)
+        channel._provider._websocket_manager.add_websocket("CONV_Y", mock_ws_y)
 
         # Send multiple messages to each conversation
         await channel.send_response("CONV_X", "Message 1 to X")
@@ -859,19 +863,19 @@ class TestVoiceChannel:
         channel = VoiceChannel(tac)
 
         # Add a websocket
-        channel._websocket_manager.add_websocket("CONV_Z", AsyncMock())
-        assert channel._websocket_manager.has_websocket("CONV_Z")
+        channel._provider._websocket_manager.add_websocket("CONV_Z", AsyncMock())
+        assert channel._provider._websocket_manager.has_websocket("CONV_Z")
 
         # Remove it once
-        channel._websocket_manager.remove_websocket("CONV_Z")
-        assert not channel._websocket_manager.has_websocket("CONV_Z")
+        channel._provider._websocket_manager.remove_websocket("CONV_Z")
+        assert not channel._provider._websocket_manager.has_websocket("CONV_Z")
 
         # Remove it again (should not raise error)
-        channel._websocket_manager.remove_websocket("CONV_Z")
-        assert not channel._websocket_manager.has_websocket("CONV_Z")
+        channel._provider._websocket_manager.remove_websocket("CONV_Z")
+        assert not channel._provider._websocket_manager.has_websocket("CONV_Z")
 
         # Remove non-existent websocket (should not raise error)
-        channel._websocket_manager.remove_websocket("NON_EXISTENT")
+        channel._provider._websocket_manager.remove_websocket("NON_EXISTENT")
 
     @pytest.mark.asyncio
     async def test_websocket_replacement(self) -> None:
@@ -881,23 +885,23 @@ class TestVoiceChannel:
 
         # Add first websocket
         first_ws = AsyncMock()
-        channel._websocket_manager.add_websocket("CONV_REPLACE", first_ws)
+        channel._provider._websocket_manager.add_websocket("CONV_REPLACE", first_ws)
 
         # Verify first websocket is registered
-        retrieved_ws = channel._websocket_manager.get_websocket("CONV_REPLACE")
+        retrieved_ws = channel._provider._websocket_manager.get_websocket("CONV_REPLACE")
         assert retrieved_ws is first_ws
 
         # Add second websocket with same conversation ID
         second_ws = AsyncMock()
-        channel._websocket_manager.add_websocket("CONV_REPLACE", second_ws)
+        channel._provider._websocket_manager.add_websocket("CONV_REPLACE", second_ws)
 
         # Verify second websocket replaced the first
-        retrieved_ws = channel._websocket_manager.get_websocket("CONV_REPLACE")
+        retrieved_ws = channel._provider._websocket_manager.get_websocket("CONV_REPLACE")
         assert retrieved_ws is second_ws
         assert retrieved_ws is not first_ws
 
         # Verify still only one websocket tracked
-        assert len(channel._websocket_manager) == 1
+        assert len(channel._provider._websocket_manager) == 1
 
     @pytest.mark.asyncio
     async def test_send_response_with_invalid_type_raises_error(self) -> None:
@@ -910,7 +914,7 @@ class TestVoiceChannel:
 
         # Mock websocket
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL_INVALID", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL_INVALID", mock_websocket)
 
         # Test with integer (invalid type)
         with pytest.raises(TypeError, match="Voice channel requires string or async generator"):
@@ -937,7 +941,7 @@ class TestVoiceChannel:
 
         # Mock websocket
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CALL_STREAM", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CALL_STREAM", mock_websocket)
 
         # Create async generator
         async def stream_response() -> AsyncGenerator[str, None]:
@@ -966,16 +970,16 @@ class TestVoiceChannel:
         # Start conversation and add a mock websocket
         channel._start_conversation("CALL_CB1", "prof_cb1")
         mock_ws = MagicMock()
-        channel._websocket_manager.add_websocket("CALL_CB1", mock_ws)
+        channel._provider._websocket_manager.add_websocket("CALL_CB1", mock_ws)
 
-        await channel._cleanup_connection("CALL_CB1")
+        await channel._provider._cleanup_connection("CALL_CB1")
 
         # Callback should NOT be called (conversation still tracked for webhook)
         assert len(captured) == 0
         # Conversation should still be tracked
         assert "CALL_CB1" in channel._conversations
         # WebSocket should be removed
-        assert not channel._websocket_manager.has_websocket("CALL_CB1")
+        assert not channel._provider._websocket_manager.has_websocket("CALL_CB1")
 
     @pytest.mark.asyncio
     async def test_cleanup_connection_removes_websocket_only(self) -> None:
@@ -985,14 +989,14 @@ class TestVoiceChannel:
 
         channel._start_conversation("CALL_CB2", "prof_cb2")
         mock_ws = MagicMock()
-        channel._websocket_manager.add_websocket("CALL_CB2", mock_ws)
+        channel._provider._websocket_manager.add_websocket("CALL_CB2", mock_ws)
 
-        await channel._cleanup_connection("CALL_CB2")
+        await channel._provider._cleanup_connection("CALL_CB2")
 
         # Conversation still tracked (waiting for webhook)
         assert "CALL_CB2" in channel._conversations
         # WebSocket removed
-        assert not channel._websocket_manager.has_websocket("CALL_CB2")
+        assert not channel._provider._websocket_manager.has_websocket("CALL_CB2")
 
     @pytest.mark.asyncio
     async def test_webhook_triggers_conversation_ended_callback(self) -> None:
@@ -1030,15 +1034,15 @@ class TestVoiceChannel:
 
         channel._start_conversation("CALL_NOCB", "prof_nocb")
         mock_ws = MagicMock()
-        channel._websocket_manager.add_websocket("CALL_NOCB", mock_ws)
+        channel._provider._websocket_manager.add_websocket("CALL_NOCB", mock_ws)
 
-        await channel._cleanup_connection("CALL_NOCB")
+        await channel._provider._cleanup_connection("CALL_NOCB")
         # Second cleanup should be a no-op (websocket already removed)
-        await channel._cleanup_connection("CALL_NOCB")
+        await channel._provider._cleanup_connection("CALL_NOCB")
 
         # Conversation still tracked (only webhook removes it)
         assert "CALL_NOCB" in channel._conversations
-        assert not channel._websocket_manager.has_websocket("CALL_NOCB")
+        assert not channel._provider._websocket_manager.has_websocket("CALL_NOCB")
 
     @pytest.mark.asyncio
     async def test_task_cancellation_with_unified_workflow(self) -> None:
@@ -1094,7 +1098,7 @@ class TestVoiceChannel:
 
         # Mock websocket
         mock_websocket = AsyncMock()
-        voice_channel._websocket_manager.add_websocket("CONV_CANCEL_TEST", mock_websocket)
+        voice_channel._provider._websocket_manager.add_websocket("CONV_CANCEL_TEST", mock_websocket)
 
         # Create prompt message
         prompt_data = {
@@ -1107,7 +1111,9 @@ class TestVoiceChannel:
         session_state = session_manager.get_or_create_session("CONV_CANCEL_TEST")
 
         # Start processing prompt (creates task but doesn't await it)
-        await voice_channel._handle_prompt_async("CONV_CANCEL_TEST", prompt_data, session_state)
+        await voice_channel._provider._handle_prompt_async(
+            "CONV_CANCEL_TEST", prompt_data, session_state
+        )
 
         # Verify task was created
         assert session_state.stream_task is not None
@@ -1140,7 +1146,9 @@ class TestVoiceChannel:
         assert chunks_sent > 0, "Should have sent some chunks before cancellation"
 
         # Now process new prompt
-        await voice_channel._handle_prompt_async("CONV_CANCEL_TEST", prompt_data2, session_state)
+        await voice_channel._provider._handle_prompt_async(
+            "CONV_CANCEL_TEST", prompt_data2, session_state
+        )
 
         # Verify new task was created
         assert session_state.stream_task is not None
@@ -2038,7 +2046,7 @@ class TestConversationInitializationFlow:
         assert profile_id == "profile_voice_correct"
 
     @pytest.mark.asyncio
-    @patch("tac.channels.voice.channel._POLL_BASE_DELAY", 0)
+    @patch("tac.channels.voice.conversation_relay._POLL_BASE_DELAY", 0)
     async def test_error_when_no_conversations_found(self, capsys: pytest.CaptureFixture) -> None:
         """Test RuntimeError when ConversationRelay creates 0 conversations."""
         from tac.channels.websocket_protocol import WebSocketDisconnectError
@@ -2075,7 +2083,7 @@ class TestConversationInitializationFlow:
         assert len(channel._conversations) == 0
 
     @pytest.mark.asyncio
-    @patch("tac.channels.voice.channel._POLL_BASE_DELAY", 0)
+    @patch("tac.channels.voice.conversation_relay._POLL_BASE_DELAY", 0)
     async def test_error_when_multiple_conversations_found(
         self, capsys: pytest.CaptureFixture
     ) -> None:
@@ -2198,7 +2206,7 @@ class TestConversationInitializationFlow:
 
         # The websocket registration is cleaned up (not leaked) even though
         # no prompt ever arrived to claim conv_id itself.
-        assert not channel._websocket_manager.has_websocket("CH_setup_test")
+        assert not channel._provider._websocket_manager.has_websocket("CH_setup_test")
         # The conversation entry legitimately stays until CO's CLOSED
         # webhook — same as any other orchestrator-mode call.
         assert list(channel._conversations.keys()) == ["CH_setup_test"]
@@ -2288,8 +2296,8 @@ class TestSessionManagerDefaults:
         channel = VoiceChannel(tac)
 
         # Verify session_manager is created by default
-        assert channel.session_manager is not None
-        assert isinstance(channel.session_manager, ThreadSafeSessionManager)
+        assert channel._provider.session_manager is not None
+        assert isinstance(channel._provider.session_manager, ThreadSafeSessionManager)
 
     def test_session_manager_can_be_set_to_none(self) -> None:
         """Test that session_manager can be explicitly disabled."""
@@ -2300,7 +2308,7 @@ class TestSessionManagerDefaults:
         channel = VoiceChannel(tac, config=config)
 
         # Verify session_manager is None when explicitly disabled
-        assert channel.session_manager is None
+        assert channel._provider.session_manager is None
 
     def test_session_manager_can_be_dict_none(self) -> None:
         """Test that session_manager can be disabled via config dict."""
@@ -2308,7 +2316,7 @@ class TestSessionManagerDefaults:
         channel = VoiceChannel(tac, config={"session_manager": None})
 
         # Verify session_manager is None when explicitly disabled via dict
-        assert channel.session_manager is None
+        assert channel._provider.session_manager is None
 
     @pytest.mark.asyncio
     async def test_cleanup_cancels_running_task(self) -> None:
@@ -2332,16 +2340,18 @@ class TestSessionManagerDefaults:
         # Start conversation
         channel._start_conversation("CONV_CLEANUP_TEST", None)
         mock_websocket = AsyncMock()
-        channel._websocket_manager.add_websocket("CONV_CLEANUP_TEST", mock_websocket)
+        channel._provider._websocket_manager.add_websocket("CONV_CLEANUP_TEST", mock_websocket)
 
         # Create and start a task
-        session_state = channel.session_manager.get_or_create_session("CONV_CLEANUP_TEST")
+        session_state = channel._provider.session_manager.get_or_create_session("CONV_CLEANUP_TEST")
         prompt_data = {
             "type": "prompt",
             "conversationId": "CONV_CLEANUP_TEST",
             "voicePrompt": "Test",
         }
-        await channel._handle_prompt_async("CONV_CLEANUP_TEST", prompt_data, session_state)
+        await channel._provider._handle_prompt_async(
+            "CONV_CLEANUP_TEST", prompt_data, session_state
+        )
 
         # Give task time to start
         await asyncio.sleep(0.05)
@@ -2349,7 +2359,7 @@ class TestSessionManagerDefaults:
         assert not session_state.stream_task.done()
 
         # Cleanup should cancel the task
-        await channel._cleanup_connection("CONV_CLEANUP_TEST")
+        await channel._provider._cleanup_connection("CONV_CLEANUP_TEST")
 
         # Verify task was cancelled
         assert task_cancelled == [True]


### PR DESCRIPTION
## Summary
- Stacked on #114 — merge that one first.
- `VoiceChannel` owned every piece of ConversationRelay-specific behavior directly: the WebSocket setup/prompt/interrupt protocol loop, outbound call initiation, and the ConversationRelay callback webhook. Moves all of it onto `ConversationRelayProvider`; `VoiceChannel` now only builds the provider (`config.create_provider(self, tac.config)`) and delegates through thin wrapper methods.
- Moved as-is — method bodies are unchanged apart from the necessary `self.X` → `self.channel.X` renames for functionality `VoiceChannel` still owns (`TAC`, conversation bookkeeping, Calls API client). Verified via a line-by-line diff against the pre-move code.
- `_merge_call_options`/`_build_call_kwargs` move in full — they're only used by outbound, and outbound support itself is provider-specific, so there's no reason to keep them on `VoiceChannel` for a hypothetical second provider that may not support outbound at all.
- Renames `handle_conversation_relay_callback` → `handle_twilio_provider_callback`: this webhook is Twilio's ConversationRelay-specific mechanism, but Media Streams has its own independent `statusCallback` equivalent, so the channel-facing name shouldn't bake in "ConversationRelay". `VoiceProvider` declares the neutral no-op default; `ConversationRelayProvider` implements it.
- `VoiceProvider.__init__(channel)` now stores `self.channel` and gets its own `self.logger` (named after the concrete provider's module, same convention as `BaseChannel`) — no more threading `channel` through every method call.
- Left on `VoiceChannel` unchanged: Calls-API webhook handling (`on_call_status`/`on_amd`/`on_recording` + their event handlers), `_get_twilio_client`, `end_call`, `get_conversation_session_by_call_sid`, `process_webhook` — all genuinely provider-agnostic.
- No public API changes. Test changes are mechanical only: private provider methods are now reached via `channel._provider`, no more `channel` argument to thread through.

## Test plan
- [x] `make lint` / `make type-check` / `make check` all pass
- [x] 876 existing tests pass (mechanical updates only, no assertions changed)
- [x] Manually tested end-to-end against a real call via ngrok + `voice_streaming.py` example — full flow (WS setup → CO conversation lookup → memory retrieval → hangup → WS cleanup → ConversationRelay callback → conversation ended) works, logs correctly attributed to `tac.channels.voice.conversation_relay` vs `tac.channels.voice.channel`