### PR TITLE
refactor(voice): decouple TwiML options from VoiceChannel/VoiceProvider

### DIFF
--- a/src/tac/channels/voice/__init__.py
+++ b/src/tac/channels/voice/__init__.py
@@ -21,6 +21,8 @@ from tac.models.voice import (
     RecordingEvent,
     TwiMLOptions,
     TwiMLRequest,
+    VoiceTwiMLOptions,
+    VoiceTwiMLOptionsConversationRelay,
 )
 
 __all__ = [
@@ -42,5 +44,7 @@ __all__ = [
     "VoiceChannelConfig",
     "VoiceProvider",
     "VoiceProviderConfig",
+    "VoiceTwiMLOptions",
+    "VoiceTwiMLOptionsConversationRelay",
     "generate_twiml",
 ]

--- a/src/tac/channels/voice/__init__.py
+++ b/src/tac/channels/voice/__init__.py
@@ -1,14 +1,13 @@
 """Voice channel for handling voice-based conversations."""
 
-from tac.channels.voice.channel import VoiceChannel
-from tac.channels.voice.config import (
+from tac.channels.voice.channel import (
     AmdHandler,
     CallStatusHandler,
-    ConversationRelayProviderConfig,
     InboundCallTwiMLHandler,
     RecordingHandler,
-    VoiceChannelConfig,
+    VoiceChannel,
 )
+from tac.channels.voice.config import ConversationRelayProviderConfig, VoiceChannelConfig
 from tac.channels.voice.conversation_relay import ConversationRelayProvider
 from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
 from tac.channels.voice.twiml import generate_twiml

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -19,18 +19,17 @@ from tac.models.voice import (
     AmdEvent,
     CallStatusEvent,
     RecordingEvent,
-    TwiMLOptions,
     TwiMLRequest,
+    VoiceTwiMLOptions,
 )
 
-from .config import (
-    AmdHandler,
-    CallStatusHandler,
-    InboundCallTwiMLHandler,
-    RecordingHandler,
-    VoiceChannelConfig,
-)
+from .config import VoiceChannelConfig
 from .provider import VoiceProviderConfig
+
+InboundCallTwiMLHandler = Callable[[TwiMLRequest], Awaitable[VoiceTwiMLOptions]]
+CallStatusHandler = Callable[[CallStatusEvent], Awaitable[None]]
+AmdHandler = Callable[[AmdEvent], Awaitable[None]]
+RecordingHandler = Callable[[RecordingEvent], Awaitable[None]]
 
 
 class VoiceChannel(BaseChannel):
@@ -58,16 +57,24 @@ class VoiceChannel(BaseChannel):
 
         Args:
             tac: TAC instance for memory/context operations
-            config: Voice channel configuration (a ``VoiceProviderConfig`` —
-                ``VoiceChannelConfig`` today — or dict). If None, uses default
-                configuration.
+            config: Voice channel configuration — a ``VoiceProviderConfig``
+                instance for any provider, or a dict. The dict form is
+                shorthand for ``VoiceChannelConfig`` (the default
+                ConversationRelay provider) specifically, not a generic
+                constructor — it's hydrated as ``VoiceChannelConfig(**config)``
+                and fails if it has fields that config doesn't have. To
+                configure a different provider, construct that provider's
+                config and pass it directly instead of a dict. If None, uses
+                ``VoiceChannelConfig()``.
 
         Examples:
             >>> channel = VoiceChannel(tac, config={"memory_mode": "always"})
             >>> channel = VoiceChannel(tac, config=VoiceChannelConfig(session_manager=sm))
             >>> channel = VoiceChannel(tac)  # Use defaults
         """
-        # Convert dict to config model or use defaults.
+        # dict is shorthand for VoiceChannelConfig specifically — see the
+        # config Args note above. Not a generic dict-to-provider-config
+        # constructor.
         if isinstance(config, dict):
             config = VoiceChannelConfig(**config)
         elif config is None:
@@ -83,23 +90,14 @@ class VoiceChannel(BaseChannel):
 
     def on_inbound_call_twiml(self, callback: InboundCallTwiMLHandler) -> None:
         """Register a callback that produces per-call overrides for the
-        TwiML inside ``<ConversationRelay>`` on inbound calls.
+        active provider's inbound-call TwiML.
 
         The callback receives a framework-neutral ``TwiMLRequest`` (parsed
-        from the Twilio webhook form) and returns a ``TwiMLOptions``. Fields
-        the callback explicitly sets override ``default_twiml_options`` and
-        TAC defaults; unset fields fall through.
-
-        Example:
-            ```python
-            async def by_country(req: TwiMLRequest) -> TwiMLOptions:
-                if req.caller_country == "MX":
-                    return TwiMLOptions(language="es-MX", welcome_greeting="¡Hola!")
-                return TwiMLOptions()
-
-
-            voice_channel.on_inbound_call_twiml(by_country)
-            ```
+        from the Twilio webhook form) and returns a ``VoiceTwiMLOptions`` —
+        the concrete subclass the active provider expects (e.g.
+        ``VoiceTwiMLOptionsConversationRelay`` for the default
+        ConversationRelay provider; see that provider's
+        ``handle_incoming_call`` for its merge/precedence rules).
 
         Outbound calls don't use this — pass per-call TwiML via
         ``InitiateVoiceConversationOptions.twiml_options`` directly.
@@ -191,12 +189,16 @@ class VoiceChannel(BaseChannel):
         self,
         twiml_request: TwiMLRequest | None = None,
         *,
-        host_twiml_options: TwiMLOptions | None = None,
+        host_twiml_options: VoiceTwiMLOptions | None = None,
     ) -> str:
         """Generate TwiML response for incoming voice calls. Delegates to the
         active provider — see ``ConversationRelayProvider.handle_incoming_call``
         for the full merge/precedence rules (only meaningful for that provider;
         a non-TwiML provider ignores ``host_twiml_options``).
+
+        ``host_twiml_options`` is typed against the ``VoiceTwiMLOptions`` base —
+        the active provider defines the concrete shape it expects (e.g.
+        ``VoiceTwiMLOptionsConversationRelay``) and validates it at runtime.
         """
         return await self._provider.handle_incoming_call(
             twiml_request, host_twiml_options=host_twiml_options
@@ -305,7 +307,7 @@ class VoiceChannel(BaseChannel):
         await self._on_recording(event)
 
     async def end_call(self, call_sid: str) -> bool:
-        """Hang up a call and clean up its ConversationRelay session.
+        """Hang up a call and clean up its session.
 
         Works on ``call_sid`` alone, whether or not a session exists yet.
         No-ops the session cleanup if none is tracked.
@@ -358,7 +360,7 @@ class VoiceChannel(BaseChannel):
         At the other end, orchestrator mode keeps the session until Conversation
         Orchestrator's CLOSED webhook, so it outlives the call and
         ``on_call_status`` / ``on_recording`` do resolve. Relay-only mode tears
-        down on the ConversationRelay callback instead, which races them.
+        down on the provider's out-of-band callback instead, which races them.
 
         Named for ``ConversationSession``; ``session_manager`` deals in
         ``SessionState``, a different type.

--- a/src/tac/channels/voice/config.py
+++ b/src/tac/channels/voice/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 from pydantic import Field
@@ -14,19 +13,8 @@ from tac.core.config import TACConfig
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
 from tac.models.outbound import CallOptions
-from tac.models.voice import (
-    AmdEvent,
-    CallStatusEvent,
-    RecordingEvent,
-    TwiMLOptions,
-    TwiMLRequest,
-)
+from tac.models.voice import VoiceTwiMLOptionsConversationRelay
 from tac.session import SessionManager, ThreadSafeSessionManager
-
-InboundCallTwiMLHandler = Callable[[TwiMLRequest], Awaitable[TwiMLOptions]]
-CallStatusHandler = Callable[[CallStatusEvent], Awaitable[None]]
-AmdHandler = Callable[[AmdEvent], Awaitable[None]]
-RecordingHandler = Callable[[RecordingEvent], Awaitable[None]]
 
 
 class ConversationRelayProviderConfig(VoiceProviderConfig):
@@ -66,7 +54,7 @@ class ConversationRelayProviderConfig(VoiceProviderConfig):
             - "once": Retrieve memory once at conversation start with empty query and cache it.
                      Cache is invalidated when conversation becomes INACTIVE.
             - "never": Skip memory retrieval
-        default_twiml_options: Static ``TwiMLOptions`` applied to every call
+        default_twiml_options: Static ``VoiceTwiMLOptionsConversationRelay`` applied to every call
             (inbound and outbound). Controls the TwiML inside
             ``<ConversationRelay>`` — voice, language, transcription provider,
             welcome_greeting, ``<Language>`` children, etc. Use this when the
@@ -89,9 +77,10 @@ class ConversationRelayProviderConfig(VoiceProviderConfig):
             "Set to None only for debugging/testing."
         ),
     )
-    default_twiml_options: TwiMLOptions | None = Field(
+    default_twiml_options: VoiceTwiMLOptionsConversationRelay | None = Field(
         default=None,
-        description="Static TwiMLOptions for the TwiML inside <ConversationRelay>, "
+        description="Static VoiceTwiMLOptionsConversationRelay for the TwiML inside "
+        "<ConversationRelay>, "
         "applied to every call (inbound and outbound). Per-call inbound "
         "customization is registered via VoiceChannel.on_inbound_call_twiml(...). "
         "Note: ``custom_parameters`` and ``languages`` replace wholesale when a "

--- a/src/tac/channels/voice/conversation_relay.py
+++ b/src/tac/channels/voice/conversation_relay.py
@@ -148,7 +148,14 @@ class ConversationRelayProvider(VoiceProvider):
 
         customized: VoiceTwiMLOptionsConversationRelay | None = None
         if self.channel._on_inbound_call_twiml is not None and twiml_request is not None:
-            customized = await self.channel._on_inbound_call_twiml(twiml_request)
+            result = await self.channel._on_inbound_call_twiml(twiml_request)
+            if not isinstance(result, VoiceTwiMLOptionsConversationRelay):
+                raise TypeError(
+                    "ConversationRelayProvider.handle_incoming_call requires the "
+                    "on_inbound_call_twiml customizer to return a "
+                    f"VoiceTwiMLOptionsConversationRelay, got {type(result).__name__}"
+                )
+            customized = result
 
         return self._twiml.build(
             "handle_incoming_call",
@@ -509,6 +516,16 @@ class ConversationRelayProvider(VoiceProvider):
         ``TACConfig.voice_websocket_path``, unless overridden per-call via
         ``options.websocket_url``.
         """
+        twiml_options = options.twiml_options
+        if twiml_options is not None and not isinstance(
+            twiml_options, VoiceTwiMLOptionsConversationRelay
+        ):
+            raise TypeError(
+                "ConversationRelayProvider.initiate_outbound_conversation requires "
+                "options.twiml_options to be a VoiceTwiMLOptionsConversationRelay, got "
+                f"{type(twiml_options).__name__}"
+            )
+
         from_number = self.channel.tac.config.phone_number
 
         self.logger.info(
@@ -523,7 +540,7 @@ class ConversationRelayProvider(VoiceProvider):
         # through the layered merge; both fall back to the TACConfig-derived URL.
         twiml_xml = self._twiml.build(
             "initiate_outbound_conversation",
-            per_call=options.twiml_options,
+            per_call=twiml_options,
             websocket_url=options.websocket_url,
         )
 

--- a/src/tac/channels/voice/conversation_relay.py
+++ b/src/tac/channels/voice/conversation_relay.py
@@ -28,8 +28,9 @@ from tac.models.voice import (
     InterruptMessage,
     PromptMessage,
     SetupMessage,
-    TwiMLOptions,
     TwiMLRequest,
+    VoiceTwiMLOptions,
+    VoiceTwiMLOptionsConversationRelay,
 )
 from tac.session import SessionState
 from tac.utils.redaction import mask_phone, redact_twiml_parameters
@@ -83,7 +84,7 @@ class ConversationRelayProvider(VoiceProvider):
         self,
         twiml_request: TwiMLRequest | None = None,
         *,
-        host_twiml_options: TwiMLOptions | None = None,
+        host_twiml_options: VoiceTwiMLOptions | None = None,
     ) -> str:
         """
         Generate TwiML response for incoming voice calls.
@@ -136,7 +137,16 @@ class ConversationRelayProvider(VoiceProvider):
         Returns:
             TwiML XML string for call connection.
         """
-        customized: TwiMLOptions | None = None
+        if host_twiml_options is not None and not isinstance(
+            host_twiml_options, VoiceTwiMLOptionsConversationRelay
+        ):
+            raise TypeError(
+                "ConversationRelayProvider.handle_incoming_call requires host_twiml_options "
+                f"to be a VoiceTwiMLOptionsConversationRelay, got "
+                f"{type(host_twiml_options).__name__}"
+            )
+
+        customized: VoiceTwiMLOptionsConversationRelay | None = None
         if self.channel._on_inbound_call_twiml is not None and twiml_request is not None:
             customized = await self.channel._on_inbound_call_twiml(twiml_request)
 

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -16,7 +16,7 @@ from tac.core.config import TACConfig
 from tac.core.logging import get_logger
 from tac.models.memory import MemoryMode
 from tac.models.outbound import InitiateVoiceConversationOptions, InitiateVoiceConversationResult
-from tac.models.voice import TwiMLOptions, TwiMLRequest
+from tac.models.voice import TwiMLRequest, VoiceTwiMLOptions
 
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
@@ -46,7 +46,7 @@ class VoiceProvider:
         self,
         twiml_request: TwiMLRequest | None = None,
         *,
-        host_twiml_options: TwiMLOptions | None = None,
+        host_twiml_options: VoiceTwiMLOptions | None = None,
     ) -> str:
         """Build the response for an inbound call. Default: not supported."""
         raise NotImplementedError(f"{type(self).__name__} does not support inbound calls.")

--- a/src/tac/channels/voice/twiml.py
+++ b/src/tac/channels/voice/twiml.py
@@ -8,15 +8,16 @@ from pydantic import BaseModel
 from twilio.twiml.voice_response import VoiceResponse
 
 from tac.core.config import TACConfig
-from tac.models.voice import TwiMLOptions
+from tac.models.voice import VoiceTwiMLOptionsConversationRelay
 from tac.tools.handoff import studio_voice_handoff_url
 
 if TYPE_CHECKING:
     from .config import VoiceChannelConfig
 
-# Fields on TwiMLOptions that map to <ConversationRelay> attributes and are
-# emitted via the snake_case → camelCase conversion done by twilio's SDK.
-# Must stay in sync with TwiMLOptions field declarations; see _verify_attrs_in_sync.
+# Fields on VoiceTwiMLOptionsConversationRelay that map to <ConversationRelay> attributes
+# and are emitted via the snake_case → camelCase conversion done by twilio's SDK.
+# Must stay in sync with VoiceTwiMLOptionsConversationRelay's field declarations —
+# see _verify_attrs_in_sync.
 _OPTIONAL_RELAY_ATTRS = (
     "welcome_greeting",
     "welcome_greeting_interruptible",
@@ -48,7 +49,7 @@ _OPTIONAL_RELAY_ATTRS = (
     "intelligence_service",
 )
 
-# Fields on TwiMLOptions that this module handles specially (not via the
+# Fields on VoiceTwiMLOptionsConversationRelay that this module handles specially (not via the
 # generic _OPTIONAL_RELAY_ATTRS loop) — the websocket_url (emitted as the
 # ``<ConversationRelay url=...>`` attribute, resolved from the positional
 # ``websocket_url`` arg or ``options.websocket_url``), the action_url, the
@@ -64,23 +65,23 @@ _HANDLED_OUTSIDE_LOOP = {
 
 
 def _verify_attrs_in_sync() -> None:
-    """Fail fast at import time if TwiMLOptions grows a field that isn't
+    """Fail fast at import time if VoiceTwiMLOptionsConversationRelay grows a field that isn't
     accounted for here — either it's a new ConversationRelay attribute that
     needs to go in _OPTIONAL_RELAY_ATTRS, or it's special-cased and should
     be added to _HANDLED_OUTSIDE_LOOP.
     """
-    declared = set(TwiMLOptions.model_fields)
+    declared = set(VoiceTwiMLOptionsConversationRelay.model_fields)
     accounted = set(_OPTIONAL_RELAY_ATTRS) | _HANDLED_OUTSIDE_LOOP
     missing = declared - accounted
     extra = accounted - declared
     if missing:
         raise RuntimeError(
-            f"TwiMLOptions field(s) {sorted(missing)} not handled by twiml.py — "
-            "add to _OPTIONAL_RELAY_ATTRS or _HANDLED_OUTSIDE_LOOP."
+            f"VoiceTwiMLOptionsConversationRelay field(s) {sorted(missing)} not handled by "
+            "twiml.py — add to _OPTIONAL_RELAY_ATTRS or _HANDLED_OUTSIDE_LOOP."
         )
     if extra:
         raise RuntimeError(
-            f"twiml.py references TwiMLOptions field(s) {sorted(extra)} that "
+            f"twiml.py references VoiceTwiMLOptionsConversationRelay field(s) {sorted(extra)} that "
             "no longer exist on the model."
         )
 
@@ -90,7 +91,7 @@ _verify_attrs_in_sync()
 
 def generate_twiml(
     websocket_url: str | None = None,
-    options: TwiMLOptions | dict[str, Any] | None = None,
+    options: VoiceTwiMLOptionsConversationRelay | dict[str, Any] | None = None,
 ) -> str:
     """
     Generate TwiML XML for ConversationRelay.
@@ -102,13 +103,13 @@ def generate_twiml(
 
     The WebSocket URL may be passed positionally or as ``options.websocket_url``
     (positional wins when both are given), so a caller can pass everything in one
-    object: ``generate_twiml(options=TwiMLOptions(websocket_url=...))``.
+    object: ``generate_twiml(options=VoiceTwiMLOptionsConversationRelay(websocket_url=...))``.
 
     Args:
         websocket_url: Public WebSocket URL for ConversationRelay
             (e.g. ``'wss://example.ngrok.app/ws'``). Optional if
             ``options.websocket_url`` is set.
-        options: Optional ``TwiMLOptions`` (or dict). See ``TwiMLOptions``
+        options: Optional ``VoiceTwiMLOptionsConversationRelay`` (or dict). See that model
             for supported fields. Newly-added ConversationRelay attributes
             not yet typed on the model can be passed via ``extra``.
 
@@ -121,19 +122,20 @@ def generate_twiml(
     Example:
         >>> twiml = generate_twiml(
         ...     "wss://example.com/voice",
-        ...     TwiMLOptions(
+        ...     VoiceTwiMLOptionsConversationRelay(
         ...         welcome_greeting="Hello!",
         ...         conversation_configuration="conv_configuration_xxxx",
         ...     ),
         ... )
     """
     if options is None:
-        options = TwiMLOptions()
+        options = VoiceTwiMLOptionsConversationRelay()
     elif isinstance(options, dict):
-        options = TwiMLOptions(**options)
+        options = VoiceTwiMLOptionsConversationRelay(**options)
 
     # Positional arg wins when both are set; fall back to options.websocket_url.
-    # (TwiMLOptions rejects an empty websocket_url, so any value here is real.)
+    # (VoiceTwiMLOptionsConversationRelay rejects an empty websocket_url, so any value
+    # here is real.)
     resolved_websocket_url = websocket_url if websocket_url is not None else options.websocket_url
     if not resolved_websocket_url:
         raise ValueError(
@@ -163,8 +165,8 @@ def generate_twiml(
             value = "any" if value else "none"
         relay_kwargs[attr] = value
 
-    # TwiMLOptions' validator already rejects extra keys that shadow typed
-    # fields, so we can pass everything through here as-is.
+    # VoiceTwiMLOptionsConversationRelay's validator already rejects extra keys that shadow
+    # typed fields, so we can pass everything through here as-is.
     if options.extra:
         relay_kwargs.update(options.extra)
 
@@ -215,8 +217,8 @@ class TwiMLBuilderConversationRelay:
         self,
         caller: str,
         *,
-        host: TwiMLOptions | None = None,
-        per_call: TwiMLOptions | None = None,
+        host: VoiceTwiMLOptionsConversationRelay | None = None,
+        per_call: VoiceTwiMLOptionsConversationRelay | None = None,
         websocket_url: str | None = None,
     ) -> str:
         """Build the TwiML XML for one call.
@@ -259,15 +261,15 @@ class TwiMLBuilderConversationRelay:
 
     def _build_twiml_options(
         self,
-        host: TwiMLOptions | None,
-        per_call: TwiMLOptions | None,
-    ) -> TwiMLOptions:
+        host: VoiceTwiMLOptionsConversationRelay | None,
+        per_call: VoiceTwiMLOptionsConversationRelay | None,
+    ) -> VoiceTwiMLOptionsConversationRelay:
         """Layer TwiML options, lowest precedence first: TAC defaults →
         ``host`` (calling host's per-call values) → ``default_twiml_options`` →
         ``per_call`` (application customizer output for inbound, or
         ``InitiateVoiceConversationOptions.twiml_options`` for outbound).
         """
-        merged = TwiMLOptions(
+        merged = VoiceTwiMLOptionsConversationRelay(
             welcome_greeting=DEFAULT_WELCOME_GREETING,
             conversation_configuration=self.tac_config.conversation_configuration_id,
             action_url=self._resolve_action_url(host, per_call),
@@ -281,7 +283,9 @@ class TwiMLBuilderConversationRelay:
         return merged
 
     @staticmethod
-    def _overlay_fields(target: TwiMLOptions, source: TwiMLOptions) -> None:
+    def _overlay_fields(
+        target: VoiceTwiMLOptionsConversationRelay, source: VoiceTwiMLOptionsConversationRelay
+    ) -> None:
         """Apply fields explicitly set on ``source`` onto ``target``.
 
         Nested models (``custom_parameters``), lists (``languages``), and
@@ -302,8 +306,8 @@ class TwiMLBuilderConversationRelay:
 
     def _resolve_action_url(
         self,
-        host: TwiMLOptions | None,
-        customized: TwiMLOptions | None,
+        host: VoiceTwiMLOptionsConversationRelay | None,
+        customized: VoiceTwiMLOptionsConversationRelay | None,
     ) -> str | None:
         """Resolve the TwiML ``<Connect action=...>`` URL.
 

--- a/src/tac/models/__init__.py
+++ b/src/tac/models/__init__.py
@@ -55,7 +55,14 @@ from tac.models.tac import (
     TACCommunicationContent,
     TACMemoryResponse,
 )
-from tac.models.voice import AmdEvent, CallStatusEvent, RecordingEvent, TwiMLOptions
+from tac.models.voice import (
+    AmdEvent,
+    CallStatusEvent,
+    RecordingEvent,
+    TwiMLOptions,
+    VoiceTwiMLOptions,
+    VoiceTwiMLOptionsConversationRelay,
+)
 
 # Rebuild ConversationSession after importing TACMemoryResponse so Pydantic can
 # resolve the forward reference used by ConversationSession. The session model
@@ -119,4 +126,6 @@ __all__ = [
     "TACMemoryResponse",
     "TriggerDetails",
     "TwiMLOptions",
+    "VoiceTwiMLOptions",
+    "VoiceTwiMLOptionsConversationRelay",
 ]

--- a/src/tac/models/outbound.py
+++ b/src/tac/models/outbound.py
@@ -6,7 +6,7 @@ from typing import Any, ClassVar, Literal
 from pydantic import BaseModel, Field, field_serializer, model_validator
 
 from tac.models.session import ConversationSession
-from tac.models.voice import TwiMLOptions
+from tac.models.voice import VoiceTwiMLOptions
 
 
 class InitiateMessagingConversationOptions(BaseModel):
@@ -182,7 +182,7 @@ class InitiateVoiceConversationOptions(BaseModel):
          action_url resolved via Studio handoff if configured)
 
     Fields you don't set at a layer fall through to lower layers — so
-    ``twiml_options=TwiMLOptions(voice="es-MX-Neural2-A")`` on this call
+    ``twiml_options=VoiceTwiMLOptionsConversationRelay(voice="es-MX-Neural2-A")`` on this call
     overrides only ``voice``; ``language``, ``interruptible``, etc. from the
     channel config still apply.
 
@@ -201,9 +201,10 @@ class InitiateVoiceConversationOptions(BaseModel):
         "``voice_websocket_path``. Pass it here only to override the URL "
         "for a specific call.",
     )
-    twiml_options: TwiMLOptions | None = Field(
+    twiml_options: VoiceTwiMLOptions | None = Field(
         default=None,
-        description="Per-call overrides for the TwiML inside <ConversationRelay>. "
+        description="Per-call overrides for the outbound TwiML — a "
+        "VoiceTwiMLOptionsConversationRelay for the default ConversationRelay provider. "
         "Merged over VoiceChannelConfig.default_twiml_options and TAC defaults.",
     )
     call_options: CallOptions | None = Field(

--- a/src/tac/models/voice.py
+++ b/src/tac/models/voice.py
@@ -271,7 +271,13 @@ class VoiceTwiMLOptions(BaseModel):
     future subclass for ``<Stream>``), so ``VoiceProvider.handle_incoming_call``'s
     ``host_twiml_options`` is typed against this base rather than a specific
     provider's options.
+
+    Rejects unknown fields (inherited by subclasses) — this base has none of
+    its own, so a dict passed where a ``VoiceTwiMLOptions`` is expected would
+    otherwise silently validate into an empty instance.
     """
+
+    model_config = {"extra": "forbid"}
 
 
 class VoiceTwiMLOptionsConversationRelay(VoiceTwiMLOptions):

--- a/src/tac/models/voice.py
+++ b/src/tac/models/voice.py
@@ -263,7 +263,18 @@ class LanguageConfig(BaseModel):
     model_config = {"populate_by_name": True}
 
 
-class TwiMLOptions(BaseModel):
+class VoiceTwiMLOptions(BaseModel):
+    """Base for a ``VoiceProvider``'s inbound-call TwiML customization options.
+
+    Each provider answers the inbound-call webhook with its own TwiML shape
+    (``VoiceTwiMLOptionsConversationRelay`` for ``<ConversationRelay>``, a
+    future subclass for ``<Stream>``), so ``VoiceProvider.handle_incoming_call``'s
+    ``host_twiml_options`` is typed against this base rather than a specific
+    provider's options.
+    """
+
+
+class VoiceTwiMLOptionsConversationRelay(VoiceTwiMLOptions):
     """Options for the TwiML inside ``<ConversationRelay>`` (plus the
     ``<Connect action>`` URL).
 
@@ -447,7 +458,7 @@ class TwiMLOptions(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def _reject_extra_shadowing_typed_fields(self) -> "TwiMLOptions":
+    def _reject_extra_shadowing_typed_fields(self) -> "VoiceTwiMLOptionsConversationRelay":
         """Fail fast when ``extra`` includes a key that has a typed field on
         this model. Without this, the user's value would be silently dropped
         by the TwiML serializer in favor of the typed default — a footgun.
@@ -458,10 +469,15 @@ class TwiMLOptions(BaseModel):
         shadowed = sorted(k for k in self.extra if k in typed)
         if shadowed:
             raise ValueError(
-                f"TwiMLOptions.extra keys {shadowed} shadow typed fields. "
+                f"VoiceTwiMLOptionsConversationRelay.extra keys {shadowed} shadow typed fields. "
                 "Set the typed field directly instead of using ``extra``."
             )
         return self
+
+
+# TwiMLOptions is this same class under its pre-Media-Streams name — not a
+# separate model, so this alias is the only place the two names diverge.
+TwiMLOptions = VoiceTwiMLOptionsConversationRelay
 
 
 class TwiMLRequest(BaseModel):

--- a/tests/test_outbound.py
+++ b/tests/test_outbound.py
@@ -802,6 +802,17 @@ class TestInitiateVoiceConversationOptionsForbidsExtra:
         with pytest.raises(ValidationError, match="custom_parameters"):
             InitiateVoiceConversationOptions(to="+15551234567", custom_parameters={"k": "v"})  # type: ignore[call-arg]
 
+    def test_twiml_options_dict_raises_instead_of_silently_dropping(self) -> None:
+        """twiml_options is typed against the VoiceTwiMLOptions base, which has
+        no fields of its own and forbids extras — so a dict raises instead of
+        silently validating into an empty VoiceTwiMLOptions()."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="welcome_greeting"):
+            InitiateVoiceConversationOptions(
+                to="+15551234567", twiml_options={"welcome_greeting": "Hi!"}
+            )
+
 
 # =============================================================================
 # isOwnMessage 2-tier

--- a/tests/test_outbound.py
+++ b/tests/test_outbound.py
@@ -1021,6 +1021,32 @@ class TestVoiceOutboundErrors:
             )
 
     @pytest.mark.asyncio
+    async def test_twiml_options_wrong_type_raises(self) -> None:
+        """twiml_options is typed against the VoiceTwiMLOptions base, but
+        ConversationRelayProvider needs the concrete
+        VoiceTwiMLOptionsConversationRelay to build TwiML."""
+        from tac.models.voice import VoiceTwiMLOptions
+
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+
+        mock_client = MagicMock()
+
+        with (
+            patch.object(channel, "_get_twilio_client", return_value=mock_client),
+            pytest.raises(TypeError, match="VoiceTwiMLOptionsConversationRelay"),
+        ):
+            await channel.initiate_outbound_conversation(
+                InitiateVoiceConversationOptions(
+                    to="+15559876543",
+                    websocket_url="wss://example.com/ws",
+                    twiml_options=VoiceTwiMLOptions(),
+                )
+            )
+
+        mock_client.calls.create.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_custom_parameters_in_twiml(self) -> None:
         from tac.models.voice import TwiMLOptions
 

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -1769,6 +1769,37 @@ class TestHandleIncomingCallMerge:
         assert 'welcomeGreeting="Channel default"' in twiml
         assert "Host override" not in twiml
 
+    @pytest.mark.asyncio
+    async def test_host_twiml_options_wrong_type_raises(self) -> None:
+        """host_twiml_options is typed against the VoiceTwiMLOptions base (any
+        provider's options satisfy the type), but ConversationRelayProvider
+        needs the concrete VoiceTwiMLOptionsConversationRelay to build TwiML —
+        a base instance (or another provider's options) must be rejected."""
+        from tac.models.voice import VoiceTwiMLOptions
+
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+
+        with pytest.raises(TypeError, match="VoiceTwiMLOptionsConversationRelay"):
+            await channel.handle_incoming_call(host_twiml_options=VoiceTwiMLOptions())
+
+    @pytest.mark.asyncio
+    async def test_on_inbound_call_twiml_customizer_wrong_return_type_raises(self) -> None:
+        """The on_inbound_call_twiml customizer is typed to return the
+        VoiceTwiMLOptions base, but ConversationRelayProvider needs the
+        concrete VoiceTwiMLOptionsConversationRelay to build TwiML."""
+        from tac.models.voice import TwiMLRequest, VoiceTwiMLOptions
+
+        async def wrong_type_customizer(req: TwiMLRequest) -> VoiceTwiMLOptions:
+            return VoiceTwiMLOptions()
+
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        channel.on_inbound_call_twiml(wrong_type_customizer)
+
+        with pytest.raises(TypeError, match="VoiceTwiMLOptionsConversationRelay"):
+            await channel.handle_incoming_call(twiml_request=TwiMLRequest())
+
 
 class TestStaticTwiMLOptions:
     """VoiceChannelConfig.twiml_options applies to every call without a callback."""


### PR DESCRIPTION
## Summary

`TwiMLOptions` models `<ConversationRelay>`-specific attributes, but several provider-neutral surfaces (`VoiceProvider.handle_incoming_call`, `VoiceChannel`'s handler type aliases, `InitiateVoiceConversationOptions.twiml_options`) were typed directly against it — leaking a CR-specific type into interfaces meant to host future providers (e.g. Media Streams).

- Adds `VoiceTwiMLOptions`, an empty base for a provider's TwiML options.
- Renames the concrete class to `VoiceTwiMLOptionsConversationRelay(VoiceTwiMLOptions)`; `TwiMLOptions` is kept as a back-compat alias (same pattern as `VoiceChannelConfig` / `ConversationRelayProviderConfig`).
- Widens every provider-neutral surface to the `VoiceTwiMLOptions` base:
  - `VoiceProvider.handle_incoming_call`'s `host_twiml_options`
  - `InboundCallTwiMLHandler` (the `on_inbound_call_twiml` customizer's return type)
  - `InitiateVoiceConversationOptions.twiml_options`
  - `ConversationRelayProvider`'s overrides widen to match (required for LSP — mypy strict flags a narrower override param type) and do a runtime `isinstance` check before narrowing to the concrete type they actually build TwiML with. Added tests for all three of these checks (none existed before).
- `twiml.py` (`generate_twiml`, `TwiMLBuilderConversationRelay`) and `config.py` (`ConversationRelayProviderConfig`) updated to reference the real name throughout, since they're entirely ConversationRelay-specific.
- Moved the four `Callable` handler type aliases (`InboundCallTwiMLHandler`, `CallStatusHandler`, `AmdHandler`, `RecordingHandler`) from `config.py` to `channel.py` — the only place that actually uses them; `config.py` had no use for them itself.
- `VoiceChannel.__init__`'s `config: dict` shorthand is explicitly documented as `VoiceChannelConfig`-only (not a generic provider-config constructor) — considered dropping it for a cleaner multi-provider story, but that's a breaking change (would require a 3.0.0 bump), so kept as-is for now with the limitation spelled out.

No behavior change for existing callers — `TwiMLOptions` still works everywhere it's used today.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated (879 passed, including 3 new tests for the runtime type-boundary checks this introduced)
- [x] Documentation updated (docstrings)
- [x] Tested E2E (manual call against local server + ngrok tunnel, twice)

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [x] Change is Python-specific (no TypeScript update needed)