### PR TITLE
feat(voice): add OpenAIRealtimeProvider (Twilio Media Streams <-> OpenAI Realtime)

### DIFF
--- a/getting_started/examples/features/s2s/media_stream_openai_realtime.py
+++ b/getting_started/examples/features/s2s/media_stream_openai_realtime.py
@@ -25,8 +25,8 @@ Env vars required:
 - TWILIO_VOICE_PUBLIC_DOMAIN (your ngrok domain or similar)
 - OPENAI_API_KEY
 
-Install the extra dependency this example needs:
-    pip install "tac[openai-realtime]"
+Install the extra dependencies this example needs:
+    pip install "tac[server,openai-realtime]"
 
 Usage:
     python media_stream_openai_realtime.py                    # inbound only
@@ -42,10 +42,10 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 
 from tac import TAC, TACConfig
-from tac.channels.voice import (
+from tac.channels.voice import VoiceChannel
+from tac.channels.voice.media_streams.openai_realtime import (
     TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
     OpenAIRealtimeProviderConfig,
-    VoiceChannel,
 )
 from tac.models.outbound import InitiateVoiceConversationOptions
 from tac.models.session import ConversationSession

--- a/getting_started/examples/features/s2s/media_stream_openai_realtime.py
+++ b/getting_started/examples/features/s2s/media_stream_openai_realtime.py
@@ -1,0 +1,127 @@
+"""
+Example (POC): OpenAI Realtime API voice calls via Twilio Media Streams.
+
+Twilio streams call audio to our own WebSocket, and this provider relays it
+to/from the OpenAI Realtime WebSocket. The session config (model, voice, turn
+detection, instructions) is static, set once on the provider's config.
+
+Unlike the ConversationRelay examples, this runs in relay-only mode
+regardless of TAC's Conversation Orchestrator configuration — there's no
+profile lookup or CO conversation for a Media Streams call.
+
+One-time account setup:
+
+1. Twilio Console:
+   - Buy (or use an existing) Voice-capable phone number.
+   - Point its Voice webhook at your public tunnel + TACServerConfig.twiml_path
+     (default /twiml). No SIP Trunk needed — just a normal Voice URL.
+
+2. Run this script behind a public tunnel (e.g. `ngrok http 8000`) so Twilio
+   can reach both the TwiML endpoint and the Media Stream WebSocket.
+
+Env vars required:
+- TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_API_KEY, TWILIO_API_SECRET
+- TWILIO_PHONE_NUMBER
+- TWILIO_VOICE_PUBLIC_DOMAIN (your ngrok domain or similar)
+- OPENAI_API_KEY
+
+Install the extra dependency this example needs:
+    pip install "tac[openai-realtime]"
+
+Usage:
+    python media_stream_openai_realtime.py                    # inbound only
+    python media_stream_openai_realtime.py --to +16505551234  # also place an outbound call
+"""
+
+import argparse
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from dotenv import load_dotenv
+from fastapi import FastAPI
+
+from tac import TAC, TACConfig
+from tac.channels.voice import (
+    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    OpenAIRealtimeProviderConfig,
+    VoiceChannel,
+)
+from tac.models.outbound import InitiateVoiceConversationOptions
+from tac.models.session import ConversationSession
+from tac.server import TACFastAPIServer
+from tac.tools import function_tool
+
+load_dotenv()
+
+tac = TAC(config=TACConfig.from_env())
+
+
+@function_tool()
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    return f"It's sunny and 72F in {city}."
+
+
+SESSION_CONFIG = {
+    "type": "realtime",
+    "model": "gpt-realtime-2.1",
+    "output_modalities": ["audio"],
+    "instructions": (
+        "You are a warm, friendly voice assistant speaking with a caller over the phone. "
+        "Keep responses short — a sentence or two per turn. No markdown, emojis, or bullet "
+        "lists; your words will be spoken aloud."
+    ),
+    "audio": {
+        "input": {
+            "format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+            "turn_detection": {"type": "semantic_vad", "eagerness": "high"},
+            "transcription": {"model": "gpt-live-transcribe"},
+        },
+        "output": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT, "voice": "marin"},
+    },
+    "tools": [get_weather.to_realtime_format()],
+    "tool_choice": "auto",
+}
+
+voice_channel = VoiceChannel(
+    tac,
+    config=OpenAIRealtimeProviderConfig(
+        tools=[get_weather],
+        welcome_greeting_response={"instructions": "Hello! How can I help you today?"},
+        session_config=SESSION_CONFIG,
+    ),
+)
+
+
+@tac.on_conversation_ended
+async def handle_conversation_ended(context: ConversationSession) -> None:
+    """Print the full transcript once the Media Stream WebSocket closes."""
+    transcript = context.metadata.get("transcript", [])
+    print(f"Call {context.conversation_id} ended. Transcript:")
+    for turn in transcript:
+        print(f"  {turn['role']}: {turn['text']}")
+
+
+async def place_outbound_call(to: str) -> None:
+    result = await voice_channel.initiate_outbound_conversation(
+        InitiateVoiceConversationOptions(to=to)
+    )
+    print(f"Call placed to {to} (SID: {result.call_sid})")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="OpenAI Realtime voice example")
+    parser.add_argument("--to", help="Destination phone number to call, e.g. +16505551234")
+    args = parser.parse_args()
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        if args.to:
+            asyncio.create_task(place_outbound_call(args.to))
+        yield
+
+    app = FastAPI(title="TAC OpenAI Realtime Example", lifespan=lifespan)
+
+    server = TACFastAPIServer(tac=tac, voice_channel=voice_channel, app=app)
+    server.start()

--- a/getting_started/examples/partners/openai_realtime.py
+++ b/getting_started/examples/partners/openai_realtime.py
@@ -1,5 +1,5 @@
 """
-Example (POC): OpenAI Realtime API voice calls via Twilio Media Streams.
+Example: OpenAI Realtime API voice calls via Twilio Media Streams.
 
 Twilio streams call audio to our own WebSocket, and this provider relays it
 to/from the OpenAI Realtime WebSocket. ``default_session_config`` applies to

--- a/getting_started/examples/partners/openai_realtime.py
+++ b/getting_started/examples/partners/openai_realtime.py
@@ -2,8 +2,10 @@
 Example (POC): OpenAI Realtime API voice calls via Twilio Media Streams.
 
 Twilio streams call audio to our own WebSocket, and this provider relays it
-to/from the OpenAI Realtime WebSocket. The session config (model, voice, turn
-detection, instructions) is static, set once on the provider's config.
+to/from the OpenAI Realtime WebSocket. ``default_session_config`` applies to
+every call unless overridden — per inbound call via
+``on_inbound_call_session_config``, or per outbound call via
+``InitiateVoiceConversationOptionsOpenAIRealtime``.
 
 Unlike the ConversationRelay examples, this runs in relay-only mode
 regardless of TAC's Conversation Orchestrator configuration — there's no
@@ -29,14 +31,15 @@ Install the extra dependencies this example needs:
     pip install "tac[server,openai-realtime]"
 
 Usage:
-    python media_stream_openai_realtime.py                    # inbound only
-    python media_stream_openai_realtime.py --to +16505551234  # also place an outbound call
+    python openai_realtime.py                    # inbound only
+    python openai_realtime.py --to +16505551234   # also place an outbound call
 """
 
 import argparse
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
@@ -47,8 +50,9 @@ from tac.channels.voice.media_streams.openai_realtime import (
     TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
     OpenAIRealtimeProviderConfig,
 )
-from tac.models.outbound import InitiateVoiceConversationOptions
+from tac.models.outbound import InitiateVoiceConversationOptionsOpenAIRealtime
 from tac.models.session import ConversationSession
+from tac.models.voice import TwiMLRequest
 from tac.server import TACFastAPIServer
 from tac.tools import function_tool
 
@@ -63,7 +67,7 @@ def get_weather(city: str) -> str:
     return f"It's sunny and 72F in {city}."
 
 
-SESSION_CONFIG = {
+DEFAULT_SESSION_CONFIG = {
     "type": "realtime",
     "model": "gpt-realtime-2.1",
     "output_modalities": ["audio"],
@@ -84,12 +88,24 @@ SESSION_CONFIG = {
     "tool_choice": "auto",
 }
 
+
+async def customize_session_config(req: TwiMLRequest) -> dict[str, Any] | None:
+    """Per-call override for inbound calls. None falls back to DEFAULT_SESSION_CONFIG."""
+    if req.caller_country == "US":
+        return {
+            **DEFAULT_SESSION_CONFIG,
+            "instructions": "你是一个友好的语音助手。请用中文回答。",
+        }
+    return None
+
+
 voice_channel = VoiceChannel(
     tac,
     config=OpenAIRealtimeProviderConfig(
         tools=[get_weather],
         welcome_greeting_response={"instructions": "Hello! How can I help you today?"},
-        session_config=SESSION_CONFIG,
+        default_session_config=DEFAULT_SESSION_CONFIG,
+        on_inbound_call_session_config=customize_session_config,
     ),
 )
 
@@ -104,8 +120,16 @@ async def handle_conversation_ended(context: ConversationSession) -> None:
 
 
 async def place_outbound_call(to: str) -> None:
+    """Per-outbound-call session_config override — a direct value, since
+    outbound has no webhook to hang a customizer off of."""
     result = await voice_channel.initiate_outbound_conversation(
-        InitiateVoiceConversationOptions(to=to)
+        InitiateVoiceConversationOptionsOpenAIRealtime(
+            to=to,
+            session_config={
+                **DEFAULT_SESSION_CONFIG,
+                "instructions": "Tu es un assistant vocal amical. Réponds en français.",
+            },
+        )
     )
     print(f"Call placed to {to} (SID: {result.call_sid})")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ server = [
     "python-multipart>=0.0.20,<1",
 ]
 openai-realtime = [
-    "websockets>=13,<17",
+    "websockets>=14,<17",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ server = [
     "uvicorn[standard]>=0.32.0,<1",
     "python-multipart>=0.0.20,<1",
 ]
+openai-realtime = [
+    "websockets>=13,<17",
+]
 
 [dependency-groups]
 dev = [

--- a/src/tac/channels/voice/__init__.py
+++ b/src/tac/channels/voice/__init__.py
@@ -9,6 +9,12 @@ from tac.channels.voice.channel import (
 )
 from tac.channels.voice.config import ConversationRelayProviderConfig, VoiceChannelConfig
 from tac.channels.voice.conversation_relay import ConversationRelayProvider
+from tac.channels.voice.media_streams.openai_realtime import (
+    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    OpenAIRealtimeProvider,
+    OpenAIRealtimeProviderConfig,
+    VoiceTwiMLOptionsMediaStreams,
+)
 from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
 from tac.channels.voice.twiml import generate_twiml
 from tac.models.outbound import CallOptions
@@ -35,8 +41,11 @@ __all__ = [
     "InboundCallTwiMLHandler",
     "InterruptMode",
     "LanguageConfig",
+    "OpenAIRealtimeProvider",
+    "OpenAIRealtimeProviderConfig",
     "RecordingEvent",
     "RecordingHandler",
+    "TWILIO_MEDIA_STREAM_AUDIO_FORMAT",
     "TwiMLOptions",
     "TwiMLRequest",
     "VoiceChannel",
@@ -45,5 +54,6 @@ __all__ = [
     "VoiceProviderConfig",
     "VoiceTwiMLOptions",
     "VoiceTwiMLOptionsConversationRelay",
+    "VoiceTwiMLOptionsMediaStreams",
     "generate_twiml",
 ]

--- a/src/tac/channels/voice/__init__.py
+++ b/src/tac/channels/voice/__init__.py
@@ -1,4 +1,9 @@
-"""Voice channel for handling voice-based conversations."""
+"""Voice channel for handling voice-based conversations.
+
+``OpenAIRealtimeProvider`` needs the optional ``websockets`` dependency, so
+import it from ``tac.channels.voice.media_streams.openai_realtime`` instead
+of from here.
+"""
 
 from tac.channels.voice.channel import (
     AmdHandler,
@@ -9,12 +14,6 @@ from tac.channels.voice.channel import (
 )
 from tac.channels.voice.config import ConversationRelayProviderConfig, VoiceChannelConfig
 from tac.channels.voice.conversation_relay import ConversationRelayProvider
-from tac.channels.voice.media_streams.openai_realtime import (
-    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
-    OpenAIRealtimeProvider,
-    OpenAIRealtimeProviderConfig,
-    VoiceTwiMLOptionsMediaStreams,
-)
 from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
 from tac.channels.voice.twiml import generate_twiml
 from tac.models.outbound import CallOptions
@@ -41,11 +40,8 @@ __all__ = [
     "InboundCallTwiMLHandler",
     "InterruptMode",
     "LanguageConfig",
-    "OpenAIRealtimeProvider",
-    "OpenAIRealtimeProviderConfig",
     "RecordingEvent",
     "RecordingHandler",
-    "TWILIO_MEDIA_STREAM_AUDIO_FORMAT",
     "TwiMLOptions",
     "TwiMLRequest",
     "VoiceChannel",
@@ -54,6 +50,5 @@ __all__ = [
     "VoiceProviderConfig",
     "VoiceTwiMLOptions",
     "VoiceTwiMLOptionsConversationRelay",
-    "VoiceTwiMLOptionsMediaStreams",
     "generate_twiml",
 ]

--- a/src/tac/channels/voice/media_streams/__init__.py
+++ b/src/tac/channels/voice/media_streams/__init__.py
@@ -1,0 +1,3 @@
+"""Voice providers bridging Twilio Media Streams (``<Connect><Stream>``) to a
+speech-to-speech model. ``openai_realtime`` is the first implementation.
+"""

--- a/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
@@ -1,0 +1,21 @@
+"""``OpenAIRealtimeProvider``: bridges Twilio Media Streams to OpenAI's Realtime API."""
+
+from tac.channels.voice.media_streams.openai_realtime.config import (
+    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    OpenAIRealtimeProviderConfig,
+)
+from tac.channels.voice.media_streams.openai_realtime.provider import OpenAIRealtimeProvider
+from tac.channels.voice.media_streams.openai_realtime.twiml import (
+    VoiceTwiMLOptionsMediaStreams,
+    generate_twiml,
+)
+from tac.models.stream import StreamStartMessage
+
+__all__ = [
+    "TWILIO_MEDIA_STREAM_AUDIO_FORMAT",
+    "OpenAIRealtimeProvider",
+    "OpenAIRealtimeProviderConfig",
+    "StreamStartMessage",
+    "VoiceTwiMLOptionsMediaStreams",
+    "generate_twiml",
+]

--- a/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
@@ -1,10 +1,10 @@
 """``OpenAIRealtimeProvider``: bridges Twilio Media Streams to OpenAI's Realtime API."""
 
-from tac.channels.voice.media_streams.openai_realtime.config import (
+from tac.channels.voice.media_streams.openai_realtime.config import OpenAIRealtimeProviderConfig
+from tac.channels.voice.media_streams.openai_realtime.provider import (
     TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
-    OpenAIRealtimeProviderConfig,
+    OpenAIRealtimeProvider,
 )
-from tac.channels.voice.media_streams.openai_realtime.provider import OpenAIRealtimeProvider
 from tac.channels.voice.media_streams.openai_realtime.twiml import (
     VoiceTwiMLOptionsMediaStreams,
     generate_twiml,

--- a/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
@@ -9,10 +9,12 @@ from tac.channels.voice.media_streams.openai_realtime.twiml import (
     VoiceTwiMLOptionsMediaStreams,
     generate_twiml,
 )
+from tac.models.outbound import InitiateVoiceConversationOptionsOpenAIRealtime
 from tac.models.stream import StreamStartMessage
 
 __all__ = [
     "TWILIO_MEDIA_STREAM_AUDIO_FORMAT",
+    "InitiateVoiceConversationOptionsOpenAIRealtime",
     "OpenAIRealtimeProvider",
     "OpenAIRealtimeProviderConfig",
     "StreamStartMessage",

--- a/src/tac/channels/voice/media_streams/openai_realtime/config.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/config.py
@@ -35,7 +35,11 @@ class OpenAIRealtimeProviderConfig(VoiceProviderConfig):
     )
     tools: list[TACTool] = Field(
         default_factory=list,
-        description="TACTool functions the model can call mid-call.",
+        description=(
+            "Executable TACTool implementations, looked up by name to run mid-call tool "
+            "requests. This alone does not tell the model these tools exist — also add each "
+            "tool's `to_realtime_format()` schema to `session_config['tools']`."
+        ),
     )
     welcome_greeting_response: dict[str, Any] | None = Field(
         default=None,
@@ -47,7 +51,9 @@ class OpenAIRealtimeProviderConfig(VoiceProviderConfig):
         ...,
         description="The session.update payload's 'session' body, sent once the "
         "model connects. See https://developers.openai.com/api/reference/resources/"
-        "realtime/client-events#session.update for the schema.",
+        "realtime/client-events#session.update for the schema. If using `tools`, its "
+        "'tools' entry must separately list each tool's `to_realtime_format()` schema — "
+        "this config is passed to OpenAI as-is, with no tool schemas merged in.",
     )
     default_twiml_options: VoiceTwiMLOptionsMediaStreams | None = Field(
         default=None,

--- a/src/tac/channels/voice/media_streams/openai_realtime/config.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/config.py
@@ -17,13 +17,6 @@ from tac.tools import TACTool
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
 
-#: Twilio Media Streams always sends 8kHz G.711 u-law audio — this is a fact
-#: about Twilio's stream, not a provider choice, so ``default_session_config``
-#: should use this same audio format for both input and output. No ``rate`` field —
-#: OpenAI's Realtime ``session.audio.*.format`` schema rejects it as an
-#: unknown parameter (g711 is inherently fixed-rate, so it isn't settable).
-TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu"}
-
 
 class OpenAIRealtimeProviderConfig(VoiceProviderConfig):
     """Configuration for ``OpenAIRealtimeProvider``."""

--- a/src/tac/channels/voice/media_streams/openai_realtime/config.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/config.py
@@ -3,22 +3,23 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from tac.channels.voice.media_streams.openai_realtime.provider import OpenAIRealtimeProvider
 from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
 from tac.core.config import TACConfig
-from tac.models.voice import VoiceTwiMLOptionsMediaStreams
+from tac.models.voice import TwiMLRequest, VoiceTwiMLOptionsMediaStreams
 from tac.tools import TACTool
 
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
 
 #: Twilio Media Streams always sends 8kHz G.711 u-law audio — this is a fact
-#: about Twilio's stream, not a provider choice, so ``session_config`` should
-#: use this same audio format for both input and output. No ``rate`` field —
+#: about Twilio's stream, not a provider choice, so ``default_session_config``
+#: should use this same audio format for both input and output. No ``rate`` field —
 #: OpenAI's Realtime ``session.audio.*.format`` schema rejects it as an
 #: unknown parameter (g711 is inherently fixed-rate, so it isn't settable).
 TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu"}
@@ -38,7 +39,7 @@ class OpenAIRealtimeProviderConfig(VoiceProviderConfig):
         description=(
             "Executable TACTool implementations, looked up by name to run mid-call tool "
             "requests. This alone does not tell the model these tools exist — also add each "
-            "tool's `to_realtime_format()` schema to `session_config['tools']`."
+            "tool's `to_realtime_format()` schema to `default_session_config['tools']`."
         ),
     )
     welcome_greeting_response: dict[str, Any] | None = Field(
@@ -47,13 +48,15 @@ class OpenAIRealtimeProviderConfig(VoiceProviderConfig):
         "when the call connects — e.g. {'instructions': 'Hi there!'}. No SDK-added "
         "wrapping text or language assumption.",
     )
-    session_config: dict[str, Any] = Field(
-        ...,
-        description="The session.update payload's 'session' body, sent once the "
-        "model connects. See https://developers.openai.com/api/reference/resources/"
-        "realtime/client-events#session.update for the schema. If using `tools`, its "
-        "'tools' entry must separately list each tool's `to_realtime_format()` schema — "
-        "this config is passed to OpenAI as-is, with no tool schemas merged in.",
+    default_session_config: dict[str, Any] | None = Field(
+        default=None,
+        description="The session.update payload's 'session' body, sent once the model "
+        "connects — used for any call that doesn't supply its own via "
+        "`on_inbound_call_session_config` or `InitiateVoiceConversationOptionsOpenAIRealtime`. "
+        "See https://developers.openai.com/api/reference/resources/realtime/"
+        "client-events#session.update for the schema. If using `tools`, its 'tools' entry "
+        "must separately list each tool's `to_realtime_format()` schema — this config is "
+        "passed to OpenAI as-is, with no tool schemas merged in.",
     )
     default_twiml_options: VoiceTwiMLOptionsMediaStreams | None = Field(
         default=None,
@@ -61,6 +64,24 @@ class OpenAIRealtimeProviderConfig(VoiceProviderConfig):
         "Per-call customization is registered via VoiceChannel.on_inbound_call_twiml(...), "
         "which takes precedence over this.",
     )
+    on_inbound_call_session_config: (
+        Callable[[TwiMLRequest], Awaitable[dict[str, Any] | None]] | None
+    ) = Field(
+        default=None,
+        description="Per-inbound-call override for `default_session_config`, called with the "
+        "TwiMLRequest. Its return value is used verbatim (not merged with "
+        "`default_session_config`); return None to fall back to it. Outbound calls don't use "
+        "this — see `InitiateVoiceConversationOptionsOpenAIRealtime`.",
+    )
+
+    @model_validator(mode="after")
+    def _validate(self) -> OpenAIRealtimeProviderConfig:
+        if not self.openai_api_key:
+            raise ValueError(
+                "openai_api_key is required. Set the OPENAI_API_KEY environment "
+                "variable or provide openai_api_key in OpenAIRealtimeProviderConfig."
+            )
+        return self
 
     def create_provider(self, channel: VoiceChannel, tac_config: TACConfig) -> VoiceProvider:
         return OpenAIRealtimeProvider(channel, tac_config, self)

--- a/src/tac/channels/voice/media_streams/openai_realtime/config.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/config.py
@@ -1,0 +1,60 @@
+"""``OpenAIRealtimeProvider`` configuration."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from pydantic import Field
+
+from tac.channels.voice.media_streams.openai_realtime.provider import OpenAIRealtimeProvider
+from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
+from tac.core.config import TACConfig
+from tac.models.voice import VoiceTwiMLOptionsMediaStreams
+from tac.tools import TACTool
+
+if TYPE_CHECKING:
+    from tac.channels.voice.channel import VoiceChannel
+
+#: Twilio Media Streams always sends 8kHz G.711 u-law audio — this is a fact
+#: about Twilio's stream, not a provider choice, so ``session_config`` should
+#: use this same audio format for both input and output. No ``rate`` field —
+#: OpenAI's Realtime ``session.audio.*.format`` schema rejects it as an
+#: unknown parameter (g711 is inherently fixed-rate, so it isn't settable).
+TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu"}
+
+
+class OpenAIRealtimeProviderConfig(VoiceProviderConfig):
+    """Configuration for ``OpenAIRealtimeProvider``."""
+
+    model_config = {"extra": "forbid", "arbitrary_types_allowed": True}
+
+    openai_api_key: str | None = Field(
+        default_factory=lambda: os.environ.get("OPENAI_API_KEY"),
+        description="OpenAI API key. Defaults to the OPENAI_API_KEY environment variable.",
+    )
+    tools: list[TACTool] = Field(
+        default_factory=list,
+        description="TACTool functions the model can call mid-call.",
+    )
+    welcome_greeting_response: dict[str, Any] | None = Field(
+        default=None,
+        description="If set, sent verbatim as response.create's 'response' payload "
+        "when the call connects — e.g. {'instructions': 'Hi there!'}. No SDK-added "
+        "wrapping text or language assumption.",
+    )
+    session_config: dict[str, Any] = Field(
+        ...,
+        description="The session.update payload's 'session' body, sent once the "
+        "model connects. See https://developers.openai.com/api/reference/resources/"
+        "realtime/client-events#session.update for the schema.",
+    )
+    default_twiml_options: VoiceTwiMLOptionsMediaStreams | None = Field(
+        default=None,
+        description="Static VoiceTwiMLOptionsMediaStreams applied to every inbound call. "
+        "Per-call customization is registered via VoiceChannel.on_inbound_call_twiml(...), "
+        "which takes precedence over this.",
+    )
+
+    def create_provider(self, channel: VoiceChannel, tac_config: TACConfig) -> VoiceProvider:
+        return OpenAIRealtimeProvider(channel, tac_config, self)

--- a/src/tac/channels/voice/media_streams/openai_realtime/models.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/models.py
@@ -1,0 +1,49 @@
+"""Per-call state for ``OpenAIRealtimeProvider``, not part of the public API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from tac.channels.websocket_protocol import WebSocketProtocol
+
+
+@dataclass
+class _BargeInState:
+    """Per-call barge-in bookkeeping.
+
+    ``current_item_audio_ms`` is the exact duration of audio actually sent
+    to Twilio for ``last_assistant_item``, computed from delta byte counts —
+    not a wall-clock estimate. ``conversation.item.truncate`` rejects an
+    ``audio_end_ms`` beyond the item's real content, so this must never
+    overstate it.
+
+    ``response_active`` tracks whether a response is still being generated
+    (set on ``response.created``, cleared on ``response.done`` or once
+    barge-in cancels it) — ``response.cancel`` with nothing in flight is
+    itself an error event, so this gates whether to send it.
+    """
+
+    last_assistant_item: str | None = None
+    current_item_audio_ms: int = 0
+    muted_item_id: str | None = None
+    response_active: bool = False
+
+
+@dataclass
+class _CallState:
+    """Per-call bookkeeping this provider needs beyond ``ConversationSession``.
+
+    Both legs of one call's audio bridge — the Twilio-facing socket and the
+    OpenAI Realtime socket — live here together, rather than in two parallel
+    dicts keyed by conversation id that could drift out of sync.
+
+    ``stream_sid`` and ``transcript`` live on ``ConversationSession.metadata``
+    instead, not here — this dict is popped before ``on_conversation_ended``
+    fires, so anything a handler needs to read after the call ends must
+    survive on the session, not in here.
+    """
+
+    twilio_ws: WebSocketProtocol | None = None
+    model_ws: Any = None
+    barge_in: _BargeInState = field(default_factory=_BargeInState)

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -30,6 +30,7 @@ from tac.core.config import CallEventKind, TACConfig
 from tac.models.outbound import (
     CallOptions,
     InitiateVoiceConversationOptions,
+    InitiateVoiceConversationOptionsOpenAIRealtime,
     InitiateVoiceConversationResult,
 )
 from tac.models.session import ConversationSession
@@ -56,7 +57,7 @@ class OpenAIRealtimeProvider(VoiceProvider):
 
     Example:
         ```python
-        channel = VoiceChannel(tac, config=OpenAIRealtimeProviderConfig(session_config=...))
+        channel = VoiceChannel(tac, config=OpenAIRealtimeProviderConfig(default_session_config=...))
         ```
     """
 
@@ -68,22 +69,13 @@ class OpenAIRealtimeProvider(VoiceProvider):
     ) -> None:
         super().__init__(channel)
 
-        if not config.openai_api_key:
-            raise ValueError(
-                "openai_api_key is required. Set the OPENAI_API_KEY environment "
-                "variable or provide openai_api_key in OpenAIRealtimeProviderConfig."
-            )
-        if not config.session_config.get("model"):
-            raise ValueError(
-                "session_config must include a 'model' field — it's used as the "
-                "?model= query param when opening the OpenAI Realtime WebSocket."
-            )
-
         self.config = config
         self.tac_config = tac_config
         self._tools_by_name: dict[str, TACTool] = {tool.name: tool for tool in config.tools}
         self._calls: dict[str, _CallState] = {}
         self._twiml = TwiMLBuilderMediaStreams(tac_config, config)
+        # Keyed by call_sid; set in handle_incoming_call, popped in _connect_model.
+        self._call_session_configs: dict[str, dict[str, Any]] = {}
 
     @property
     def channel_name(self) -> str:
@@ -120,6 +112,9 @@ class OpenAIRealtimeProvider(VoiceProvider):
           3. ``host_twiml_options`` — per-call transport facts supplied by the host.
           4. TAC defaults: the WebSocket URL derived from
              ``TACConfig.voice_public_domain`` + ``voice_websocket_path``.
+
+        Also runs ``on_inbound_call_session_config`` (if set) and stashes its
+        result for ``_connect_model`` to pick up once the call connects.
         """
         if host_twiml_options is not None and not isinstance(
             host_twiml_options, VoiceTwiMLOptionsMediaStreams
@@ -139,6 +134,15 @@ class OpenAIRealtimeProvider(VoiceProvider):
                     f"VoiceTwiMLOptionsMediaStreams, got {type(result).__name__}"
                 )
             customized = result
+
+        if (
+            self.config.on_inbound_call_session_config is not None
+            and twiml_request is not None
+            and twiml_request.call_sid is not None
+        ):
+            session_config = await self.config.on_inbound_call_session_config(twiml_request)
+            if session_config is not None:
+                self._call_session_configs[twiml_request.call_sid] = session_config
 
         return self._twiml.build(
             "handle_incoming_call", host=host_twiml_options, per_call=customized
@@ -182,6 +186,9 @@ class OpenAIRealtimeProvider(VoiceProvider):
         The WebSocket URL is derived from ``TACConfig.voice_public_domain`` +
         ``TACConfig.voice_websocket_path``, unless overridden per-call via
         ``options.websocket_url``.
+
+        Pass ``InitiateVoiceConversationOptionsOpenAIRealtime`` with
+        ``session_config`` set to override the default for this call.
         """
         twiml_options = options.twiml_options
         if twiml_options is not None and not isinstance(
@@ -226,6 +233,12 @@ class OpenAIRealtimeProvider(VoiceProvider):
                 call_sid=call.sid,
                 to=mask_phone(options.to),
             )
+
+            if (
+                isinstance(options, InitiateVoiceConversationOptionsOpenAIRealtime)
+                and options.session_config is not None
+            ):
+                self._call_session_configs[call.sid] = options.session_config
 
             return InitiateVoiceConversationResult(call_sid=call.sid)
 
@@ -323,9 +336,28 @@ class OpenAIRealtimeProvider(VoiceProvider):
         return conv_id
 
     async def _connect_model(self, conv_id: str) -> None:
-        """Open the OpenAI Realtime WebSocket and send the session config."""
+        """Open the OpenAI Realtime WebSocket and send the session config.
+
+        Uses this call's ``_call_session_configs`` entry if one was stashed
+        (by ``handle_incoming_call`` or ``initiate_outbound_conversation``),
+        else falls back to ``default_session_config``.
+        """
+        session_config = (
+            self._call_session_configs.pop(conv_id, None) or self.config.default_session_config
+        )
+        if session_config is None:
+            raise ValueError(
+                f"No session_config available for call {conv_id} — this call supplied none "
+                "and default_session_config isn't set either."
+            )
+        if not session_config.get("model"):
+            raise ValueError(
+                f"session_config for call {conv_id} must include a 'model' field — it's "
+                "used as the ?model= query param when opening the OpenAI Realtime WebSocket."
+            )
+
         model_ws = await websockets.connect(
-            f"wss://api.openai.com/v1/realtime?model={self.config.session_config['model']}",
+            f"wss://api.openai.com/v1/realtime?model={session_config['model']}",
             additional_headers={"Authorization": f"Bearer {self.config.openai_api_key}"},
         )
         call = self._calls.get(conv_id)
@@ -333,9 +365,7 @@ class OpenAIRealtimeProvider(VoiceProvider):
             call.model_ws = model_ws
         self.logger.info("Connected to OpenAI Realtime", conversation_id=conv_id)
 
-        await self._model_send(
-            conv_id, {"type": "session.update", "session": self.config.session_config}
-        )
+        await self._model_send(conv_id, {"type": "session.update", "session": session_config})
 
         # VAD waits for the caller to speak first; request a response to greet.
         response = self.config.welcome_greeting_response

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -14,6 +14,7 @@ import asyncio
 import base64
 import contextlib
 import json
+import uuid
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -37,7 +38,7 @@ from tac.models.session import ConversationSession
 from tac.models.stream import StreamStartMessage
 from tac.models.voice import TwiMLRequest, VoiceTwiMLOptions
 from tac.tools import TACTool
-from tac.utils.redaction import mask_phone
+from tac.utils.redaction import mask_phone, redact_twiml_parameters
 
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
@@ -46,10 +47,25 @@ if TYPE_CHECKING:
     )
 
 
+#: Twilio Media Streams always sends/expects 8kHz G.711 u-law audio — per
+#: https://www.twilio.com/docs/voice/media-streams/websocket-messages, this
+#: isn't a provider choice or a default, it's the only format Twilio's
+#: bidirectional Stream supports. No ``rate`` field — OpenAI's Realtime
+#: ``session.audio.*.format`` schema rejects it as unknown (g711 is
+#: inherently fixed-rate, so it isn't settable).
+TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu"}
+
 #: G.711 u-law at 8kHz is 1 byte/sample, 8000 samples/sec — a fixed,
 #: non-configurable rate, so audio byte count converts to milliseconds by
 #: this constant alone, regardless of session_config.
 _PCMU_BYTES_PER_MS = 8
+
+#: Reserved <Stream> custom_parameters key used to correlate an outbound
+#: call's session_config override to its WebSocket start event. calls.create()
+#: returning call.sid doesn't happen-before Twilio connecting the stream, so
+#: call.sid can't be the correlation key — this token, embedded in the TwiML
+#: before the call is placed, can.
+_SESSION_CONFIG_TOKEN_PARAM = "_tac_session_config_token"
 
 
 class OpenAIRealtimeProvider(VoiceProvider):
@@ -200,6 +216,30 @@ class OpenAIRealtimeProvider(VoiceProvider):
                 f"{type(twiml_options).__name__}"
             )
 
+        # A token embedded in the TwiML below correlates this override to its
+        # WebSocket start event — not call.sid, since Twilio connecting the
+        # stream doesn't happen-after calls.create() returning call.sid.
+        # Building the token/TwiML here doesn't touch _call_session_configs
+        # yet; that's deferred until right before the call is placed (below),
+        # so a failure in _twiml.build() has nothing to leak.
+        session_config = (
+            options.session_config
+            if isinstance(options, InitiateVoiceConversationOptionsOpenAIRealtime)
+            else None
+        )
+        session_config_token: str | None = None
+        if session_config is not None:
+            session_config_token = uuid.uuid4().hex
+            existing_params = (twiml_options.custom_parameters or {}) if twiml_options else {}
+            twiml_options = (twiml_options or VoiceTwiMLOptionsMediaStreams()).model_copy(
+                update={
+                    "custom_parameters": {
+                        **existing_params,
+                        _SESSION_CONFIG_TOKEN_PARAM: session_config_token,
+                    }
+                }
+            )
+
         from_number = self.channel.tac.config.phone_number
 
         self.logger.info(
@@ -216,8 +256,15 @@ class OpenAIRealtimeProvider(VoiceProvider):
 
         call_kwargs = self._build_call_kwargs(options.call_options)
 
+        if session_config_token is not None and session_config is not None:
+            self._call_session_configs[session_config_token] = session_config
+
         try:
-            self.logger.debug("Outbound call TwiML", twiml=twiml_xml, to=mask_phone(options.to))
+            self.logger.debug(
+                "Outbound call TwiML",
+                twiml=redact_twiml_parameters(twiml_xml),
+                to=mask_phone(options.to),
+            )
 
             client = self.channel._get_twilio_client()
             call = await asyncio.to_thread(
@@ -234,15 +281,11 @@ class OpenAIRealtimeProvider(VoiceProvider):
                 to=mask_phone(options.to),
             )
 
-            if (
-                isinstance(options, InitiateVoiceConversationOptionsOpenAIRealtime)
-                and options.session_config is not None
-            ):
-                self._call_session_configs[call.sid] = options.session_config
-
             return InitiateVoiceConversationResult(call_sid=call.sid)
 
         except Exception as e:
+            if session_config_token is not None:
+                self._call_session_configs.pop(session_config_token, None)
             self.logger.error(
                 "Failed to initiate outbound call",
                 to=mask_phone(options.to),
@@ -324,6 +367,12 @@ class OpenAIRealtimeProvider(VoiceProvider):
         message = StreamStartMessage(**start)
         conv_id = message.conversation_id
 
+        token = message.custom_parameters.get(_SESSION_CONFIG_TOKEN_PARAM)
+        if token is not None:
+            session_config = self._call_session_configs.pop(token, None)
+            if session_config is not None:
+                self._call_session_configs[conv_id] = session_config
+
         self._calls[conv_id] = _CallState(twilio_ws=websocket)
 
         session = self.channel._start_conversation(conv_id, profile_id=None)
@@ -342,9 +391,9 @@ class OpenAIRealtimeProvider(VoiceProvider):
         (by ``handle_incoming_call`` or ``initiate_outbound_conversation``),
         else falls back to ``default_session_config``.
         """
-        session_config = (
-            self._call_session_configs.pop(conv_id, None) or self.config.default_session_config
-        )
+        session_config = self._call_session_configs.pop(conv_id, None)
+        if session_config is None:
+            session_config = self.config.default_session_config
         if session_config is None:
             raise ValueError(
                 f"No session_config available for call {conv_id} — this call supplied none "
@@ -355,6 +404,15 @@ class OpenAIRealtimeProvider(VoiceProvider):
                 f"session_config for call {conv_id} must include a 'model' field — it's "
                 "used as the ?model= query param when opening the OpenAI Realtime WebSocket."
             )
+        for direction in ("input", "output"):
+            fmt = ((session_config.get("audio") or {}).get(direction) or {}).get("format")
+            if fmt != TWILIO_MEDIA_STREAM_AUDIO_FORMAT:
+                raise ValueError(
+                    f"session_config for call {conv_id} has audio.{direction}.format={fmt!r} — "
+                    f"Twilio Media Streams always sends/expects "
+                    f"{TWILIO_MEDIA_STREAM_AUDIO_FORMAT!r}, this isn't configurable. Set "
+                    f"audio.{direction}.format to TWILIO_MEDIA_STREAM_AUDIO_FORMAT."
+                )
 
         model_ws = await websockets.connect(
             f"wss://api.openai.com/v1/realtime?model={session_config['model']}",
@@ -529,9 +587,26 @@ class OpenAIRealtimeProvider(VoiceProvider):
         barge_in.current_item_audio_ms = 0
 
     async def _handle_function_call(self, conv_id: str, item: dict[str, Any]) -> None:
-        """Run a model-requested tool call and hand the result back."""
+        """Run a model-requested tool call and hand the result back.
+
+        Always sends a function_call_output — even a tool that ran
+        successfully can return a non-JSON-serializable object (a datetime,
+        a Pydantic model, ...), and the model would otherwise be left
+        waiting on a call_id it never gets a result for.
+        """
         call_id = item.get("call_id")
-        output = await self._run_tool_call(conv_id, item.get("name"), item.get("arguments"))
+        name = item.get("name")
+        output = await self._run_tool_call(conv_id, name, item.get("arguments"))
+        try:
+            output_json = json.dumps(output)
+        except TypeError as e:
+            self.logger.error(
+                f"Tool '{name}' returned a non-JSON-serializable result: {e}",
+                conversation_id=conv_id,
+            )
+            output_json = json.dumps(
+                {"error": f"Tool '{name}' returned a non-serializable result."}
+            )
 
         await self._model_send(
             conv_id,
@@ -540,7 +615,7 @@ class OpenAIRealtimeProvider(VoiceProvider):
                 "item": {
                     "type": "function_call_output",
                     "call_id": call_id,
-                    "output": json.dumps(output),
+                    "output": output_json,
                 },
             },
         )

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any
@@ -238,7 +239,13 @@ class OpenAIRealtimeProvider(VoiceProvider):
             raise
 
     async def handle_websocket(self, websocket: WebSocketProtocol) -> None:
-        """Drive one Twilio Media Stream connection from accept to disconnect."""
+        """Drive one Twilio Media Stream connection from accept to disconnect.
+
+        Races the Twilio read against the OpenAI model-event reader so that
+        if the model side disconnects first, we stop pumping caller audio
+        into a dead socket and tear the call down immediately instead of
+        leaving the caller connected to silence.
+        """
         await websocket.accept()
 
         conv_id: str | None = None
@@ -246,7 +253,23 @@ class OpenAIRealtimeProvider(VoiceProvider):
 
         try:
             while True:
-                data = await websocket.receive_json()
+                recv_task: asyncio.Task[dict[str, Any]] = asyncio.create_task(
+                    websocket.receive_json()
+                )
+                waiters: list[asyncio.Task[Any]] = [recv_task]
+                if model_reader is not None:
+                    waiters.append(model_reader)
+
+                done, _pending = await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
+
+                if model_reader is not None and model_reader in done:
+                    recv_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await recv_task
+                    self.logger.info("Model connection ended", conversation_id=conv_id)
+                    break
+
+                data = recv_task.result()
                 event = data.get("event")
 
                 if event == "start":
@@ -275,8 +298,11 @@ class OpenAIRealtimeProvider(VoiceProvider):
         except Exception as e:
             self.logger.error(f"Media stream WebSocket error: {e}", exc_info=True)
         finally:
-            if model_reader is not None:
+            if model_reader is not None and not model_reader.done():
                 model_reader.cancel()
+            if model_reader is not None:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await model_reader
             if conv_id is not None:
                 await self._cleanup_call(conv_id)
 
@@ -356,9 +382,19 @@ class OpenAIRealtimeProvider(VoiceProvider):
             return
 
         if event_type == "error":
-            self.logger.error(
-                "OpenAI Realtime error event", conversation_id=conv_id, error=event.get("error")
-            )
+            error = event.get("error") or {}
+            if error.get("code") == "response_cancel_not_active":
+                # Benign race: our response.cancel (sent while
+                # barge_in.response_active was true) lost to the model's own
+                # response.done arriving first. Nothing to cancel anymore,
+                # which is exactly what we wanted.
+                self.logger.debug(
+                    "response.cancel raced response.done", conversation_id=conv_id, error=error
+                )
+            else:
+                self.logger.error(
+                    "OpenAI Realtime error event", conversation_id=conv_id, error=error
+                )
 
         elif event_type == "input_audio_buffer.speech_started":
             self.logger.debug("Caller speech detected (VAD)", conversation_id=conv_id)

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -1,0 +1,544 @@
+"""``OpenAIRealtimeProvider``: bridges Twilio Media Streams to OpenAI's
+Realtime API.
+
+Twilio streams call audio to our own WebSocket via ``<Connect><Stream>``, and
+this provider relays it to/from a second WebSocket it opens to OpenAI's
+Realtime API. Session lifecycle is independent of Conversation Orchestrator —
+this provider always starts the local session with ``profile_id=None``, the
+same as ConversationRelay's relay-only mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections.abc import AsyncGenerator, Callable
+from typing import TYPE_CHECKING, Any
+
+import websockets
+
+from tac.channels.voice.media_streams.openai_realtime.models import _CallState
+from tac.channels.voice.media_streams.openai_realtime.twiml import (
+    TwiMLBuilderMediaStreams,
+    VoiceTwiMLOptionsMediaStreams,
+)
+from tac.channels.voice.provider import VoiceProvider
+from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
+from tac.core.config import CallEventKind, TACConfig
+from tac.models.outbound import (
+    CallOptions,
+    InitiateVoiceConversationOptions,
+    InitiateVoiceConversationResult,
+)
+from tac.models.session import ConversationSession
+from tac.models.stream import StreamStartMessage
+from tac.models.voice import TwiMLRequest, VoiceTwiMLOptions
+from tac.tools import TACTool
+from tac.utils.redaction import mask_phone
+
+if TYPE_CHECKING:
+    from tac.channels.voice.channel import VoiceChannel
+    from tac.channels.voice.media_streams.openai_realtime.config import (
+        OpenAIRealtimeProviderConfig,
+    )
+
+
+#: G.711 u-law at 8kHz is 1 byte/sample, 8000 samples/sec — a fixed,
+#: non-configurable rate, so audio byte count converts to milliseconds by
+#: this constant alone, regardless of session_config.
+_PCMU_BYTES_PER_MS = 8
+
+
+class OpenAIRealtimeProvider(VoiceProvider):
+    """``VoiceProvider`` bridging Twilio Media Streams to OpenAI Realtime.
+
+    Example:
+        ```python
+        channel = VoiceChannel(tac, config=OpenAIRealtimeProviderConfig(session_config=...))
+        ```
+    """
+
+    def __init__(
+        self,
+        channel: VoiceChannel,
+        tac_config: TACConfig,
+        config: OpenAIRealtimeProviderConfig,
+    ) -> None:
+        super().__init__(channel)
+
+        if not config.openai_api_key:
+            raise ValueError(
+                "openai_api_key is required. Set the OPENAI_API_KEY environment "
+                "variable or provide openai_api_key in OpenAIRealtimeProviderConfig."
+            )
+        if not config.session_config.get("model"):
+            raise ValueError(
+                "session_config must include a 'model' field — it's used as the "
+                "?model= query param when opening the OpenAI Realtime WebSocket."
+            )
+
+        self.config = config
+        self.tac_config = tac_config
+        self._tools_by_name: dict[str, TACTool] = {tool.name: tool for tool in config.tools}
+        self._calls: dict[str, _CallState] = {}
+        self._twiml = TwiMLBuilderMediaStreams(tac_config, config)
+
+    @property
+    def channel_name(self) -> str:
+        return "VOICE_MEDIA_STREAM_OPENAI_REALTIME"
+
+    def get_transcript(self, conversation_id: str) -> list[dict[str, str]]:
+        """Return the transcript captured so far for an in-progress call.
+
+        Lives on ``ConversationSession.metadata["transcript"]``, so once the
+        call ends (and the session is popped from ``channel._conversations``)
+        it's no longer reachable here — read it from the session an
+        ``on_conversation_ended`` handler receives instead.
+        """
+        session = self.channel._conversations.get(conversation_id)
+        return list(session.metadata.get("transcript", [])) if session else []
+
+    def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
+        call = self._calls.get(conversation_id)
+        return call.twilio_ws if call else None
+
+    async def handle_incoming_call(
+        self,
+        twiml_request: TwiMLRequest | None = None,
+        *,
+        host_twiml_options: VoiceTwiMLOptions | None = None,
+    ) -> str:
+        """Build the ``<Connect><Stream>`` TwiML for an inbound call.
+
+        TwiML fields are merged per-field, highest precedence first:
+          1. Output of the customizer registered via
+             ``VoiceChannel.on_inbound_call_twiml(...)`` if configured
+             and ``twiml_request`` is given.
+          2. ``OpenAIRealtimeProviderConfig.default_twiml_options`` — per-channel defaults.
+          3. ``host_twiml_options`` — per-call transport facts supplied by the host.
+          4. TAC defaults: the WebSocket URL derived from
+             ``TACConfig.voice_public_domain`` + ``voice_websocket_path``.
+        """
+        if host_twiml_options is not None and not isinstance(
+            host_twiml_options, VoiceTwiMLOptionsMediaStreams
+        ):
+            raise TypeError(
+                "OpenAIRealtimeProvider.handle_incoming_call requires host_twiml_options "
+                f"to be a VoiceTwiMLOptionsMediaStreams, got {type(host_twiml_options).__name__}"
+            )
+
+        customized: VoiceTwiMLOptionsMediaStreams | None = None
+        if self.channel._on_inbound_call_twiml is not None and twiml_request is not None:
+            result = await self.channel._on_inbound_call_twiml(twiml_request)
+            if not isinstance(result, VoiceTwiMLOptionsMediaStreams):
+                raise TypeError(
+                    "OpenAIRealtimeProvider.handle_incoming_call requires the "
+                    "on_inbound_call_twiml customizer to return a "
+                    f"VoiceTwiMLOptionsMediaStreams, got {type(result).__name__}"
+                )
+            customized = result
+
+        return self._twiml.build(
+            "handle_incoming_call", host=host_twiml_options, per_call=customized
+        )
+
+    def _build_call_kwargs(self, call_options: CallOptions | None) -> dict[str, Any]:
+        """Build the extra kwargs for ``client.calls.create``.
+
+        Layers, highest precedence first: this call's ``call_options``, then
+        callback URLs derived from ``voice_public_domain`` + ``voice_call_event_path``,
+        one per registered handler.
+        """
+        call_kwargs = call_options.to_call_kwargs() if call_options else {}
+
+        wiring: list[tuple[CallEventKind, str, Callable[..., Any] | None]] = [
+            ("status", "status_callback", self.channel._on_call_status),
+            ("amd", "async_amd_status_callback", self.channel._on_amd),
+            ("recording", "recording_status_callback", self.channel._on_recording),
+        ]
+        for kind, param, handler in wiring:
+            if handler is None:
+                continue
+            url = self.channel.tac.config.call_event_url(kind)
+            if url is not None:
+                call_kwargs.setdefault(param, url)
+
+        return call_kwargs
+
+    async def initiate_outbound_conversation(
+        self,
+        options: InitiateVoiceConversationOptions,
+    ) -> InitiateVoiceConversationResult:
+        """Initiate an outbound voice conversation.
+
+        Places an outbound call with inline TwiML that connects to a Media
+        Stream. Unlike inbound, there's no local session yet at this point —
+        it's created when Twilio's WebSocket ``start`` event arrives, the
+        same as ``_register_call`` does for inbound.
+
+        TwiML fields are merged per-field — see ``TwiMLBuilderMediaStreams.build``.
+        The WebSocket URL is derived from ``TACConfig.voice_public_domain`` +
+        ``TACConfig.voice_websocket_path``, unless overridden per-call via
+        ``options.websocket_url``.
+        """
+        twiml_options = options.twiml_options
+        if twiml_options is not None and not isinstance(
+            twiml_options, VoiceTwiMLOptionsMediaStreams
+        ):
+            raise TypeError(
+                "OpenAIRealtimeProvider.initiate_outbound_conversation requires "
+                "options.twiml_options to be a VoiceTwiMLOptionsMediaStreams, got "
+                f"{type(twiml_options).__name__}"
+            )
+
+        from_number = self.channel.tac.config.phone_number
+
+        self.logger.info(
+            "Initiating outbound voice conversation",
+            to=mask_phone(options.to),
+            from_number=mask_phone(from_number),
+        )
+
+        twiml_xml = self._twiml.build(
+            "initiate_outbound_conversation",
+            per_call=twiml_options,
+            websocket_url=options.websocket_url,
+        )
+
+        call_kwargs = self._build_call_kwargs(options.call_options)
+
+        try:
+            self.logger.debug("Outbound call TwiML", twiml=twiml_xml, to=mask_phone(options.to))
+
+            client = self.channel._get_twilio_client()
+            call = await asyncio.to_thread(
+                client.calls.create,
+                to=options.to,
+                from_=from_number,
+                twiml=twiml_xml,
+                **call_kwargs,
+            )
+
+            self.logger.info(
+                "Outbound voice call placed",
+                call_sid=call.sid,
+                to=mask_phone(options.to),
+            )
+
+            return InitiateVoiceConversationResult(call_sid=call.sid)
+
+        except Exception as e:
+            self.logger.error(
+                "Failed to initiate outbound call",
+                to=mask_phone(options.to),
+                error=str(e),
+                exc_info=True,
+            )
+            raise
+
+    async def handle_websocket(self, websocket: WebSocketProtocol) -> None:
+        """Drive one Twilio Media Stream connection from accept to disconnect."""
+        await websocket.accept()
+
+        conv_id: str | None = None
+        model_reader: asyncio.Task[None] | None = None
+
+        try:
+            while True:
+                data = await websocket.receive_json()
+                event = data.get("event")
+
+                if event == "start":
+                    conv_id = self._register_call(data.get("start") or {}, websocket)
+                    await self._connect_model(conv_id)
+                    model_reader = asyncio.create_task(self._handle_model_events(conv_id))
+
+                elif event == "media":
+                    media = data.get("media") or {}
+                    if conv_id is not None:
+                        if media.get("payload"):
+                            await self._model_send(
+                                conv_id,
+                                {
+                                    "type": "input_audio_buffer.append",
+                                    "audio": media["payload"],
+                                },
+                            )
+
+                elif event == "stop":
+                    self.logger.info("Media stream stopped", conversation_id=conv_id)
+                    break
+
+        except WebSocketDisconnectError:
+            self.logger.info("Media stream WebSocket closed", conversation_id=conv_id)
+        except Exception as e:
+            self.logger.error(f"Media stream WebSocket error: {e}", exc_info=True)
+        finally:
+            if model_reader is not None:
+                model_reader.cancel()
+            if conv_id is not None:
+                await self._cleanup_call(conv_id)
+
+    def _register_call(self, start: dict[str, Any], websocket: WebSocketProtocol) -> str:
+        """Handle Twilio's ``start`` event, returning the conversation id."""
+        message = StreamStartMessage(**start)
+        conv_id = message.conversation_id
+
+        self._calls[conv_id] = _CallState(twilio_ws=websocket)
+
+        session = self.channel._start_conversation(conv_id, profile_id=None)
+        session.call_sid = message.call_sid
+        session.metadata.update({"stream_sid": message.stream_sid, "transcript": []})
+
+        self.logger.debug(
+            "Media stream started", conversation_id=conv_id, media_format=message.media_format
+        )
+        return conv_id
+
+    async def _connect_model(self, conv_id: str) -> None:
+        """Open the OpenAI Realtime WebSocket and send the session config."""
+        model_ws = await websockets.connect(
+            f"wss://api.openai.com/v1/realtime?model={self.config.session_config['model']}",
+            additional_headers={"Authorization": f"Bearer {self.config.openai_api_key}"},
+        )
+        call = self._calls.get(conv_id)
+        if call is not None:
+            call.model_ws = model_ws
+        self.logger.info("Connected to OpenAI Realtime", conversation_id=conv_id)
+
+        await self._model_send(
+            conv_id, {"type": "session.update", "session": self.config.session_config}
+        )
+
+        # VAD waits for the caller to speak first; request a response to greet.
+        response = self.config.welcome_greeting_response
+        if response is not None:
+            await self._model_send(conv_id, {"type": "response.create", "response": response})
+
+    async def _handle_model_events(self, conv_id: str) -> None:
+        """Read OpenAI Realtime events until the socket closes, dispatching each one.
+
+        A failure handling one event (e.g. a malformed delta) is logged and
+        skipped rather than ending the loop — only the socket actually
+        closing (raised by ``async for`` itself, not from inside it) does.
+        """
+        call = self._calls.get(conv_id)
+        if call is None or call.model_ws is None:
+            return
+        try:
+            async for raw in call.model_ws:
+                try:
+                    event = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+                    session = self.channel._conversations.get(conv_id)
+                    if session is None:
+                        continue
+                    await self._dispatch_model_event(conv_id, session, event)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    self.logger.error(
+                        f"Error handling model event: {e}",
+                        conversation_id=conv_id,
+                        exc_info=True,
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.logger.debug(f"Model read loop ended: {e}", conversation_id=conv_id)
+
+    async def _dispatch_model_event(
+        self, conv_id: str, session: ConversationSession, event: dict[str, Any]
+    ) -> None:
+        event_type = event.get("type")
+        call = self._calls.get(conv_id)
+        if call is None:
+            return
+
+        if event_type == "error":
+            self.logger.error(
+                "OpenAI Realtime error event", conversation_id=conv_id, error=event.get("error")
+            )
+
+        elif event_type == "input_audio_buffer.speech_started":
+            self.logger.debug("Caller speech detected (VAD)", conversation_id=conv_id)
+            await self._handle_barge_in(conv_id, session, call)
+
+        elif event_type == "response.created":
+            call.barge_in.response_active = True
+
+        elif event_type == "conversation.item.input_audio_transcription.completed":
+            if event.get("transcript"):
+                session.metadata.setdefault("transcript", []).append(
+                    {"role": "user", "text": event["transcript"]}
+                )
+
+        elif event_type == "response.output_item.done":
+            # Fires per-item, ahead of response.done — lower tool-call latency.
+            # "completed" excludes calls cut short by an interruption, whose
+            # arguments JSON may be a truncated fragment.
+            item = event.get("item", {})
+            if item.get("type") == "function_call" and item.get("status") == "completed":
+                await self._handle_function_call(conv_id, item)
+
+        elif event_type == "response.done":
+            # last_assistant_item stays set — the model generates faster than
+            # realtime, so Twilio may still be playing this when it arrives.
+            # response_active clears though: nothing left to cancel.
+            call.barge_in.response_active = False
+            for item in event.get("response", {}).get("output", []):
+                if item.get("role") != "assistant":
+                    continue
+                for content in item.get("content", []):
+                    if content.get("transcript"):
+                        session.metadata.setdefault("transcript", []).append(
+                            {"role": "assistant", "text": content["transcript"]}
+                        )
+
+        elif event_type == "response.output_audio.delta" and event.get("delta"):
+            barge_in = call.barge_in
+            item_id = event.get("item_id")
+            if item_id and item_id == barge_in.muted_item_id:
+                # Stale audio for an item already truncated by barge-in.
+                return
+
+            if item_id and item_id != barge_in.last_assistant_item:
+                barge_in.last_assistant_item = item_id
+                barge_in.current_item_audio_ms = 0
+
+            barge_in.current_item_audio_ms += (
+                len(base64.b64decode(event["delta"])) // _PCMU_BYTES_PER_MS
+            )
+
+            await self._twilio_send(
+                conv_id,
+                {
+                    "event": "media",
+                    "streamSid": session.metadata.get("stream_sid"),
+                    "media": {"payload": event["delta"]},
+                },
+            )
+
+    async def _handle_barge_in(
+        self, conv_id: str, session: ConversationSession, call: _CallState
+    ) -> None:
+        """Caller started talking. Cancel any response still generating,
+        truncate the model's memory of the last reply at the point actually
+        heard, then clear Twilio's buffered audio so playback stops
+        immediately. If no assistant audio has been sent since the last
+        barge-in, there's nothing queued at Twilio to clear, so this is a
+        no-op."""
+        barge_in = call.barge_in
+
+        last_assistant_item = barge_in.last_assistant_item
+        if last_assistant_item is None:
+            self.logger.debug("Barge-in: no assistant item to interrupt", conversation_id=conv_id)
+            return
+
+        self.logger.debug("Barge-in: truncating assistant reply", conversation_id=conv_id)
+        if barge_in.response_active:
+            # Stop the model from generating more of a reply nobody will
+            # hear — otherwise it keeps burning tokens on discarded audio.
+            # Only send this while a response is actually in flight —
+            # response.cancel with nothing to cancel is itself an error event.
+            await self._model_send(conv_id, {"type": "response.cancel"})
+            barge_in.response_active = False
+        await self._model_send(
+            conv_id,
+            {
+                "type": "conversation.item.truncate",
+                "item_id": last_assistant_item,
+                "content_index": 0,
+                # current_item_audio_ms is the exact duration of audio sent
+                # for this item, so it never exceeds the item's real content.
+                "audio_end_ms": barge_in.current_item_audio_ms,
+            },
+        )
+        await self._twilio_send(
+            conv_id, {"event": "clear", "streamSid": session.metadata.get("stream_sid")}
+        )
+
+        barge_in.muted_item_id = last_assistant_item
+        barge_in.last_assistant_item = None
+        barge_in.current_item_audio_ms = 0
+
+    async def _handle_function_call(self, conv_id: str, item: dict[str, Any]) -> None:
+        """Run a model-requested tool call and hand the result back."""
+        call_id = item.get("call_id")
+        output = await self._run_tool_call(conv_id, item.get("name"), item.get("arguments"))
+
+        await self._model_send(
+            conv_id,
+            {
+                "type": "conversation.item.create",
+                "item": {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": json.dumps(output),
+                },
+            },
+        )
+        await self._model_send(conv_id, {"type": "response.create"})
+
+    async def _run_tool_call(
+        self, conv_id: str, name: str | None, arguments_json: str | None
+    ) -> object:
+        """Look up a model-requested tool by name, run it, and return its output.
+
+        Errors are returned as part of the output rather than raised, so a bad
+        tool call doesn't kill the call.
+        """
+        tool = self._tools_by_name.get(name) if name else None
+
+        self.logger.debug(f"Tool call: {name}({arguments_json})", conversation_id=conv_id)
+
+        if tool is None:
+            return {"error": f"Unknown tool '{name}'"}
+
+        try:
+            arguments = json.loads(arguments_json or "{}")
+            output = await tool(**arguments)
+            self.logger.debug(f"Tool result: {name} -> {output}", conversation_id=conv_id)
+            return output
+        except Exception as e:
+            self.logger.error(f"Tool '{name}' failed: {e}", conversation_id=conv_id, exc_info=True)
+            return {"error": f"Tool '{name}' failed to execute."}
+
+    async def _model_send(self, conv_id: str, obj: dict[str, Any]) -> None:
+        call = self._calls.get(conv_id)
+        if call is None or call.model_ws is None:
+            return
+        try:
+            await call.model_ws.send(json.dumps(obj))
+        except Exception as e:
+            self.logger.debug(f"Failed to send to model: {e}", conversation_id=conv_id)
+
+    async def _twilio_send(self, conv_id: str, obj: dict[str, Any]) -> None:
+        call = self._calls.get(conv_id)
+        if call is None or call.twilio_ws is None:
+            return
+        try:
+            await call.twilio_ws.send_text(json.dumps(obj))
+        except (WebSocketDisconnectError, RuntimeError) as e:
+            self.logger.debug(f"Failed to send to Twilio: {e}", conversation_id=conv_id)
+
+    async def _cleanup_call(self, conv_id: str) -> None:
+        call = self._calls.pop(conv_id, None)
+        if call is not None and call.model_ws is not None:
+            try:
+                await call.model_ws.close()
+            except Exception as e:
+                self.logger.debug(f"Error closing model socket: {e}", conversation_id=conv_id)
+        await self.channel._end_conversation(conv_id)
+
+    async def send_response(
+        self,
+        conversation_id: str,
+        response: str | AsyncGenerator[str | dict[str, Any], None],
+        role: str | None = None,
+    ) -> None:
+        """Not supported: the model streams audio to Twilio directly, so there
+        is no text response for this provider to send."""
+        raise NotImplementedError(
+            f"{type(self).__name__} produces audio via the model; it has no text send_response."
+        )

--- a/src/tac/channels/voice/media_streams/openai_realtime/twiml.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/twiml.py
@@ -1,0 +1,172 @@
+"""TwiML generation for ``OpenAIRealtimeProvider``.
+
+See https://www.twilio.com/docs/voice/twiml/stream for the ``<Stream>`` verb.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from twilio.twiml.voice_response import Connect, VoiceResponse
+
+from tac.core.config import TACConfig
+from tac.models.voice import VoiceTwiMLOptionsMediaStreams
+
+if TYPE_CHECKING:
+    from tac.channels.voice.media_streams.openai_realtime.config import (
+        OpenAIRealtimeProviderConfig,
+    )
+
+
+def generate_twiml(
+    websocket_url: str | None = None,
+    options: VoiceTwiMLOptionsMediaStreams | dict[str, Any] | None = None,
+) -> str:
+    """Generate TwiML that connects the call to a bidirectional Media Stream.
+
+    The WebSocket URL may be passed positionally or as ``options.websocket_url``
+    (positional wins when both are given), so a caller can pass everything in
+    one object: ``generate_twiml(options=VoiceTwiMLOptionsMediaStreams(websocket_url=...))``.
+
+    Args:
+        websocket_url: Public ``wss://`` URL of the WebSocket endpoint Twilio
+            should stream call audio to (the ``<Stream url=...>`` attribute).
+            Optional if ``options.websocket_url`` is set.
+        options: Optional ``VoiceTwiMLOptionsMediaStreams`` (or dict).
+
+    Returns:
+        TwiML XML string ready to return to Twilio.
+
+    Raises:
+        ValueError: If no WebSocket URL is provided via either source.
+    """
+    if options is None:
+        options = VoiceTwiMLOptionsMediaStreams()
+    elif isinstance(options, dict):
+        options = VoiceTwiMLOptionsMediaStreams(**options)
+
+    resolved_websocket_url = websocket_url if websocket_url is not None else options.websocket_url
+    if not resolved_websocket_url:
+        raise ValueError(
+            "generate_twiml requires a WebSocket URL — pass it positionally or "
+            "set options.websocket_url."
+        )
+
+    response = VoiceResponse()
+
+    connect_kwargs: dict[str, str] = {}
+    if options.action_url:
+        connect_kwargs["action"] = options.action_url
+    if options.action_method:
+        connect_kwargs["method"] = options.action_method
+    connect = Connect(**connect_kwargs)
+
+    stream_kwargs: dict[str, Any] = {"url": resolved_websocket_url}
+    if options.name:
+        stream_kwargs["name"] = options.name
+    if options.status_callback:
+        stream_kwargs["status_callback"] = options.status_callback
+    if options.status_callback_method:
+        stream_kwargs["status_callback_method"] = options.status_callback_method
+    stream = connect.stream(**stream_kwargs)
+
+    if options.custom_parameters:
+        for name, value in options.custom_parameters.items():
+            if value is not None:
+                stream.parameter(name=name, value=str(value))
+
+    response.append(connect)
+    return str(response)
+
+
+class TwiMLBuilderMediaStreams:
+    """Builds the TwiML for a Media Streams call, owning the layering and
+    WebSocket URL resolution so ``OpenAIRealtimeProvider`` doesn't have to.
+    """
+
+    def __init__(self, tac_config: TACConfig, channel_config: OpenAIRealtimeProviderConfig) -> None:
+        self.tac_config = tac_config
+        self.channel_config = channel_config
+
+    def build(
+        self,
+        caller: str,
+        *,
+        host: VoiceTwiMLOptionsMediaStreams | None = None,
+        per_call: VoiceTwiMLOptionsMediaStreams | None = None,
+        websocket_url: str | None = None,
+    ) -> str:
+        """Build the TwiML XML for one call.
+
+        TwiML fields are merged per-field, highest precedence first:
+          1. ``per_call`` — the ``on_inbound_call_twiml`` customizer's output
+             for inbound, or ``InitiateVoiceConversationOptions.twiml_options``
+             for outbound.
+          2. ``OpenAIRealtimeProviderConfig.default_twiml_options`` — channel-wide defaults
+          3. ``host`` — per-call transport facts supplied by the host (e.g. a
+             per-call ``websocket_url`` with an affinity token)
+          4. TAC defaults: the WebSocket URL derived from
+             ``TACConfig.voice_public_domain`` + ``voice_websocket_path``
+
+        Args:
+            caller: Name of the calling method, used in the "no WebSocket URL"
+                error so it points at the API the developer actually called.
+            host: Per-call overrides from the host owning the route.
+            per_call: Per-call overrides — the ``on_inbound_call_twiml``
+                customizer's output for inbound, or
+                ``InitiateVoiceConversationOptions.twiml_options`` for outbound.
+            websocket_url: Dedicated per-call WebSocket override that wins over
+                any ``websocket_url`` coming through the option layers. Used by
+                outbound, which takes it as its own argument.
+
+        Raises:
+            ValueError: If no layer and no ``TACConfig``-derived default
+                supplies a WebSocket URL.
+        """
+        merged = self._build_twiml_options(host, per_call)
+
+        if websocket_url is not None:
+            resolved_websocket_url = websocket_url
+        elif merged.websocket_url is not None:
+            resolved_websocket_url = merged.websocket_url
+        elif self.tac_config.voice_public_domain:
+            resolved_websocket_url = (
+                f"wss://{self.tac_config.voice_public_domain}{self.tac_config.voice_websocket_path}"
+            )
+        else:
+            raise ValueError(
+                f"{caller} needs a WebSocket URL. Set TWILIO_VOICE_PUBLIC_DOMAIN "
+                "(or TACConfig.voice_public_domain)."
+            )
+
+        return generate_twiml(resolved_websocket_url, merged)
+
+    def _build_twiml_options(
+        self,
+        host: VoiceTwiMLOptionsMediaStreams | None,
+        per_call: VoiceTwiMLOptionsMediaStreams | None,
+    ) -> VoiceTwiMLOptionsMediaStreams:
+        """Layer TwiML options, lowest precedence first: ``host`` →
+        ``default_twiml_options`` → ``per_call`` (the ``on_inbound_call_twiml``
+        customizer's output).
+        """
+        merged = VoiceTwiMLOptionsMediaStreams()
+        if host is not None:
+            self._overlay_fields(merged, host)
+        if self.channel_config.default_twiml_options is not None:
+            self._overlay_fields(merged, self.channel_config.default_twiml_options)
+        if per_call is not None:
+            self._overlay_fields(merged, per_call)
+        return merged
+
+    @staticmethod
+    def _overlay_fields(
+        target: VoiceTwiMLOptionsMediaStreams, source: VoiceTwiMLOptionsMediaStreams
+    ) -> None:
+        """Apply fields explicitly set on ``source`` onto ``target``.
+
+        ``custom_parameters`` replaces wholesale when set at a higher-priority
+        layer — there's no per-key merging.
+        """
+        for field in source.model_fields_set:
+            setattr(target, field, getattr(source, field))

--- a/src/tac/channels/voice/media_streams/openai_realtime/twiml.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/twiml.py
@@ -46,7 +46,7 @@ def generate_twiml(
         options = VoiceTwiMLOptionsMediaStreams(**options)
 
     resolved_websocket_url = websocket_url if websocket_url is not None else options.websocket_url
-    if not resolved_websocket_url:
+    if not resolved_websocket_url or not resolved_websocket_url.strip():
         raise ValueError(
             "generate_twiml requires a WebSocket URL — pass it positionally or "
             "set options.websocket_url."

--- a/src/tac/channels/voice/twiml.py
+++ b/src/tac/channels/voice/twiml.py
@@ -134,10 +134,11 @@ def generate_twiml(
         options = VoiceTwiMLOptionsConversationRelay(**options)
 
     # Positional arg wins when both are set; fall back to options.websocket_url.
-    # (VoiceTwiMLOptionsConversationRelay rejects an empty websocket_url, so any value
-    # here is real.)
+    # (VoiceTwiMLOptionsConversationRelay rejects an empty options.websocket_url, but
+    # the positional arg bypasses that pydantic validation entirely, so it still
+    # needs its own whitespace check below.)
     resolved_websocket_url = websocket_url if websocket_url is not None else options.websocket_url
-    if not resolved_websocket_url:
+    if not resolved_websocket_url or not resolved_websocket_url.strip():
         raise ValueError(
             "generate_twiml requires a WebSocket URL — pass it positionally or "
             "set options.websocket_url."

--- a/src/tac/models/outbound.py
+++ b/src/tac/models/outbound.py
@@ -217,6 +217,16 @@ class InitiateVoiceConversationOptions(BaseModel):
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
 
+class InitiateVoiceConversationOptionsOpenAIRealtime(InitiateVoiceConversationOptions):
+    """Outbound options for ``OpenAIRealtimeProvider``, adding a per-call ``session_config``."""
+
+    session_config: dict[str, Any] | None = Field(
+        default=None,
+        description="Used verbatim in place of "
+        "OpenAIRealtimeProviderConfig.default_session_config for this call.",
+    )
+
+
 class InitiateVoiceConversationResult(BaseModel):
     """Result of initiating an outbound voice conversation."""
 

--- a/src/tac/models/stream.py
+++ b/src/tac/models/stream.py
@@ -1,0 +1,20 @@
+"""Pydantic models for Twilio Media Streams (``<Connect><Stream>``) WebSocket messages."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class StreamStartMessage(BaseModel):
+    """The ``start`` field of Twilio's Media Stream ``start`` event."""
+
+    stream_sid: str | None = Field(None, alias="streamSid")
+    call_sid: str | None = Field(None, alias="callSid")
+    media_format: dict[str, Any] | None = Field(None, alias="mediaFormat")
+    custom_parameters: dict[str, str] = Field(default_factory=dict, alias="customParameters")
+
+    model_config = {"populate_by_name": True}
+
+    @property
+    def conversation_id(self) -> str:
+        return self.call_sid or self.stream_sid or "unknown-call"

--- a/src/tac/models/stream.py
+++ b/src/tac/models/stream.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel, Field
 class StreamStartMessage(BaseModel):
     """The ``start`` field of Twilio's Media Stream ``start`` event."""
 
-    stream_sid: str | None = Field(None, alias="streamSid")
-    call_sid: str | None = Field(None, alias="callSid")
+    stream_sid: str = Field(alias="streamSid")
+    call_sid: str = Field(alias="callSid")
     media_format: dict[str, Any] | None = Field(None, alias="mediaFormat")
     custom_parameters: dict[str, str] = Field(default_factory=dict, alias="customParameters")
 
@@ -17,4 +17,4 @@ class StreamStartMessage(BaseModel):
 
     @property
     def conversation_id(self) -> str:
-        return self.call_sid or self.stream_sid or "unknown-call"
+        return self.call_sid

--- a/src/tac/models/voice.py
+++ b/src/tac/models/voice.py
@@ -486,6 +486,52 @@ class VoiceTwiMLOptionsConversationRelay(VoiceTwiMLOptions):
 TwiMLOptions = VoiceTwiMLOptionsConversationRelay
 
 
+class VoiceTwiMLOptionsMediaStreams(VoiceTwiMLOptions):
+    """Options for the TwiML inside ``<Connect><Stream>``.
+
+    Fields map to the attributes documented at
+    https://www.twilio.com/docs/voice/twiml/stream (the ``<Stream>`` verb)
+    and https://www.twilio.com/docs/voice/twiml/connect (the ``<Connect>``
+    verb it's nested in). ``track`` is omitted — bidirectional ``<Connect>``
+    streams only ever carry ``inbound_track``, so it isn't settable.
+    """
+
+    websocket_url: str | None = Field(
+        None,
+        description="Public WebSocket URL for Twilio's Media Stream (the "
+        "<Stream url=...> attribute). Leave None to use the URL derived from "
+        "TACConfig.voice_public_domain + voice_websocket_path.",
+    )
+    custom_parameters: dict[str, Any] | None = Field(
+        None,
+        description="Custom parameters emitted as <Parameter> children of <Stream>. "
+        "They arrive back in the WebSocket 'start' event under start.customParameters.",
+    )
+    name: str | None = Field(
+        None,
+        description="Friendly name for the Stream (the <Stream name=...> attribute). "
+        "Must be unique per call; arrives back in the WebSocket 'start' event.",
+    )
+    status_callback: str | None = Field(
+        None,
+        description="Absolute URL Twilio posts to when the stream starts, stops, or "
+        "errors (StreamSid/StreamName/StreamEvent/StreamError/Timestamp params).",
+    )
+    status_callback_method: Literal["GET", "POST"] | None = Field(
+        None,
+        description="HTTP method for status_callback. Defaults to POST on Twilio.",
+    )
+    action_url: str | None = Field(
+        None,
+        description="URL Twilio requests when the <Connect> verb completes (the "
+        "<Connect action=...> attribute), with standard call parameters.",
+    )
+    action_method: Literal["GET", "POST"] | None = Field(
+        None,
+        description="HTTP method for action_url. Defaults to POST on Twilio.",
+    )
+
+
 class TwiMLRequest(BaseModel):
     """Framework-neutral view of the Twilio TwiML webhook form.
 

--- a/src/tac/tools/base.py
+++ b/src/tac/tools/base.py
@@ -258,6 +258,24 @@ class TACTool:
             },
         }
 
+    def to_realtime_format(self) -> dict[str, object]:
+        """
+        Get tool schema in OpenAI Realtime API function-calling format.
+
+        Unlike ``to_openai_format`` (Chat Completions, which nests the schema
+        under a ``"function"`` key), Realtime's ``session.tools`` expects the
+        fields flat on the tool object.
+
+        Returns:
+            Dictionary in Realtime tool format
+        """
+        return {
+            "type": "function",
+            "name": self.name,
+            "description": self.description,
+            "parameters": self.params_json_schema,
+        }
+
     def to_anthropic_format(self) -> dict[str, object]:
         """
         Get tool schema in Anthropic tool calling format.

--- a/tests/test_openai_realtime_provider.py
+++ b/tests/test_openai_realtime_provider.py
@@ -1,0 +1,379 @@
+"""Tests for OpenAIRealtimeProvider: connection lifecycle, barge-in, tool calls."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tac import TAC
+from tac.channels.voice import VoiceChannel
+from tac.channels.voice.media_streams.openai_realtime import OpenAIRealtimeProviderConfig
+from tac.channels.voice.media_streams.openai_realtime.models import _BargeInState, _CallState
+from tac.tools import function_tool
+
+
+def get_test_tac_config() -> dict:
+    return {
+        "account_sid": "ACtest123",
+        "auth_token": "test_token_123",
+        "api_key": "SK123",
+        "api_secret": "test_api_token",
+        "conversation_configuration_id": "conv_configuration_test123",
+        "phone_number": "+15551234567",
+        "voice_public_domain": "example.com",
+    }
+
+
+def make_channel(**config_kwargs: object) -> VoiceChannel:
+    tac = TAC(get_test_tac_config())
+    config = OpenAIRealtimeProviderConfig(
+        openai_api_key="sk-test",
+        session_config={"model": "gpt-realtime-test"},
+        **config_kwargs,
+    )
+    return VoiceChannel(tac, config=config)
+
+
+class FakeTwilioWebSocket:
+    """Fake Twilio-facing WebSocket. Yields queued events, then hangs
+    forever (like a real, still-open connection with nothing new to say)
+    until the awaiting task is cancelled."""
+
+    def __init__(self, events: list[dict]) -> None:
+        self._events = list(events)
+        self.accepted = False
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive_json(self) -> dict:
+        if self._events:
+            return self._events.pop(0)
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def send_text(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeModelWebSocket:
+    """Fake OpenAI Realtime WebSocket. Async-iterates over queued raw
+    events.
+
+    When ``events`` runs out: if ``stay_open`` is True, hangs forever (a
+    live connection with nothing new to say — required whenever a test also
+    exercises the Twilio leg, since ending this instantly races the
+    model_reader task against the Twilio recv task in handle_websocket's
+    asyncio.wait, non-deterministically dropping already-queued Twilio
+    events). Otherwise ends the stream immediately (a closed connection).
+    """
+
+    def __init__(self, events: list[dict] | None = None, stay_open: bool = False) -> None:
+        self._events = list(events or [])
+        self._stay_open = stay_open
+        self.sent: list[dict] = []
+        self.closed = False
+
+    def __aiter__(self) -> "FakeModelWebSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        if self._events:
+            return json.dumps(self._events.pop(0))
+        if self._stay_open:
+            await asyncio.Event().wait()
+        raise StopAsyncIteration
+
+    async def send(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class TestHandleWebSocketLifecycle:
+    """The Twilio-read loop and the OpenAI model-event reader run as two
+    tasks raced against each other — whichever leg disconnects first must
+    tear the whole call down instead of leaving the other leg running."""
+
+    @pytest.mark.asyncio
+    async def test_model_disconnect_ends_call_without_hanging(self) -> None:
+        """If the OpenAI leg closes first, the Twilio read loop must stop
+        (rather than keep pumping caller audio into a dead model socket)
+        and the call must be cleaned up."""
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[{"event": "start", "start": {"callSid": "CA123", "streamSid": "MZ123"}}]
+        )
+        model_ws = FakeModelWebSocket(events=[])  # ends immediately
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        # Call was cleaned up: no leftover state, model socket closed,
+        # conversation ended.
+        assert provider._calls == {}
+        assert model_ws.closed is True
+        assert "CA123" not in channel._conversations
+
+    @pytest.mark.asyncio
+    async def test_twilio_stop_event_ends_call(self) -> None:
+        """The Twilio leg ending normally (a 'stop' event) must also clean
+        up the still-running model reader, not just break out silently."""
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {"event": "start", "start": {"callSid": "CA456", "streamSid": "MZ456"}},
+                {"event": "stop"},
+            ]
+        )
+        # Stays open so this test exercises "Twilio said stop" cleanup —
+        # not "model disconnected first" (covered separately above).
+        model_ws = FakeModelWebSocket(events=[], stay_open=True)
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert provider._calls == {}
+        assert model_ws.closed is True
+        assert "CA456" not in channel._conversations
+
+    @pytest.mark.asyncio
+    async def test_media_event_forwarded_to_model(self) -> None:
+        """Caller audio arriving before the model disconnects is forwarded
+        as an input_audio_buffer.append event."""
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {"event": "start", "start": {"callSid": "CA789", "streamSid": "MZ789"}},
+                {"event": "media", "media": {"payload": "abcd"}},
+                {"event": "stop"},
+            ]
+        )
+        # Stays open — must not race the "media" event's processing.
+        model_ws = FakeModelWebSocket(events=[], stay_open=True)
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        forwarded = [m for m in model_ws.sent if m.get("type") == "input_audio_buffer.append"]
+        assert forwarded == [{"type": "input_audio_buffer.append", "audio": "abcd"}]
+
+    @pytest.mark.asyncio
+    async def test_malformed_start_event_rejected_not_collapsed_to_shared_key(self) -> None:
+        """A 'start' event missing callSid/streamSid must fail validation
+        instead of falling back to a shared "unknown-call" id that a second
+        malformed connection could collide with and clobber."""
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(events=[{"event": "start", "start": {}}])
+        model_ws = FakeModelWebSocket(events=[], stay_open=True)
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        # Rejected before a call was ever registered under any key.
+        assert provider._calls == {}
+        assert channel._conversations == {}
+
+
+class TestBargeIn:
+    """Barge-in truncates the model's memory of the interrupted reply and
+    clears Twilio's playback buffer."""
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_assistant_audio_sent_yet(self) -> None:
+        """If nothing has been sent to Twilio since the last barge-in,
+        there's nothing to truncate or clear."""
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(events=[])
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA1"] = _CallState(twilio_ws=twilio_ws, model_ws=model_ws)
+        session = channel._start_conversation("CA1", profile_id=None)
+
+        call = provider._calls["CA1"]
+        assert call.barge_in.last_assistant_item is None
+
+        await provider._handle_barge_in("CA1", session, call)
+
+        assert model_ws.sent == []
+        assert twilio_ws.sent == []
+
+    @pytest.mark.asyncio
+    async def test_truncates_and_clears_when_interrupted_mid_reply(self) -> None:
+        """A barge-in mid-reply sends response.cancel (if a response is
+        still generating), truncates at the exact sent-audio duration, and
+        clears Twilio's buffer."""
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(events=[])
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA2"] = _CallState(
+            twilio_ws=twilio_ws,
+            model_ws=model_ws,
+            barge_in=_BargeInState(
+                last_assistant_item="item_1", current_item_audio_ms=250, response_active=True
+            ),
+        )
+        session = channel._start_conversation("CA2", profile_id=None)
+        session.metadata["stream_sid"] = "MZ123"
+
+        call = provider._calls["CA2"]
+        await provider._handle_barge_in("CA2", session, call)
+
+        assert {"type": "response.cancel"} in model_ws.sent
+        truncate = next(m for m in model_ws.sent if m["type"] == "conversation.item.truncate")
+        assert truncate["item_id"] == "item_1"
+        assert truncate["audio_end_ms"] == 250
+        assert {"event": "clear", "streamSid": "MZ123"} in twilio_ws.sent
+
+        # State reset for the next reply.
+        assert call.barge_in.last_assistant_item is None
+        assert call.barge_in.current_item_audio_ms == 0
+        assert call.barge_in.muted_item_id == "item_1"
+        assert call.barge_in.response_active is False
+
+    @pytest.mark.asyncio
+    async def test_skips_response_cancel_when_no_response_in_flight(self) -> None:
+        """response.cancel is only sent while a response is actually
+        generating — sending it otherwise is itself an OpenAI error event."""
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(events=[])
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA3"] = _CallState(
+            twilio_ws=twilio_ws,
+            model_ws=model_ws,
+            barge_in=_BargeInState(
+                last_assistant_item="item_2", current_item_audio_ms=100, response_active=False
+            ),
+        )
+        session = channel._start_conversation("CA3", profile_id=None)
+
+        call = provider._calls["CA3"]
+        await provider._handle_barge_in("CA3", session, call)
+
+        assert {"type": "response.cancel"} not in model_ws.sent
+
+
+class TestErrorEventDowngrade:
+    """A response.cancel that raced a response.done is benign, not a
+    genuine error worth alarming on."""
+
+    @pytest.mark.asyncio
+    async def test_response_cancel_not_active_is_not_logged_as_error(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        provider._calls["CA4"] = _CallState()
+        session = channel._start_conversation("CA4", profile_id=None)
+
+        with (
+            patch.object(provider.logger, "error") as mock_error,
+            patch.object(provider.logger, "debug") as mock_debug,
+        ):
+            await provider._dispatch_model_event(
+                "CA4",
+                session,
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "invalid_request_error",
+                        "code": "response_cancel_not_active",
+                        "message": "Cancellation failed: no active response found",
+                    },
+                },
+            )
+
+        mock_error.assert_not_called()
+        assert any(
+            "response.cancel raced response.done" in c.args[0] for c in mock_debug.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_other_error_codes_still_logged_as_error(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        provider._calls["CA5"] = _CallState()
+        session = channel._start_conversation("CA5", profile_id=None)
+
+        with patch.object(provider.logger, "error") as mock_error:
+            await provider._dispatch_model_event(
+                "CA5",
+                session,
+                {"type": "error", "error": {"code": "some_other_error", "message": "boom"}},
+            )
+
+        mock_error.assert_called_once()
+
+
+class TestToolCalls:
+    """Tool execution errors must be reported back to the model, not raised
+    and left to crash the call."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error_without_raising(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        result = await provider._run_tool_call("CA6", "does_not_exist", "{}")
+
+        assert result == {"error": "Unknown tool 'does_not_exist'"}
+
+    @pytest.mark.asyncio
+    async def test_tool_exception_returns_error_without_raising(self) -> None:
+        @function_tool()
+        def broken_tool() -> str:
+            """A tool that always fails."""
+            raise RuntimeError("boom")
+
+        channel = make_channel(tools=[broken_tool])
+        provider = channel._provider
+
+        result = await provider._run_tool_call("CA7", "broken_tool", "{}")
+
+        assert result == {"error": "Tool 'broken_tool' failed to execute."}
+
+    @pytest.mark.asyncio
+    async def test_successful_tool_call_returns_output(self) -> None:
+        @function_tool()
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        channel = make_channel(tools=[add])
+        provider = channel._provider
+
+        result = await provider._run_tool_call("CA8", "add", json.dumps({"a": 2, "b": 3}))
+
+        assert result == 5

--- a/tests/test_openai_realtime_provider.py
+++ b/tests/test_openai_realtime_provider.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -10,6 +10,11 @@ from tac import TAC
 from tac.channels.voice import VoiceChannel
 from tac.channels.voice.media_streams.openai_realtime import OpenAIRealtimeProviderConfig
 from tac.channels.voice.media_streams.openai_realtime.models import _BargeInState, _CallState
+from tac.models.outbound import (
+    InitiateVoiceConversationOptions,
+    InitiateVoiceConversationOptionsOpenAIRealtime,
+)
+from tac.models.voice import TwiMLRequest
 from tac.tools import function_tool
 
 
@@ -29,7 +34,7 @@ def make_channel(**config_kwargs: object) -> VoiceChannel:
     tac = TAC(get_test_tac_config())
     config = OpenAIRealtimeProviderConfig(
         openai_api_key="sk-test",
-        session_config={"model": "gpt-realtime-test"},
+        default_session_config={"model": "gpt-realtime-test"},
         **config_kwargs,
     )
     return VoiceChannel(tac, config=config)
@@ -377,3 +382,205 @@ class TestToolCalls:
         result = await provider._run_tool_call("CA8", "add", json.dumps({"a": 2, "b": 3}))
 
         assert result == 5
+
+
+class TestConfigValidation:
+    """OpenAIRealtimeProviderConfig fails fast on unusable combinations."""
+
+    def test_requires_openai_api_key(self) -> None:
+        with pytest.raises(ValueError, match="openai_api_key is required"):
+            OpenAIRealtimeProviderConfig(openai_api_key=None, default_session_config={"model": "x"})
+
+    def test_on_inbound_call_session_config_alone_is_valid(self) -> None:
+        async def customizer(req: TwiMLRequest) -> dict | None:
+            return {"model": "gpt-realtime-test"}
+
+        # Must not raise — a customizer alone is a legitimate session_config source.
+        OpenAIRealtimeProviderConfig(
+            openai_api_key="sk-test", on_inbound_call_session_config=customizer
+        )
+
+    def test_neither_source_alone_is_also_valid(self) -> None:
+        """Legitimate for an outbound-only provider supplying session_config
+        per-call via InitiateVoiceConversationOptionsOpenAIRealtime."""
+        OpenAIRealtimeProviderConfig(openai_api_key="sk-test")
+
+
+class TestInboundCallSessionConfig:
+    """Per-inbound-call session_config via on_inbound_call_session_config."""
+
+    @pytest.mark.asyncio
+    async def test_customizer_result_used_verbatim_for_that_call(self) -> None:
+
+        async def customizer(req: TwiMLRequest) -> dict | None:
+            if req.caller_country == "MX":
+                return {"model": "gpt-realtime-mx", "instructions": "Habla en español."}
+            return None
+
+        channel = make_channel(on_inbound_call_session_config=customizer)
+        provider = channel._provider
+
+        await provider.handle_incoming_call(
+            twiml_request=TwiMLRequest(call_sid="CA_MX", caller_country="MX")
+        )
+        assert provider._call_session_configs["CA_MX"] == {
+            "model": "gpt-realtime-mx",
+            "instructions": "Habla en español.",
+        }
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[{"event": "start", "start": {"callSid": "CA_MX", "streamSid": "MZ_MX"}}]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=False)
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ) as mock_connect:
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert "model=gpt-realtime-mx" in mock_connect.call_args.args[0]
+        sent_session = next(m for m in model_ws.sent if m["type"] == "session.update")
+        assert sent_session["session"] == {
+            "model": "gpt-realtime-mx",
+            "instructions": "Habla en español.",
+        }
+        assert "CA_MX" not in provider._call_session_configs
+
+    @pytest.mark.asyncio
+    async def test_customizer_returning_none_falls_back_to_default(self) -> None:
+        async def customizer(req: TwiMLRequest) -> dict | None:
+            return None
+
+        channel = make_channel(on_inbound_call_session_config=customizer)
+        provider = channel._provider
+
+        await provider.handle_incoming_call(
+            twiml_request=TwiMLRequest(call_sid="CA_US", caller_country="US")
+        )
+        assert "CA_US" not in provider._call_session_configs
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[{"event": "start", "start": {"callSid": "CA_US", "streamSid": "MZ_US"}}]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=False)
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        sent_session = next(m for m in model_ws.sent if m["type"] == "session.update")
+        assert sent_session["session"] == {"model": "gpt-realtime-test"}
+
+    @pytest.mark.asyncio
+    async def test_no_call_sid_skips_customizer(self) -> None:
+        customizer = AsyncMock(return_value={"model": "should-not-be-used"})
+
+        channel = make_channel(on_inbound_call_session_config=customizer)
+        provider = channel._provider
+
+        await provider.handle_incoming_call(twiml_request=TwiMLRequest(caller_country="MX"))
+
+        customizer.assert_not_called()
+        assert provider._call_session_configs == {}
+
+    @pytest.mark.asyncio
+    async def test_missing_model_field_raises_at_connect_time(self) -> None:
+        """Calls _connect_model directly — handle_websocket swallows
+        exceptions into a log line."""
+        channel = make_channel()
+        provider = channel._provider
+        provider._call_session_configs["CA_BAD"] = {"instructions": "no model field here"}
+
+        with pytest.raises(ValueError, match="must include a 'model' field"):
+            await provider._connect_model("CA_BAD")
+
+    @pytest.mark.asyncio
+    async def test_missing_session_config_entirely_raises_at_connect_time(self) -> None:
+        async def customizer(req: TwiMLRequest) -> dict | None:
+            return None
+
+        tac = TAC(get_test_tac_config())
+        config = OpenAIRealtimeProviderConfig(
+            openai_api_key="sk-test", on_inbound_call_session_config=customizer
+        )
+        provider = VoiceChannel(tac, config=config)._provider
+
+        with pytest.raises(ValueError, match="No session_config available"):
+            await provider._connect_model("CA_NONE")
+
+
+class TestOutboundCallSessionConfig:
+    """Per-outbound-call session_config via InitiateVoiceConversationOptionsOpenAIRealtime."""
+
+    @pytest.mark.asyncio
+    async def test_session_config_stashed_under_the_placed_call_sid(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        mock_call = MagicMock(sid="CA_OUT")
+        mock_client = MagicMock()
+        mock_client.calls.create.return_value = mock_call
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            result = await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptionsOpenAIRealtime(
+                    to="+15551234567",
+                    session_config={"model": "gpt-realtime-outbound"},
+                )
+            )
+
+        assert result.call_sid == "CA_OUT"
+        assert provider._call_session_configs["CA_OUT"] == {"model": "gpt-realtime-outbound"}
+
+    @pytest.mark.asyncio
+    async def test_plain_options_type_ignored_falls_back_to_default(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        mock_call = MagicMock(sid="CA_OUT2")
+        mock_client = MagicMock()
+        mock_client.calls.create.return_value = mock_call
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptions(to="+15551234567")
+            )
+
+        assert provider._call_session_configs == {}
+
+    @pytest.mark.asyncio
+    async def test_outbound_only_config_with_no_default_connects_via_per_call_override(
+        self,
+    ) -> None:
+        tac = TAC(get_test_tac_config())
+        config = OpenAIRealtimeProviderConfig(openai_api_key="sk-test")
+        channel = VoiceChannel(tac, config=config)
+        provider = channel._provider
+
+        mock_call = MagicMock(sid="CA_OUT3")
+        mock_client = MagicMock()
+        mock_client.calls.create.return_value = mock_call
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptionsOpenAIRealtime(
+                    to="+15551234567",
+                    session_config={"model": "gpt-realtime-outbound-only"},
+                )
+            )
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[{"event": "start", "start": {"callSid": "CA_OUT3", "streamSid": "MZ_OUT3"}}]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=False)
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ) as mock_connect:
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert "model=gpt-realtime-outbound-only" in mock_connect.call_args.args[0]

--- a/tests/test_openai_realtime_provider.py
+++ b/tests/test_openai_realtime_provider.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,12 +11,28 @@ from tac import TAC
 from tac.channels.voice import VoiceChannel
 from tac.channels.voice.media_streams.openai_realtime import OpenAIRealtimeProviderConfig
 from tac.channels.voice.media_streams.openai_realtime.models import _BargeInState, _CallState
+from tac.channels.voice.media_streams.openai_realtime.provider import (
+    _SESSION_CONFIG_TOKEN_PARAM,
+    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+)
 from tac.models.outbound import (
     InitiateVoiceConversationOptions,
     InitiateVoiceConversationOptionsOpenAIRealtime,
 )
 from tac.models.voice import TwiMLRequest
 from tac.tools import function_tool
+
+_VALID_AUDIO = {
+    "input": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+    "output": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+}
+
+
+def _extract_custom_parameter(twiml: str, name: str) -> str:
+    """Pull a <Parameter name="..." value="..."> value out of generated TwiML."""
+    match = re.search(rf'<Parameter name="{re.escape(name)}" value="([^"]*)"', twiml)
+    assert match, f"parameter {name!r} not found in TwiML: {twiml}"
+    return match.group(1)
 
 
 def get_test_tac_config() -> dict:
@@ -34,7 +51,7 @@ def make_channel(**config_kwargs: object) -> VoiceChannel:
     tac = TAC(get_test_tac_config())
     config = OpenAIRealtimeProviderConfig(
         openai_api_key="sk-test",
-        default_session_config={"model": "gpt-realtime-test"},
+        default_session_config={"model": "gpt-realtime-test", "audio": _VALID_AUDIO},
         **config_kwargs,
     )
     return VoiceChannel(tac, config=config)
@@ -383,6 +400,33 @@ class TestToolCalls:
 
         assert result == 5
 
+    @pytest.mark.asyncio
+    async def test_non_serializable_output_still_sends_function_call_output(self) -> None:
+        """A tool that runs successfully but returns something json.dumps
+        can't handle must still produce a function_call_output — otherwise
+        the model is left waiting on a call_id it never gets a result for."""
+
+        @function_tool()
+        def broken_output() -> object:
+            """Return a value json.dumps can't serialize."""
+            return object()
+
+        channel = make_channel(tools=[broken_output])
+        provider = channel._provider
+
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA9"] = _CallState(model_ws=model_ws)
+
+        await provider._handle_function_call(
+            "CA9", {"call_id": "call_1", "name": "broken_output", "arguments": "{}"}
+        )
+
+        outputs = [m for m in model_ws.sent if m["type"] == "conversation.item.create"]
+        assert len(outputs) == 1
+        payload = json.loads(outputs[0]["item"]["output"])
+        assert "error" in payload
+        assert {"type": "response.create"} in model_ws.sent
+
 
 class TestConfigValidation:
     """OpenAIRealtimeProviderConfig fails fast on unusable combinations."""
@@ -414,7 +458,11 @@ class TestInboundCallSessionConfig:
 
         async def customizer(req: TwiMLRequest) -> dict | None:
             if req.caller_country == "MX":
-                return {"model": "gpt-realtime-mx", "instructions": "Habla en español."}
+                return {
+                    "model": "gpt-realtime-mx",
+                    "instructions": "Habla en español.",
+                    "audio": _VALID_AUDIO,
+                }
             return None
 
         channel = make_channel(on_inbound_call_session_config=customizer)
@@ -426,6 +474,7 @@ class TestInboundCallSessionConfig:
         assert provider._call_session_configs["CA_MX"] == {
             "model": "gpt-realtime-mx",
             "instructions": "Habla en español.",
+            "audio": _VALID_AUDIO,
         }
 
         twilio_ws = FakeTwilioWebSocket(
@@ -444,6 +493,7 @@ class TestInboundCallSessionConfig:
         assert sent_session["session"] == {
             "model": "gpt-realtime-mx",
             "instructions": "Habla en español.",
+            "audio": _VALID_AUDIO,
         }
         assert "CA_MX" not in provider._call_session_configs
 
@@ -472,7 +522,7 @@ class TestInboundCallSessionConfig:
             await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
 
         sent_session = next(m for m in model_ws.sent if m["type"] == "session.update")
-        assert sent_session["session"] == {"model": "gpt-realtime-test"}
+        assert sent_session["session"] == {"model": "gpt-realtime-test", "audio": _VALID_AUDIO}
 
     @pytest.mark.asyncio
     async def test_no_call_sid_skips_customizer(self) -> None:
@@ -516,7 +566,10 @@ class TestOutboundCallSessionConfig:
     """Per-outbound-call session_config via InitiateVoiceConversationOptionsOpenAIRealtime."""
 
     @pytest.mark.asyncio
-    async def test_session_config_stashed_under_the_placed_call_sid(self) -> None:
+    async def test_session_config_stashed_under_a_token_before_call_is_placed(self) -> None:
+        """Stashed under a token embedded in the TwiML, not call.sid — Twilio
+        connecting the stream doesn't happen-after calls.create() returning
+        call.sid, so keying by call.sid can race _register_call."""
         channel = make_channel()
         provider = channel._provider
 
@@ -533,7 +586,102 @@ class TestOutboundCallSessionConfig:
             )
 
         assert result.call_sid == "CA_OUT"
-        assert provider._call_session_configs["CA_OUT"] == {"model": "gpt-realtime-outbound"}
+        assert "CA_OUT" not in provider._call_session_configs
+        twiml = mock_client.calls.create.call_args.kwargs["twiml"]
+        token = _extract_custom_parameter(twiml, _SESSION_CONFIG_TOKEN_PARAM)
+        assert provider._call_session_configs[token] == {"model": "gpt-realtime-outbound"}
+
+    @pytest.mark.asyncio
+    async def test_session_config_token_rekeyed_to_call_sid_on_connect(self) -> None:
+        """Once the WebSocket start event arrives, the token entry is
+        rekeyed to call_sid and consumed by _connect_model."""
+        channel = make_channel()
+        provider = channel._provider
+
+        mock_call = MagicMock(sid="CA_OUT4")
+        mock_client = MagicMock()
+        mock_client.calls.create.return_value = mock_call
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptionsOpenAIRealtime(
+                    to="+15551234567",
+                    session_config={"model": "gpt-realtime-outbound4", "audio": _VALID_AUDIO},
+                )
+            )
+
+        twiml = mock_client.calls.create.call_args.kwargs["twiml"]
+        token = _extract_custom_parameter(twiml, _SESSION_CONFIG_TOKEN_PARAM)
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {
+                    "event": "start",
+                    "start": {
+                        "callSid": "CA_OUT4",
+                        "streamSid": "MZ_OUT4",
+                        "customParameters": {_SESSION_CONFIG_TOKEN_PARAM: token},
+                    },
+                }
+            ]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=False)
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ) as mock_connect:
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert "model=gpt-realtime-outbound4" in mock_connect.call_args.args[0]
+        sent_session = next(m for m in model_ws.sent if m["type"] == "session.update")
+        assert sent_session["session"] == {
+            "model": "gpt-realtime-outbound4",
+            "audio": _VALID_AUDIO,
+        }
+        assert provider._call_session_configs == {}
+
+    @pytest.mark.asyncio
+    async def test_session_config_token_cleaned_up_if_call_creation_fails(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        mock_client = MagicMock()
+        mock_client.calls.create.side_effect = RuntimeError("boom")
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            with pytest.raises(RuntimeError):
+                await provider.initiate_outbound_conversation(
+                    InitiateVoiceConversationOptionsOpenAIRealtime(
+                        to="+15551234567",
+                        session_config={"model": "gpt-realtime-outbound"},
+                    )
+                )
+
+        assert provider._call_session_configs == {}
+
+    @pytest.mark.asyncio
+    async def test_session_config_token_not_leaked_if_twiml_build_fails(self) -> None:
+        """A failure building the TwiML itself (e.g. no resolvable WebSocket
+        URL) happens before calls.create() is ever attempted — the token
+        must not be stashed until that succeeds, or it's never cleaned up."""
+        tac = TAC(get_test_tac_config())
+        config = OpenAIRealtimeProviderConfig(
+            openai_api_key="sk-test", default_session_config={"model": "x", "audio": _VALID_AUDIO}
+        )
+        channel = VoiceChannel(tac, config=config)
+        provider = channel._provider
+        channel.tac.config.voice_public_domain = None  # no fallback WebSocket URL
+
+        with pytest.raises(ValueError, match="needs a WebSocket URL"):
+            await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptionsOpenAIRealtime(
+                    to="+15551234567",
+                    session_config={"model": "gpt-realtime-outbound"},
+                )
+            )
+
+        assert provider._call_session_configs == {}
 
     @pytest.mark.asyncio
     async def test_plain_options_type_ignored_falls_back_to_default(self) -> None:
@@ -568,12 +716,27 @@ class TestOutboundCallSessionConfig:
             await provider.initiate_outbound_conversation(
                 InitiateVoiceConversationOptionsOpenAIRealtime(
                     to="+15551234567",
-                    session_config={"model": "gpt-realtime-outbound-only"},
+                    session_config={
+                        "model": "gpt-realtime-outbound-only",
+                        "audio": _VALID_AUDIO,
+                    },
                 )
             )
 
+        twiml = mock_client.calls.create.call_args.kwargs["twiml"]
+        token = _extract_custom_parameter(twiml, _SESSION_CONFIG_TOKEN_PARAM)
+
         twilio_ws = FakeTwilioWebSocket(
-            events=[{"event": "start", "start": {"callSid": "CA_OUT3", "streamSid": "MZ_OUT3"}}]
+            events=[
+                {
+                    "event": "start",
+                    "start": {
+                        "callSid": "CA_OUT3",
+                        "streamSid": "MZ_OUT3",
+                        "customParameters": {_SESSION_CONFIG_TOKEN_PARAM: token},
+                    },
+                }
+            ]
         )
         model_ws = FakeModelWebSocket(events=[], stay_open=False)
 

--- a/tests/test_openai_realtime_twiml.py
+++ b/tests/test_openai_realtime_twiml.py
@@ -1,0 +1,249 @@
+"""Tests for OpenAIRealtimeProvider's TwiML generation and layering.
+
+Media Streams' ``generate_twiml``/``TwiMLBuilderMediaStreams`` are a
+separate implementation from ConversationRelay's (see test_voice_channel.py
+for that one) — same shape (customizer > default > host > TAC-default
+layering), different verb (``<Connect><Stream>`` vs ``<ConversationRelay>``).
+"""
+
+import pytest
+
+from tac.channels.voice.media_streams.openai_realtime import OpenAIRealtimeProviderConfig
+from tac.channels.voice.media_streams.openai_realtime.twiml import (
+    TwiMLBuilderMediaStreams,
+    generate_twiml,
+)
+from tac.core.config import TACConfig
+from tac.models.voice import VoiceTwiMLOptionsMediaStreams
+
+
+def get_test_tac_config(**overrides: object) -> TACConfig:
+    defaults: dict[str, object] = {
+        "account_sid": "ACtest123",
+        "auth_token": "test_token_123",
+        "api_key": "SK123",
+        "api_secret": "test_api_token",
+        "phone_number": "+15551234567",
+        "voice_public_domain": "example.com",
+    }
+    defaults.update(overrides)
+    return TACConfig(**defaults)  # type: ignore[arg-type]
+
+
+def get_test_channel_config(
+    default_twiml_options: VoiceTwiMLOptionsMediaStreams | None = None,
+) -> OpenAIRealtimeProviderConfig:
+    return OpenAIRealtimeProviderConfig(
+        openai_api_key="sk-test",
+        default_session_config={"model": "gpt-realtime-test"},
+        default_twiml_options=default_twiml_options,
+    )
+
+
+class TestGenerateTwiml:
+    def test_minimal(self) -> None:
+        twiml = generate_twiml("wss://example.com/ws")
+
+        assert '<?xml version="1.0" encoding="UTF-8"?>' in twiml
+        assert '<Stream url="wss://example.com/ws" />' in twiml
+        assert "<Connect>" in twiml and "</Connect>" in twiml
+        assert "<Parameter" not in twiml
+
+    def test_url_from_options_only(self) -> None:
+        twiml = generate_twiml(
+            options=VoiceTwiMLOptionsMediaStreams(websocket_url="wss://o.com/ws")
+        )
+
+        assert 'url="wss://o.com/ws"' in twiml
+
+    def test_positional_url_wins_over_options(self) -> None:
+        twiml = generate_twiml(
+            "wss://positional.com/ws",
+            VoiceTwiMLOptionsMediaStreams(websocket_url="wss://options.com/ws"),
+        )
+
+        assert 'url="wss://positional.com/ws"' in twiml
+        assert "options.com" not in twiml
+
+    def test_requires_a_url(self) -> None:
+        with pytest.raises(ValueError, match="requires a WebSocket URL"):
+            generate_twiml()
+
+    def test_whitespace_only_url_rejected(self) -> None:
+        with pytest.raises(ValueError, match="requires a WebSocket URL"):
+            generate_twiml("   ")
+
+    def test_dict_options_coerced(self) -> None:
+        twiml = generate_twiml("wss://example.com/ws", {"name": "my-stream"})
+
+        assert 'name="my-stream"' in twiml
+
+    def test_name_status_callback_rendered(self) -> None:
+        twiml = generate_twiml(
+            "wss://example.com/ws",
+            VoiceTwiMLOptionsMediaStreams(
+                name="my-stream",
+                status_callback="https://example.com/status",
+                status_callback_method="GET",
+            ),
+        )
+
+        assert 'name="my-stream"' in twiml
+        assert 'statusCallback="https://example.com/status"' in twiml
+        assert 'statusCallbackMethod="GET"' in twiml
+
+    def test_action_url_and_method_on_connect(self) -> None:
+        twiml = generate_twiml(
+            "wss://example.com/ws",
+            VoiceTwiMLOptionsMediaStreams(
+                action_url="https://example.com/action", action_method="GET"
+            ),
+        )
+
+        assert '<Connect action="https://example.com/action" method="GET">' in twiml
+
+    def test_custom_parameters_rendered_as_parameter_children(self) -> None:
+        twiml = generate_twiml(
+            "wss://example.com/ws",
+            VoiceTwiMLOptionsMediaStreams(
+                custom_parameters={"profile_id": "prof_1", "count": 3, "skip_me": None}
+            ),
+        )
+
+        assert '<Parameter name="profile_id" value="prof_1" />' in twiml
+        assert '<Parameter name="count" value="3" />' in twiml
+        assert "skip_me" not in twiml
+
+    def test_no_custom_parameters_by_default(self) -> None:
+        twiml = generate_twiml("wss://example.com/ws")
+
+        assert "<Parameter" not in twiml
+
+
+class TestTwiMLBuilderMediaStreamsPrecedence:
+    """per_call > default_twiml_options > host > TAC defaults, merged per-field."""
+
+    def test_tac_default_websocket_url_used_when_nothing_else_set(self) -> None:
+        builder = TwiMLBuilderMediaStreams(
+            get_test_tac_config(voice_public_domain="example.com"),
+            get_test_channel_config(),
+        )
+
+        twiml = builder.build("test")
+
+        assert 'url="wss://example.com/ws"' in twiml
+
+    def test_no_url_anywhere_raises_with_caller_name(self) -> None:
+        builder = TwiMLBuilderMediaStreams(
+            get_test_tac_config(voice_public_domain=None), get_test_channel_config()
+        )
+
+        with pytest.raises(ValueError, match="my_caller needs a WebSocket URL"):
+            builder.build("my_caller")
+
+    def test_explicit_websocket_url_arg_wins_over_everything(self) -> None:
+        builder = TwiMLBuilderMediaStreams(
+            get_test_tac_config(voice_public_domain="fallback.com"),
+            get_test_channel_config(
+                default_twiml_options=VoiceTwiMLOptionsMediaStreams(
+                    websocket_url="wss://default.com/ws"
+                )
+            ),
+        )
+
+        twiml = builder.build(
+            "test",
+            per_call=VoiceTwiMLOptionsMediaStreams(websocket_url="wss://per-call.com/ws"),
+            websocket_url="wss://explicit.com/ws",
+        )
+
+        assert 'url="wss://explicit.com/ws"' in twiml
+
+    def test_default_twiml_options_used_when_no_per_call_or_host(self) -> None:
+        builder = TwiMLBuilderMediaStreams(
+            get_test_tac_config(),
+            get_test_channel_config(
+                default_twiml_options=VoiceTwiMLOptionsMediaStreams(name="default-stream")
+            ),
+        )
+
+        twiml = builder.build("test")
+
+        assert 'name="default-stream"' in twiml
+
+    def test_per_call_overrides_default_twiml_options(self) -> None:
+        builder = TwiMLBuilderMediaStreams(
+            get_test_tac_config(),
+            get_test_channel_config(
+                default_twiml_options=VoiceTwiMLOptionsMediaStreams(name="default-stream")
+            ),
+        )
+
+        twiml = builder.build(
+            "test", per_call=VoiceTwiMLOptionsMediaStreams(name="per-call-stream")
+        )
+
+        assert 'name="per-call-stream"' in twiml
+        assert "default-stream" not in twiml
+
+    def test_per_call_only_overrides_the_fields_it_sets(self) -> None:
+        """Fields not set on per_call fall through to default_twiml_options —
+        overriding one field doesn't wipe out the others."""
+        builder = TwiMLBuilderMediaStreams(
+            get_test_tac_config(),
+            get_test_channel_config(
+                default_twiml_options=VoiceTwiMLOptionsMediaStreams(
+                    name="default-stream", status_callback="https://example.com/status"
+                )
+            ),
+        )
+
+        twiml = builder.build(
+            "test", per_call=VoiceTwiMLOptionsMediaStreams(name="per-call-stream")
+        )
+
+        assert 'name="per-call-stream"' in twiml
+        assert 'statusCallback="https://example.com/status"' in twiml
+
+    def test_host_options_fall_through_when_no_default_or_per_call(self) -> None:
+        builder = TwiMLBuilderMediaStreams(get_test_tac_config(), get_test_channel_config())
+
+        twiml = builder.build(
+            "test", host=VoiceTwiMLOptionsMediaStreams(websocket_url="wss://host.com/ws")
+        )
+
+        assert 'url="wss://host.com/ws"' in twiml
+
+    def test_default_twiml_options_overrides_host(self) -> None:
+        builder = TwiMLBuilderMediaStreams(
+            get_test_tac_config(),
+            get_test_channel_config(
+                default_twiml_options=VoiceTwiMLOptionsMediaStreams(name="default-stream")
+            ),
+        )
+
+        twiml = builder.build("test", host=VoiceTwiMLOptionsMediaStreams(name="host-stream"))
+
+        assert 'name="default-stream"' in twiml
+        assert "host-stream" not in twiml
+
+    def test_custom_parameters_replace_wholesale_not_merged(self) -> None:
+        """A higher-priority layer's custom_parameters replaces the lower
+        layer's entirely — no per-key merging."""
+        builder = TwiMLBuilderMediaStreams(
+            get_test_tac_config(),
+            get_test_channel_config(
+                default_twiml_options=VoiceTwiMLOptionsMediaStreams(
+                    custom_parameters={"a": "1", "b": "2"}
+                )
+            ),
+        )
+
+        twiml = builder.build(
+            "test",
+            per_call=VoiceTwiMLOptionsMediaStreams(custom_parameters={"c": "3"}),
+        )
+
+        assert '<Parameter name="c" value="3" />' in twiml
+        assert 'name="a"' not in twiml
+        assert 'name="b"' not in twiml

--- a/uv.lock
+++ b/uv.lock
@@ -2820,7 +2820,7 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.20,<1" },
     { name = "twilio", specifier = ">=9.8.3,<10" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.32.0,<1" },
-    { name = "websockets", marker = "extra == 'openai-realtime'", specifier = ">=13,<17" },
+    { name = "websockets", marker = "extra == 'openai-realtime'", specifier = ">=14,<17" },
 ]
 provides-extras = ["server", "openai-realtime"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2777,6 +2777,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+openai-realtime = [
+    { name = "websockets" },
+]
 server = [
     { name = "fastapi" },
     { name = "python-multipart" },
@@ -2817,8 +2820,9 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.20,<1" },
     { name = "twilio", specifier = ">=9.8.3,<10" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.32.0,<1" },
+    { name = "websockets", marker = "extra == 'openai-realtime'", specifier = ">=13,<17" },
 ]
-provides-extras = ["server"]
+provides-extras = ["server", "openai-realtime"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds `OpenAIRealtimeProvider`, a second `VoiceProvider` implementation that bridges Twilio's bidirectional `<Connect><Stream>` Media Streams to OpenAI's Realtime API — built purely by inheriting the `VoiceProvider`/`VoiceTwiMLOptions` bases introduced in #117, with no changes to those base classes themselves.

- **`VoiceTwiMLOptionsMediaStreams`** (`models/voice.py`) — TwiML options for `<Connect><Stream>`, including `name`/`statusCallback`/`statusCallbackMethod`/`action`/`method` (per Twilio's docs — these were originally left as a TODO, now resolved).
- **`OpenAIRealtimeProvider` + `OpenAIRealtimeProviderConfig`** (`channels/voice/media_streams/openai_realtime/`) — handles inbound and outbound calls, the Twilio↔OpenAI audio bridge, tool calling, and barge-in:
  - `audio_end_ms` for `conversation.item.truncate` is computed from actual audio-delta byte counts, not a wall-clock estimate (the wall-clock version can overshoot the item's real content and get rejected by OpenAI).
  - `response.cancel` is only sent when a response is actually in flight (tracked via `response.created`/`response.done`) — sending it with nothing to cancel is itself an error event.
  - Runs in relay-only mode regardless of TAC's Conversation Orchestrator configuration — no CO integration, matching the existing relay-only pattern.
  - A single failure handling one model event no longer kills the whole read loop for the rest of the call — only the socket actually closing does.
  - `session_config.audio.input/output.format` is validated against `TWILIO_MEDIA_STREAM_AUDIO_FORMAT` before connecting — Media Streams only supports 8kHz mu-law, so a mismatched or missing format now fails clearly instead of silently corrupting audio.
  - A tool call always gets a `function_call_output`, even when its return value isn't JSON-serializable (a `datetime`, a Pydantic model, ...) — otherwise the model is left waiting on a `call_id` it never gets a result for.
- **Per-call `session_config` overrides** — `default_session_config` applies to every call unless overridden:
  - Inbound: `OpenAIRealtimeProviderConfig.on_inbound_call_session_config`, a customizer called with the inbound `TwiMLRequest` that returns the `session_config` to use for that call (or `None` to fall back to `default_session_config`).
  - Outbound: `InitiateVoiceConversationOptionsOpenAIRealtime.session_config`, passed directly at `initiate_outbound_conversation` call time — outbound has no webhook round-trip to hang a customizer off of, so the caller already knows everything at the call site. Correlated to its WebSocket `start` event via a token embedded in the TwiML's `custom_parameters` (set before the call is placed), not `call.sid` — `calls.create()` returning `call.sid` doesn't happen-before Twilio actually connecting the stream, so keying by `call.sid` could race.
  - `default_session_config` is now optional — a provider used purely for outbound calls that always supplies `session_config` per-call no longer needs one.
- **`TwiMLBuilderMediaStreams`** — same `customizer > default_twiml_options > host > TAC-default` layering as `ConversationRelayProvider`'s builder. Covered by new tests in `tests/test_openai_realtime_twiml.py` (previously untested).
- **`TACTool.to_realtime_format()`** — Realtime's flat (non-nested) tool-calling schema.
- New optional dependency group `openai-realtime` (`websockets`).
- Example: `getting_started/examples/partners/openai_realtime.py` (moved from `features/s2s/` to match this repo's partner-example naming convention) — tested end-to-end against real inbound and outbound calls (VAD/barge-in, tool calling, transcript capture, per-call session_config overrides on both directions).

Session state (`stream_sid`, `transcript`) lives on `ConversationSession.metadata` rather than provider-internal state, so it survives into `on_conversation_ended`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated (existing suite covers the shared base classes this builds on, plus new coverage for per-call session_config on both inbound and outbound, and dedicated TwiML-layering tests)
- [x] Documentation updated (docstrings, example)
- [x] Tested E2E (real inbound and outbound calls, multiple barge-ins, tool calling, transcript capture, per-call session_config overrides)

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [x] Change is Python-specific (no TypeScript update needed)
