### PR TITLE
refactor(voice): move ConversationRelay files into a conversation_relay package

### DIFF
--- a/src/tac/channels/voice/__init__.py
+++ b/src/tac/channels/voice/__init__.py
@@ -12,10 +12,13 @@ from tac.channels.voice.channel import (
     RecordingHandler,
     VoiceChannel,
 )
-from tac.channels.voice.config import ConversationRelayProviderConfig, VoiceChannelConfig
-from tac.channels.voice.conversation_relay import ConversationRelayProvider
+from tac.channels.voice.conversation_relay import (
+    ConversationRelayProvider,
+    ConversationRelayProviderConfig,
+    VoiceChannelConfig,
+    generate_twiml,
+)
 from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
-from tac.channels.voice.twiml import generate_twiml
 from tac.models.outbound import CallOptions
 from tac.models.voice import (
     AmdEvent,

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -23,7 +23,7 @@ from tac.models.voice import (
     VoiceTwiMLOptions,
 )
 
-from .config import VoiceChannelConfig
+from .conversation_relay import VoiceChannelConfig
 from .provider import VoiceProviderConfig
 
 InboundCallTwiMLHandler = Callable[[TwiMLRequest], Awaitable[VoiceTwiMLOptions]]

--- a/src/tac/channels/voice/conversation_relay/__init__.py
+++ b/src/tac/channels/voice/conversation_relay/__init__.py
@@ -1,0 +1,17 @@
+"""``ConversationRelayProvider``: the default ``VoiceProvider`` — Twilio
+ConversationRelay's managed setup/prompt/interrupt loop over one WebSocket.
+"""
+
+from tac.channels.voice.conversation_relay.config import (
+    ConversationRelayProviderConfig,
+    VoiceChannelConfig,
+)
+from tac.channels.voice.conversation_relay.provider import ConversationRelayProvider
+from tac.channels.voice.conversation_relay.twiml import generate_twiml
+
+__all__ = [
+    "ConversationRelayProvider",
+    "ConversationRelayProviderConfig",
+    "VoiceChannelConfig",
+    "generate_twiml",
+]

--- a/src/tac/channels/voice/conversation_relay/config.py
+++ b/src/tac/channels/voice/conversation_relay/config.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import Field
 
-from tac.channels.voice.conversation_relay import ConversationRelayProvider
+from tac.channels.voice.conversation_relay.provider import ConversationRelayProvider
 from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
 from tac.core.config import TACConfig
 
@@ -85,7 +85,7 @@ class ConversationRelayProviderConfig(VoiceProviderConfig):
         "customization is registered via VoiceChannel.on_inbound_call_twiml(...). "
         "Note: ``custom_parameters`` and ``languages`` replace wholesale when a "
         "higher-priority layer sets them — see "
-        "tac.channels.voice.twiml.TwiMLBuilderConversationRelay._overlay_fields.",
+        "tac.channels.voice.conversation_relay.twiml.TwiMLBuilderConversationRelay._overlay_fields.",
     )
     default_call_options: CallOptions | None = Field(
         default=None,

--- a/src/tac/channels/voice/conversation_relay/provider.py
+++ b/src/tac/channels/voice/conversation_relay/provider.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
 
+from tac.channels.voice.conversation_relay.twiml import TwiMLBuilderConversationRelay
 from tac.channels.voice.provider import VoiceProvider
 from tac.channels.websocket_manager import WebSocketManager
 from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
@@ -35,11 +36,9 @@ from tac.models.voice import (
 from tac.session import SessionState
 from tac.utils.redaction import mask_phone, redact_twiml_parameters
 
-from . import twiml
-
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
-    from tac.channels.voice.config import ConversationRelayProviderConfig
+    from tac.channels.voice.conversation_relay.config import ConversationRelayProviderConfig
 
 _POLL_ATTEMPTS = 10
 _POLL_BASE_DELAY = 0.25
@@ -67,7 +66,7 @@ class ConversationRelayProvider(VoiceProvider):
         self.config = config
         self.session_manager = config.session_manager
         self._websocket_manager = WebSocketManager()
-        self._twiml = twiml.TwiMLBuilderConversationRelay(tac_config, config)
+        self._twiml = TwiMLBuilderConversationRelay(tac_config, config)
 
     @property
     def channel_name(self) -> str:

--- a/src/tac/channels/voice/conversation_relay/twiml.py
+++ b/src/tac/channels/voice/conversation_relay/twiml.py
@@ -12,7 +12,7 @@ from tac.models.voice import VoiceTwiMLOptionsConversationRelay
 from tac.tools.handoff import studio_voice_handoff_url
 
 if TYPE_CHECKING:
-    from .config import VoiceChannelConfig
+    from tac.channels.voice.conversation_relay.config import VoiceChannelConfig
 
 # Fields on VoiceTwiMLOptionsConversationRelay that map to <ConversationRelay> attributes
 # and are emitted via the snake_case → camelCase conversion done by twilio's SDK.

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -361,7 +361,7 @@ class TestVoiceChannel:
     async def test_process_webhook_conversation_inactive(self) -> None:
         """Test that INACTIVE invalidates cached memory when memory_mode='once'."""
 
-        from tac.channels.voice.config import VoiceChannelConfig
+        from tac.channels.voice.conversation_relay import VoiceChannelConfig
 
         tac = TAC(get_test_config())
         # Enable "once" mode to trigger cache invalidation
@@ -2077,7 +2077,7 @@ class TestConversationInitializationFlow:
         assert profile_id == "profile_voice_correct"
 
     @pytest.mark.asyncio
-    @patch("tac.channels.voice.conversation_relay._POLL_BASE_DELAY", 0)
+    @patch("tac.channels.voice.conversation_relay.provider._POLL_BASE_DELAY", 0)
     async def test_error_when_no_conversations_found(self, capsys: pytest.CaptureFixture) -> None:
         """Test RuntimeError when ConversationRelay creates 0 conversations."""
         from tac.channels.websocket_protocol import WebSocketDisconnectError
@@ -2114,7 +2114,7 @@ class TestConversationInitializationFlow:
         assert len(channel._conversations) == 0
 
     @pytest.mark.asyncio
-    @patch("tac.channels.voice.conversation_relay._POLL_BASE_DELAY", 0)
+    @patch("tac.channels.voice.conversation_relay.provider._POLL_BASE_DELAY", 0)
     async def test_error_when_multiple_conversations_found(
         self, capsys: pytest.CaptureFixture
     ) -> None:


### PR DESCRIPTION
## Summary

- Moves `config.py`, `twiml.py`, and `conversation_relay.py` (renamed to `provider.py`) into a new `src/tac/channels/voice/conversation_relay/` package, mirroring the `media_streams/openai_realtime/` layout.
- Used `git mv` throughout so file history is preserved — this is a pure structural move, no behavior change.
- Updated all internal import paths (`voice/__init__.py`, `voice/channel.py`) and the two spots in `tests/test_voice_channel.py` that referenced the old module paths (one `import`, two `@patch(...)` targets).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested E2E

## SDK Parity

- [x] Change is Python-specific (no TypeScript update needed)

## Test plan

- [x] `ruff check` / `ruff format --check` pass
- [x] `make type-check` passes (87 source files)
- [x] Full test suite passes (165 tests)
- [x] Verified `git status`/`git diff` show clean renames (not new files) for the three moved files
- [x] Live end-to-end call test against `getting_started/examples/features/voice_streaming.py` — full ConversationRelay flow (setup → CO conversation polling → memory retrieval → cleanup → callback) works with the new module paths