### PR TITLE
refactor(voice): share TwiML-builder and call-event wiring across VoiceProviders

### DIFF
--- a/src/tac/channels/voice/conversation_relay/provider.py
+++ b/src/tac/channels/voice/conversation_relay/provider.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
@@ -17,7 +17,7 @@ from tac.channels.voice.conversation_relay.twiml import TwiMLBuilderConversation
 from tac.channels.voice.provider import VoiceProvider
 from tac.channels.websocket_manager import WebSocketManager
 from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
-from tac.core.config import CallEventKind, TACConfig
+from tac.core.config import TACConfig
 from tac.models.outbound import (
     CallOptions,
     InitiateVoiceConversationOptions,
@@ -463,30 +463,10 @@ class ConversationRelayProvider(VoiceProvider):
         Layers, highest precedence first: this call's ``call_options``,
         ``ConversationRelayProviderConfig.default_call_options``, then callback URLs derived
         from ``voice_public_domain`` + ``voice_call_event_path``.
-
-        A URL is derived only when its handler is registered. That's a deliberate
-        deviation from ``websocket_url`` / ``action_url``, which derive
-        unconditionally: those are load-bearing, so a wrong one fails loudly on
-        the first call, whereas an unwanted call-event URL fails as silent 11200
-        alerts for a feature nobody asked for. Set the URLs in
-        ``default_call_options`` when TAC isn't serving the routes.
         """
         merged = self._merge_call_options(call_options)
         call_kwargs = merged.to_call_kwargs() if merged else {}
-
-        wiring: list[tuple[CallEventKind, str, Callable[..., Any] | None]] = [
-            ("status", "status_callback", self.channel._on_call_status),
-            ("amd", "async_amd_status_callback", self.channel._on_amd),
-            ("recording", "recording_status_callback", self.channel._on_recording),
-        ]
-        for kind, param, handler in wiring:
-            if handler is None:
-                continue
-            url = self.channel.tac.config.call_event_url(kind)
-            if url is not None:
-                call_kwargs.setdefault(param, url)
-
-        return call_kwargs
+        return self._apply_call_event_callbacks(call_kwargs)
 
     async def initiate_outbound_conversation(
         self,

--- a/src/tac/channels/voice/conversation_relay/twiml.py
+++ b/src/tac/channels/voice/conversation_relay/twiml.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 from twilio.twiml.voice_response import VoiceResponse
 
-from tac.core.config import TACConfig
+from tac.channels.voice.twiml import TwiMLBuilderBase
 from tac.models.voice import VoiceTwiMLOptionsConversationRelay
 from tac.tools.handoff import studio_voice_handoff_url
 
@@ -200,7 +200,7 @@ def generate_twiml(
 DEFAULT_WELCOME_GREETING = "Hello! How can I assist you today?"
 
 
-class TwiMLBuilderConversationRelay:
+class TwiMLBuilderConversationRelay(TwiMLBuilderBase):
     """Builds the TwiML for a ConversationRelay call, owning every layering
     and resolution decision so ``VoiceChannel`` doesn't have to.
 
@@ -210,11 +210,7 @@ class TwiMLBuilderConversationRelay:
     has to compute and hand over.
     """
 
-    def __init__(
-        self, tac_config: TACConfig, channel_config: ConversationRelayProviderConfig
-    ) -> None:
-        self.tac_config = tac_config
-        self.channel_config = channel_config
+    channel_config: ConversationRelayProviderConfig
 
     def build(
         self,
@@ -250,15 +246,10 @@ class TwiMLBuilderConversationRelay:
             resolved_websocket_url = websocket_url
         elif merged.websocket_url is not None:
             resolved_websocket_url = merged.websocket_url
-        elif self.tac_config.voice_public_domain:
-            resolved_websocket_url = (
-                f"wss://{self.tac_config.voice_public_domain}{self.tac_config.voice_websocket_path}"
-            )
+        elif (default_url := self._default_websocket_url()) is not None:
+            resolved_websocket_url = default_url
         else:
-            raise ValueError(
-                f"{caller} needs a WebSocket URL. Set TWILIO_VOICE_PUBLIC_DOMAIN "
-                "(or TACConfig.voice_public_domain)."
-            )
+            raise self._missing_websocket_url_error(caller)
 
         return generate_twiml(resolved_websocket_url, merged)
 
@@ -277,35 +268,16 @@ class TwiMLBuilderConversationRelay:
             conversation_configuration=self.tac_config.conversation_configuration_id,
             action_url=self._resolve_action_url(host, per_call),
         )
+        # action_url is resolved above via _resolve_action_url, so skip it here.
         if host is not None:
-            self._overlay_fields(merged, host)
+            self._overlay_fields(merged, host, skip={"action_url"})
         if self.channel_config.default_twiml_options is not None:
-            self._overlay_fields(merged, self.channel_config.default_twiml_options)
+            self._overlay_fields(
+                merged, self.channel_config.default_twiml_options, skip={"action_url"}
+            )
         if per_call is not None:
-            self._overlay_fields(merged, per_call)
+            self._overlay_fields(merged, per_call, skip={"action_url"})
         return merged
-
-    @staticmethod
-    def _overlay_fields(
-        target: VoiceTwiMLOptionsConversationRelay, source: VoiceTwiMLOptionsConversationRelay
-    ) -> None:
-        """Apply fields explicitly set on ``source`` onto ``target``.
-
-        Nested models (``custom_parameters``), lists (``languages``), and
-        dicts (``extra``) replace wholesale — there's no per-key merging.
-        If you add a field that should merge (e.g. a dict of headers),
-        special-case it here instead of getting the default overwrite behavior.
-
-        ``action_url`` is skipped here on purpose — it's resolved once via
-        ``_resolve_action_url`` looking at every layer at once, and that
-        resolved value is written into ``target`` before this overlay runs.
-        Letting it through here would let a higher-priority layer that didn't
-        set action_url silently clobber a lower layer that did.
-        """
-        for field in source.model_fields_set:
-            if field == "action_url":
-                continue
-            setattr(target, field, getattr(source, field))
 
     def _resolve_action_url(
         self,

--- a/src/tac/channels/voice/media_streams/config.py
+++ b/src/tac/channels/voice/media_streams/config.py
@@ -1,0 +1,24 @@
+"""Shared configuration for ``VoiceProvider``s built on Twilio Media Streams."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from tac.channels.voice.provider import VoiceProviderConfig
+from tac.models.voice import VoiceTwiMLOptionsMediaStreams
+
+
+class MediaStreamsProviderConfig(VoiceProviderConfig):
+    """Base configuration for a Media Streams (``<Connect><Stream>``) provider.
+
+    ``OpenAIRealtimeProviderConfig`` is the only subclass today. Lives here
+    (not in ``openai_realtime/config.py``) so a future Media Streams provider's
+    config only needs to import this module, not anything OpenAI-specific.
+    """
+
+    default_twiml_options: VoiceTwiMLOptionsMediaStreams | None = Field(
+        default=None,
+        description="Static VoiceTwiMLOptionsMediaStreams applied to every inbound call. "
+        "Per-call customization is registered via VoiceChannel.on_inbound_call_twiml(...), "
+        "which takes precedence over this.",
+    )

--- a/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
@@ -5,12 +5,10 @@ from tac.channels.voice.media_streams.openai_realtime.provider import (
     TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
     OpenAIRealtimeProvider,
 )
-from tac.channels.voice.media_streams.openai_realtime.twiml import (
-    VoiceTwiMLOptionsMediaStreams,
-    generate_twiml,
-)
+from tac.channels.voice.media_streams.twiml import generate_twiml
 from tac.models.outbound import InitiateVoiceConversationOptionsOpenAIRealtime
 from tac.models.stream import StreamStartMessage
+from tac.models.voice import VoiceTwiMLOptionsMediaStreams
 
 __all__ = [
     "TWILIO_MEDIA_STREAM_AUDIO_FORMAT",

--- a/src/tac/channels/voice/media_streams/openai_realtime/config.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/config.py
@@ -8,17 +8,18 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, model_validator
 
+from tac.channels.voice.media_streams.config import MediaStreamsProviderConfig
 from tac.channels.voice.media_streams.openai_realtime.provider import OpenAIRealtimeProvider
-from tac.channels.voice.provider import VoiceProvider, VoiceProviderConfig
+from tac.channels.voice.provider import VoiceProvider
 from tac.core.config import TACConfig
-from tac.models.voice import TwiMLRequest, VoiceTwiMLOptionsMediaStreams
+from tac.models.voice import TwiMLRequest
 from tac.tools import TACTool
 
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
 
 
-class OpenAIRealtimeProviderConfig(VoiceProviderConfig):
+class OpenAIRealtimeProviderConfig(MediaStreamsProviderConfig):
     """Configuration for ``OpenAIRealtimeProvider``."""
 
     model_config = {"extra": "forbid", "arbitrary_types_allowed": True}
@@ -50,12 +51,6 @@ class OpenAIRealtimeProviderConfig(VoiceProviderConfig):
         "client-events#session.update for the schema. If using `tools`, its 'tools' entry "
         "must separately list each tool's `to_realtime_format()` schema — this config is "
         "passed to OpenAI as-is, with no tool schemas merged in.",
-    )
-    default_twiml_options: VoiceTwiMLOptionsMediaStreams | None = Field(
-        default=None,
-        description="Static VoiceTwiMLOptionsMediaStreams applied to every inbound call. "
-        "Per-call customization is registered via VoiceChannel.on_inbound_call_twiml(...), "
-        "which takes precedence over this.",
     )
     on_inbound_call_session_config: (
         Callable[[TwiMLRequest], Awaitable[dict[str, Any] | None]] | None

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -15,19 +15,16 @@ import base64
 import contextlib
 import json
 import uuid
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
 import websockets
 
 from tac.channels.voice.media_streams.openai_realtime.models import _CallState
-from tac.channels.voice.media_streams.openai_realtime.twiml import (
-    TwiMLBuilderMediaStreams,
-    VoiceTwiMLOptionsMediaStreams,
-)
+from tac.channels.voice.media_streams.twiml import TwiMLBuilderMediaStreams
 from tac.channels.voice.provider import VoiceProvider
 from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
-from tac.core.config import CallEventKind, TACConfig
+from tac.core.config import TACConfig
 from tac.models.outbound import (
     CallOptions,
     InitiateVoiceConversationOptions,
@@ -36,7 +33,7 @@ from tac.models.outbound import (
 )
 from tac.models.session import ConversationSession
 from tac.models.stream import StreamStartMessage
-from tac.models.voice import TwiMLRequest, VoiceTwiMLOptions
+from tac.models.voice import TwiMLRequest, VoiceTwiMLOptions, VoiceTwiMLOptionsMediaStreams
 from tac.tools import TACTool
 from tac.utils.redaction import mask_phone, redact_twiml_parameters
 
@@ -172,20 +169,7 @@ class OpenAIRealtimeProvider(VoiceProvider):
         one per registered handler.
         """
         call_kwargs = call_options.to_call_kwargs() if call_options else {}
-
-        wiring: list[tuple[CallEventKind, str, Callable[..., Any] | None]] = [
-            ("status", "status_callback", self.channel._on_call_status),
-            ("amd", "async_amd_status_callback", self.channel._on_amd),
-            ("recording", "recording_status_callback", self.channel._on_recording),
-        ]
-        for kind, param, handler in wiring:
-            if handler is None:
-                continue
-            url = self.channel.tac.config.call_event_url(kind)
-            if url is not None:
-                call_kwargs.setdefault(param, url)
-
-        return call_kwargs
+        return self._apply_call_event_callbacks(call_kwargs)
 
     async def initiate_outbound_conversation(
         self,

--- a/src/tac/channels/voice/media_streams/twiml.py
+++ b/src/tac/channels/voice/media_streams/twiml.py
@@ -1,21 +1,17 @@
-"""TwiML generation for ``OpenAIRealtimeProvider``.
+"""TwiML generation for Media Streams (``<Connect><Stream>``) providers.
 
 See https://www.twilio.com/docs/voice/twiml/stream for the ``<Stream>`` verb.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from twilio.twiml.voice_response import Connect, VoiceResponse
 
-from tac.core.config import TACConfig
+from tac.channels.voice.media_streams.config import MediaStreamsProviderConfig
+from tac.channels.voice.twiml import TwiMLBuilderBase
 from tac.models.voice import VoiceTwiMLOptionsMediaStreams
-
-if TYPE_CHECKING:
-    from tac.channels.voice.media_streams.openai_realtime.config import (
-        OpenAIRealtimeProviderConfig,
-    )
 
 
 def generate_twiml(
@@ -79,14 +75,12 @@ def generate_twiml(
     return str(response)
 
 
-class TwiMLBuilderMediaStreams:
+class TwiMLBuilderMediaStreams(TwiMLBuilderBase):
     """Builds the TwiML for a Media Streams call, owning the layering and
-    WebSocket URL resolution so ``OpenAIRealtimeProvider`` doesn't have to.
+    WebSocket URL resolution so the provider doesn't have to.
     """
 
-    def __init__(self, tac_config: TACConfig, channel_config: OpenAIRealtimeProviderConfig) -> None:
-        self.tac_config = tac_config
-        self.channel_config = channel_config
+    channel_config: MediaStreamsProviderConfig
 
     def build(
         self,
@@ -129,15 +123,10 @@ class TwiMLBuilderMediaStreams:
             resolved_websocket_url = websocket_url
         elif merged.websocket_url is not None:
             resolved_websocket_url = merged.websocket_url
-        elif self.tac_config.voice_public_domain:
-            resolved_websocket_url = (
-                f"wss://{self.tac_config.voice_public_domain}{self.tac_config.voice_websocket_path}"
-            )
+        elif (default_url := self._default_websocket_url()) is not None:
+            resolved_websocket_url = default_url
         else:
-            raise ValueError(
-                f"{caller} needs a WebSocket URL. Set TWILIO_VOICE_PUBLIC_DOMAIN "
-                "(or TACConfig.voice_public_domain)."
-            )
+            raise self._missing_websocket_url_error(caller)
 
         return generate_twiml(resolved_websocket_url, merged)
 
@@ -158,15 +147,3 @@ class TwiMLBuilderMediaStreams:
         if per_call is not None:
             self._overlay_fields(merged, per_call)
         return merged
-
-    @staticmethod
-    def _overlay_fields(
-        target: VoiceTwiMLOptionsMediaStreams, source: VoiceTwiMLOptionsMediaStreams
-    ) -> None:
-        """Apply fields explicitly set on ``source`` onto ``target``.
-
-        ``custom_parameters`` replaces wholesale when set at a higher-priority
-        layer — there's no per-key merging.
-        """
-        for field in source.model_fields_set:
-            setattr(target, field, getattr(source, field))

--- a/src/tac/channels/voice/media_streams/twiml.py
+++ b/src/tac/channels/voice/media_streams/twiml.py
@@ -96,7 +96,7 @@ class TwiMLBuilderMediaStreams(TwiMLBuilderBase):
           1. ``per_call`` — the ``on_inbound_call_twiml`` customizer's output
              for inbound, or ``InitiateVoiceConversationOptions.twiml_options``
              for outbound.
-          2. ``OpenAIRealtimeProviderConfig.default_twiml_options`` — channel-wide defaults
+          2. ``MediaStreamsProviderConfig.default_twiml_options`` — channel-wide defaults
           3. ``host`` — per-call transport facts supplied by the host (e.g. a
              per-call ``websocket_url`` with an affinity token)
           4. TAC defaults: the WebSocket URL derived from

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -6,13 +6,13 @@ one kind of real-time media provider.
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
 from tac.channels.websocket_protocol import WebSocketProtocol
-from tac.core.config import TACConfig
+from tac.core.config import CallEventKind, TACConfig
 from tac.core.logging import get_logger
 from tac.models.memory import MemoryMode
 from tac.models.outbound import InitiateVoiceConversationOptions, InitiateVoiceConversationResult
@@ -89,6 +89,27 @@ class VoiceProvider:
     def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
         """Return the Twilio-facing WebSocket for a conversation, if tracked."""
         return None
+
+    def _apply_call_event_callbacks(self, call_kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Set callback URLs on ``call_kwargs`` for every registered call-event handler.
+
+        A URL is derived only when its handler is registered — an unwanted
+        call-event URL would otherwise surface as silent 11200 alerts for a
+        feature nobody asked for. Set the URLs in ``default_call_options``
+        instead when TAC isn't serving the routes.
+        """
+        wiring: list[tuple[CallEventKind, str, Callable[..., Any] | None]] = [
+            ("status", "status_callback", self.channel._on_call_status),
+            ("amd", "async_amd_status_callback", self.channel._on_amd),
+            ("recording", "recording_status_callback", self.channel._on_recording),
+        ]
+        for kind, param, handler in wiring:
+            if handler is None:
+                continue
+            url = self.channel.tac.config.call_event_url(kind)
+            if url is not None:
+                call_kwargs.setdefault(param, url)
+        return call_kwargs
 
 
 class VoiceProviderConfig(BaseModel):

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -95,8 +95,9 @@ class VoiceProvider:
 
         A URL is derived only when its handler is registered — an unwanted
         call-event URL would otherwise surface as silent 11200 alerts for a
-        feature nobody asked for. Set the URLs in ``default_call_options``
-        instead when TAC isn't serving the routes.
+        feature nobody asked for. If TAC isn't serving these routes, set the
+        URLs explicitly via ``CallOptions`` (or
+        ``ConversationRelayProviderConfig.default_call_options``, where available).
         """
         wiring: list[tuple[CallEventKind, str, Callable[..., Any] | None]] = [
             ("status", "status_callback", self.channel._on_call_status),

--- a/src/tac/channels/voice/twiml.py
+++ b/src/tac/channels/voice/twiml.py
@@ -1,0 +1,38 @@
+"""Shared scaffolding for per-provider TwiML builders."""
+
+from __future__ import annotations
+
+from collections.abc import Container
+from typing import Any
+
+from pydantic import BaseModel
+
+from tac.core.config import TACConfig
+
+
+class TwiMLBuilderBase:
+    """Common construction and option-layering helpers for a provider's TwiML builder."""
+
+    def __init__(self, tac_config: TACConfig, channel_config: Any) -> None:
+        self.tac_config = tac_config
+        self.channel_config = channel_config
+
+    @staticmethod
+    def _overlay_fields(target: BaseModel, source: BaseModel, *, skip: Container[str] = ()) -> None:
+        """Apply fields explicitly set on ``source`` onto ``target``, except those in ``skip``."""
+        for field in source.model_fields_set:
+            if field in skip:
+                continue
+            setattr(target, field, getattr(source, field))
+
+    @staticmethod
+    def _missing_websocket_url_error(caller: str) -> ValueError:
+        return ValueError(
+            f"{caller} needs a WebSocket URL. Set TWILIO_VOICE_PUBLIC_DOMAIN "
+            "(or TACConfig.voice_public_domain)."
+        )
+
+    def _default_websocket_url(self) -> str | None:
+        if not self.tac_config.voice_public_domain:
+            return None
+        return f"wss://{self.tac_config.voice_public_domain}{self.tac_config.voice_websocket_path}"

--- a/tests/test_media_streams_twiml.py
+++ b/tests/test_media_streams_twiml.py
@@ -1,18 +1,17 @@
-"""Tests for OpenAIRealtimeProvider's TwiML generation and layering.
+"""Tests for Media Streams' TwiML generation and layering.
 
-Media Streams' ``generate_twiml``/``TwiMLBuilderMediaStreams`` are a
-separate implementation from ConversationRelay's (see test_voice_channel.py
-for that one) — same shape (customizer > default > host > TAC-default
-layering), different verb (``<Connect><Stream>`` vs ``<ConversationRelay>``).
+``generate_twiml``/``TwiMLBuilderMediaStreams`` are shared by every Media
+Streams provider (``OpenAIRealtimeProviderConfig`` is the only one today, so
+it's what these tests configure the builder with) and are a separate
+implementation from ConversationRelay's (see test_voice_channel.py for that
+one) — same shape (customizer > default > host > TAC-default layering),
+different verb (``<Connect><Stream>`` vs ``<ConversationRelay>``).
 """
 
 import pytest
 
 from tac.channels.voice.media_streams.openai_realtime import OpenAIRealtimeProviderConfig
-from tac.channels.voice.media_streams.openai_realtime.twiml import (
-    TwiMLBuilderMediaStreams,
-    generate_twiml,
-)
+from tac.channels.voice.media_streams.twiml import TwiMLBuilderMediaStreams, generate_twiml
 from tac.core.config import TACConfig
 from tac.models.voice import VoiceTwiMLOptionsMediaStreams
 

--- a/tests/test_openai_realtime_provider.py
+++ b/tests/test_openai_realtime_provider.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import re
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -747,3 +748,76 @@ class TestOutboundCallSessionConfig:
             await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
 
         assert "model=gpt-realtime-outbound-only" in mock_connect.call_args.args[0]
+
+
+class TestCallEventCallbackWiring:
+    """``OpenAIRealtimeProvider._build_call_kwargs`` shares its call-event-URL
+    wiring with ``ConversationRelayProvider`` via
+    ``VoiceProvider._apply_call_event_callbacks`` — covers the same behavior
+    on this provider's outbound path (see ``TestNoAutoWiring`` in
+    test_outbound.py for the ConversationRelay side).
+    """
+
+    @staticmethod
+    def _noop_handler() -> Any:
+        async def handler(event: Any) -> None:
+            return None
+
+        return handler
+
+    async def _place_call(
+        self, channel: VoiceChannel, *, websocket_url: str | None = None
+    ) -> dict[str, Any]:
+        mock_call = MagicMock(sid="CA_WIRE")
+        mock_client = MagicMock()
+        mock_client.calls.create.return_value = mock_call
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            await channel.initiate_outbound_conversation(
+                InitiateVoiceConversationOptions(to="+15559876543", websocket_url=websocket_url)
+            )
+        return mock_client.calls.create.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_auto_wiring_without_handlers(self) -> None:
+        channel = make_channel()
+        kwargs = await self._place_call(channel)
+        assert "status_callback" not in kwargs
+        assert "async_amd_status_callback" not in kwargs
+        assert "recording_status_callback" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_each_callback_wired_only_for_its_handler(self) -> None:
+        channel = make_channel()
+        channel.on_amd(self._noop_handler())
+        kwargs = await self._place_call(channel)
+        assert kwargs["async_amd_status_callback"] == "https://example.com/twilio/call-events/amd"
+        assert "status_callback" not in kwargs
+        assert "recording_status_callback" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_all_callbacks_wired_when_all_handlers_registered(self) -> None:
+        channel = make_channel()
+        channel.on_call_status(self._noop_handler())
+        channel.on_amd(self._noop_handler())
+        channel.on_recording(self._noop_handler())
+        kwargs = await self._place_call(channel)
+        assert kwargs["status_callback"] == "https://example.com/twilio/call-events/status"
+        assert kwargs["async_amd_status_callback"] == "https://example.com/twilio/call-events/amd"
+        assert (
+            kwargs["recording_status_callback"]
+            == "https://example.com/twilio/call-events/recording"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_auto_wiring_without_domain(self) -> None:
+        tac = TAC({**get_test_tac_config(), "voice_public_domain": None})
+        channel = VoiceChannel(
+            tac,
+            config=OpenAIRealtimeProviderConfig(
+                openai_api_key="sk-test",
+                default_session_config={"model": "gpt-realtime-test", "audio": _VALID_AUDIO},
+            ),
+        )
+        channel.on_call_status(self._noop_handler())
+        kwargs = await self._place_call(channel, websocket_url="wss://example.com/ws")
+        assert "status_callback" not in kwargs


### PR DESCRIPTION
## Summary

`ConversationRelayProvider` and `OpenAIRealtimeProvider` had grown several near-identical blocks of code as they were built out independently. This PR extracts the genuinely shared pieces into common base classes, without forcing a shared abstraction onto the parts that are legitimately provider-specific:

- **`TwiMLBuilderBase`** (`tac/channels/voice/twiml.py`): common construction, per-field option-layering (`_overlay_fields`), and WebSocket URL resolution/error, shared by `TwiMLBuilderConversationRelay` and `TwiMLBuilderMediaStreams`.
- **`VoiceProvider._apply_call_event_callbacks`**: the `status`/`amd`/`recording` callback-URL wiring in `_build_call_kwargs`, previously duplicated verbatim in both providers.
- **`MediaStreamsProviderConfig`**: a new base config in `tac/channels/voice/media_streams/config.py` holding `default_twiml_options`, so `OpenAIRealtimeProviderConfig` no longer redeclares it.
- Moved Media Streams' `generate_twiml`/`TwiMLBuilderMediaStreams` from `media_streams/openai_realtime/` up to `media_streams/`, since none of it is OpenAI-specific — a future Media Streams provider can reuse it directly.

No public API changes: `generate_twiml`, `VoiceTwiMLOptionsMediaStreams`, and `OpenAIRealtimeProviderConfig` are still importable from `tac.channels.voice.media_streams.openai_realtime` with identical behavior.

### How to test

```bash
make check
```

Also added `TestCallEventCallbackWiring` in `tests/test_openai_realtime_provider.py` covering the same callback-wiring behavior on the Media Streams path that `test_outbound.py` already covered for ConversationRelay.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated
- [x] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

> **Tip:** Use the `/sync-to-ts-sdk` skill in Claude Code to automatically generate and create a TypeScript SDK PR from your changes.

- [x] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->