### PR TITLE
refactor(voice): share OpenAI config/call-state base classes for Media Streams providers

### DIFF
--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -39,8 +39,7 @@ class VoiceChannel(BaseChannel):
     Owns the Twilio Calls API lifecycle and conversation bookkeeping
     (inherited from BaseChannel). The real-time media transport itself —
     TwiML generation, WebSocket protocol handling, outbound call
-    initiation — is delegated to a pluggable ``VoiceProvider``
-    (``ConversationRelayProvider`` is the only implementation today).
+    initiation — is delegated to a pluggable ``VoiceProvider``.
 
     This channel is framework-agnostic and accepts any WebSocket implementation
     satisfying WebSocketProtocol. For a batteries-included FastAPI server, use

--- a/src/tac/channels/voice/media_streams/__init__.py
+++ b/src/tac/channels/voice/media_streams/__init__.py
@@ -1,3 +1,3 @@
 """Voice providers bridging Twilio Media Streams (``<Connect><Stream>``) to a
-speech-to-speech model. ``openai_realtime`` is the first implementation.
+speech-to-speech model.
 """

--- a/src/tac/channels/voice/media_streams/config.py
+++ b/src/tac/channels/voice/media_streams/config.py
@@ -9,12 +9,7 @@ from tac.models.voice import VoiceTwiMLOptionsMediaStreams
 
 
 class MediaStreamsProviderConfig(VoiceProviderConfig):
-    """Base configuration for a Media Streams (``<Connect><Stream>``) provider.
-
-    ``OpenAIRealtimeProviderConfig`` is the only subclass today. Lives here
-    (not in ``openai_realtime/config.py``) so a future Media Streams provider's
-    config only needs to import this module, not anything OpenAI-specific.
-    """
+    """Base configuration for a Media Streams (``<Connect><Stream>``) provider."""
 
     default_twiml_options: VoiceTwiMLOptionsMediaStreams | None = Field(
         default=None,

--- a/src/tac/channels/voice/media_streams/openai_realtime/config.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/config.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
-from tac.channels.voice.media_streams.config import MediaStreamsProviderConfig
 from tac.channels.voice.media_streams.openai_realtime.provider import OpenAIRealtimeProvider
+from tac.channels.voice.media_streams.shared.config import MediaStreamsOpenAIProviderConfig
 from tac.channels.voice.provider import VoiceProvider
 from tac.core.config import TACConfig
 from tac.models.voice import TwiMLRequest
@@ -19,15 +18,9 @@ if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
 
 
-class OpenAIRealtimeProviderConfig(MediaStreamsProviderConfig):
+class OpenAIRealtimeProviderConfig(MediaStreamsOpenAIProviderConfig):
     """Configuration for ``OpenAIRealtimeProvider``."""
 
-    model_config = {"extra": "forbid", "arbitrary_types_allowed": True}
-
-    openai_api_key: str | None = Field(
-        default_factory=lambda: os.environ.get("OPENAI_API_KEY"),
-        description="OpenAI API key. Defaults to the OPENAI_API_KEY environment variable.",
-    )
     tools: list[TACTool] = Field(
         default_factory=list,
         description=(
@@ -61,15 +54,6 @@ class OpenAIRealtimeProviderConfig(MediaStreamsProviderConfig):
         "`default_session_config`); return None to fall back to it. Outbound calls don't use "
         "this — see `InitiateVoiceConversationOptionsOpenAIRealtime`.",
     )
-
-    @model_validator(mode="after")
-    def _validate(self) -> OpenAIRealtimeProviderConfig:
-        if not self.openai_api_key:
-            raise ValueError(
-                "openai_api_key is required. Set the OPENAI_API_KEY environment "
-                "variable or provide openai_api_key in OpenAIRealtimeProviderConfig."
-            )
-        return self
 
     def create_provider(self, channel: VoiceChannel, tac_config: TACConfig) -> VoiceProvider:
         return OpenAIRealtimeProvider(channel, tac_config, self)

--- a/src/tac/channels/voice/media_streams/openai_realtime/models.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/models.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 
-from tac.channels.websocket_protocol import WebSocketProtocol
+from tac.channels.voice.media_streams.shared.models import MediaStreamsOpenAICallState
 
 
 @dataclass
@@ -31,19 +30,7 @@ class _BargeInState:
 
 
 @dataclass
-class _CallState:
-    """Per-call bookkeeping this provider needs beyond ``ConversationSession``.
+class _CallState(MediaStreamsOpenAICallState):
+    """Per-call bookkeeping this provider needs beyond ``ConversationSession``."""
 
-    Both legs of one call's audio bridge — the Twilio-facing socket and the
-    OpenAI Realtime socket — live here together, rather than in two parallel
-    dicts keyed by conversation id that could drift out of sync.
-
-    ``stream_sid`` and ``transcript`` live on ``ConversationSession.metadata``
-    instead, not here — this dict is popped before ``on_conversation_ended``
-    fires, so anything a handler needs to read after the call ends must
-    survive on the session, not in here.
-    """
-
-    twilio_ws: WebSocketProtocol | None = None
-    model_ws: Any = None
     barge_in: _BargeInState = field(default_factory=_BargeInState)

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -458,7 +458,7 @@ class OpenAIRealtimeProvider(MediaStreamsOpenAIProvider[_CallState]):
         call_id there's nothing to reply to, so the item is dropped instead.
         """
         call_id = item.get("call_id")
-        if not call_id:
+        if not isinstance(call_id, str) or not call_id:
             self.logger.error(
                 "Received malformed function_call item without call_id",
                 conversation_id=conv_id,
@@ -467,7 +467,7 @@ class OpenAIRealtimeProvider(MediaStreamsOpenAIProvider[_CallState]):
             return
 
         name = item.get("name")
-        if not name:
+        if not isinstance(name, str) or not name:
             self.logger.error(
                 "Received malformed function_call item without tool name",
                 conversation_id=conv_id,

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -15,30 +15,27 @@ import base64
 import contextlib
 import json
 import uuid
-from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
 import websockets
 
 from tac.channels.voice.media_streams.openai_realtime.models import _CallState
-from tac.channels.voice.media_streams.twiml import TwiMLBuilderMediaStreams
-from tac.channels.voice.provider import VoiceProvider
+from tac.channels.voice.media_streams.shared.openai_provider import (
+    OPENAI_USER_AGENT,
+    MediaStreamsOpenAIProvider,
+)
 from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
-from tac.core.config import TACConfig
 from tac.models.outbound import (
-    CallOptions,
     InitiateVoiceConversationOptions,
     InitiateVoiceConversationOptionsOpenAIRealtime,
     InitiateVoiceConversationResult,
 )
 from tac.models.session import ConversationSession
 from tac.models.stream import StreamStartMessage
-from tac.models.voice import TwiMLRequest, VoiceTwiMLOptions, VoiceTwiMLOptionsMediaStreams
-from tac.tools import TACTool
+from tac.models.voice import VoiceTwiMLOptionsMediaStreams
 from tac.utils.redaction import mask_phone, redact_twiml_parameters
 
 if TYPE_CHECKING:
-    from tac.channels.voice.channel import VoiceChannel
     from tac.channels.voice.media_streams.openai_realtime.config import (
         OpenAIRealtimeProviderConfig,
     )
@@ -65,7 +62,7 @@ _PCMU_BYTES_PER_MS = 8
 _SESSION_CONFIG_TOKEN_PARAM = "_tac_session_config_token"
 
 
-class OpenAIRealtimeProvider(VoiceProvider):
+class OpenAIRealtimeProvider(MediaStreamsOpenAIProvider[_CallState]):
     """``VoiceProvider`` bridging Twilio Media Streams to OpenAI Realtime.
 
     Example:
@@ -74,102 +71,11 @@ class OpenAIRealtimeProvider(VoiceProvider):
         ```
     """
 
-    def __init__(
-        self,
-        channel: VoiceChannel,
-        tac_config: TACConfig,
-        config: OpenAIRealtimeProviderConfig,
-    ) -> None:
-        super().__init__(channel)
-
-        self.config = config
-        self.tac_config = tac_config
-        self._tools_by_name: dict[str, TACTool] = {tool.name: tool for tool in config.tools}
-        self._calls: dict[str, _CallState] = {}
-        self._twiml = TwiMLBuilderMediaStreams(tac_config, config)
-        # Keyed by call_sid; set in handle_incoming_call, popped in _connect_model.
-        self._call_session_configs: dict[str, dict[str, Any]] = {}
+    config: OpenAIRealtimeProviderConfig
 
     @property
     def channel_name(self) -> str:
         return "VOICE_MEDIA_STREAM_OPENAI_REALTIME"
-
-    def get_transcript(self, conversation_id: str) -> list[dict[str, str]]:
-        """Return the transcript captured so far for an in-progress call.
-
-        Lives on ``ConversationSession.metadata["transcript"]``, so once the
-        call ends (and the session is popped from ``channel._conversations``)
-        it's no longer reachable here — read it from the session an
-        ``on_conversation_ended`` handler receives instead.
-        """
-        session = self.channel._conversations.get(conversation_id)
-        return list(session.metadata.get("transcript", [])) if session else []
-
-    def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
-        call = self._calls.get(conversation_id)
-        return call.twilio_ws if call else None
-
-    async def handle_incoming_call(
-        self,
-        twiml_request: TwiMLRequest | None = None,
-        *,
-        host_twiml_options: VoiceTwiMLOptions | None = None,
-    ) -> str:
-        """Build the ``<Connect><Stream>`` TwiML for an inbound call.
-
-        TwiML fields are merged per-field, highest precedence first:
-          1. Output of the customizer registered via
-             ``VoiceChannel.on_inbound_call_twiml(...)`` if configured
-             and ``twiml_request`` is given.
-          2. ``OpenAIRealtimeProviderConfig.default_twiml_options`` — per-channel defaults.
-          3. ``host_twiml_options`` — per-call transport facts supplied by the host.
-          4. TAC defaults: the WebSocket URL derived from
-             ``TACConfig.voice_public_domain`` + ``voice_websocket_path``.
-
-        Also runs ``on_inbound_call_session_config`` (if set) and stashes its
-        result for ``_connect_model`` to pick up once the call connects.
-        """
-        if host_twiml_options is not None and not isinstance(
-            host_twiml_options, VoiceTwiMLOptionsMediaStreams
-        ):
-            raise TypeError(
-                "OpenAIRealtimeProvider.handle_incoming_call requires host_twiml_options "
-                f"to be a VoiceTwiMLOptionsMediaStreams, got {type(host_twiml_options).__name__}"
-            )
-
-        customized: VoiceTwiMLOptionsMediaStreams | None = None
-        if self.channel._on_inbound_call_twiml is not None and twiml_request is not None:
-            result = await self.channel._on_inbound_call_twiml(twiml_request)
-            if not isinstance(result, VoiceTwiMLOptionsMediaStreams):
-                raise TypeError(
-                    "OpenAIRealtimeProvider.handle_incoming_call requires the "
-                    "on_inbound_call_twiml customizer to return a "
-                    f"VoiceTwiMLOptionsMediaStreams, got {type(result).__name__}"
-                )
-            customized = result
-
-        if (
-            self.config.on_inbound_call_session_config is not None
-            and twiml_request is not None
-            and twiml_request.call_sid is not None
-        ):
-            session_config = await self.config.on_inbound_call_session_config(twiml_request)
-            if session_config is not None:
-                self._call_session_configs[twiml_request.call_sid] = session_config
-
-        return self._twiml.build(
-            "handle_incoming_call", host=host_twiml_options, per_call=customized
-        )
-
-    def _build_call_kwargs(self, call_options: CallOptions | None) -> dict[str, Any]:
-        """Build the extra kwargs for ``client.calls.create``.
-
-        Layers, highest precedence first: this call's ``call_options``, then
-        callback URLs derived from ``voice_public_domain`` + ``voice_call_event_path``,
-        one per registered handler.
-        """
-        call_kwargs = call_options.to_call_kwargs() if call_options else {}
-        return self._apply_call_event_callbacks(call_kwargs)
 
     async def initiate_outbound_conversation(
         self,
@@ -400,7 +306,10 @@ class OpenAIRealtimeProvider(VoiceProvider):
 
         model_ws = await websockets.connect(
             f"wss://api.openai.com/v1/realtime?model={session_config['model']}",
-            additional_headers={"Authorization": f"Bearer {self.config.openai_api_key}"},
+            additional_headers={
+                "Authorization": f"Bearer {self.config.openai_api_key}",
+                "User-Agent": OPENAI_USER_AGENT,
+            },
         )
         call = self._calls.get(conv_id)
         if call is not None:
@@ -413,37 +322,6 @@ class OpenAIRealtimeProvider(VoiceProvider):
         response = self.config.welcome_greeting_response
         if response is not None:
             await self._model_send(conv_id, {"type": "response.create", "response": response})
-
-    async def _handle_model_events(self, conv_id: str) -> None:
-        """Read OpenAI Realtime events until the socket closes, dispatching each one.
-
-        A failure handling one event (e.g. a malformed delta) is logged and
-        skipped rather than ending the loop — only the socket actually
-        closing (raised by ``async for`` itself, not from inside it) does.
-        """
-        call = self._calls.get(conv_id)
-        if call is None or call.model_ws is None:
-            return
-        try:
-            async for raw in call.model_ws:
-                try:
-                    event = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
-                    session = self.channel._conversations.get(conv_id)
-                    if session is None:
-                        continue
-                    await self._dispatch_model_event(conv_id, session, event)
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    self.logger.error(
-                        f"Error handling model event: {e}",
-                        conversation_id=conv_id,
-                        exc_info=True,
-                    )
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:
-            self.logger.debug(f"Model read loop ended: {e}", conversation_id=conv_id)
 
     async def _dispatch_model_event(
         self, conv_id: str, session: ConversationSession, event: dict[str, Any]
@@ -579,18 +457,35 @@ class OpenAIRealtimeProvider(VoiceProvider):
         waiting on a call_id it never gets a result for.
         """
         call_id = item.get("call_id")
-        name = item.get("name")
-        output = await self._run_tool_call(conv_id, name, item.get("arguments"))
-        try:
-            output_json = json.dumps(output)
-        except TypeError as e:
+        if not call_id:
             self.logger.error(
-                f"Tool '{name}' returned a non-JSON-serializable result: {e}",
+                "Received malformed function_call item without call_id",
                 conversation_id=conv_id,
+                item=item,
             )
-            output_json = json.dumps(
-                {"error": f"Tool '{name}' returned a non-serializable result."}
+            return
+
+        name = item.get("name")
+        if not name:
+            self.logger.error(
+                "Received malformed function_call item without tool name",
+                conversation_id=conv_id,
+                call_id=call_id,
+                item=item,
             )
+            output_json = json.dumps({"error": "Malformed function call: missing tool name."})
+        else:
+            output = await self._run_tool_call(conv_id, name, item.get("arguments"))
+            try:
+                output_json = json.dumps(output)
+            except TypeError as e:
+                self.logger.error(
+                    f"Tool '{name}' returned a non-JSON-serializable result: {e}",
+                    conversation_id=conv_id,
+                )
+                output_json = json.dumps(
+                    {"error": f"Tool '{name}' returned a non-serializable result."}
+                )
 
         await self._model_send(
             conv_id,
@@ -605,48 +500,6 @@ class OpenAIRealtimeProvider(VoiceProvider):
         )
         await self._model_send(conv_id, {"type": "response.create"})
 
-    async def _run_tool_call(
-        self, conv_id: str, name: str | None, arguments_json: str | None
-    ) -> object:
-        """Look up a model-requested tool by name, run it, and return its output.
-
-        Errors are returned as part of the output rather than raised, so a bad
-        tool call doesn't kill the call.
-        """
-        tool = self._tools_by_name.get(name) if name else None
-
-        self.logger.debug(f"Tool call: {name}({arguments_json})", conversation_id=conv_id)
-
-        if tool is None:
-            return {"error": f"Unknown tool '{name}'"}
-
-        try:
-            arguments = json.loads(arguments_json or "{}")
-            output = await tool(**arguments)
-            self.logger.debug(f"Tool result: {name} -> {output}", conversation_id=conv_id)
-            return output
-        except Exception as e:
-            self.logger.error(f"Tool '{name}' failed: {e}", conversation_id=conv_id, exc_info=True)
-            return {"error": f"Tool '{name}' failed to execute."}
-
-    async def _model_send(self, conv_id: str, obj: dict[str, Any]) -> None:
-        call = self._calls.get(conv_id)
-        if call is None or call.model_ws is None:
-            return
-        try:
-            await call.model_ws.send(json.dumps(obj))
-        except Exception as e:
-            self.logger.debug(f"Failed to send to model: {e}", conversation_id=conv_id)
-
-    async def _twilio_send(self, conv_id: str, obj: dict[str, Any]) -> None:
-        call = self._calls.get(conv_id)
-        if call is None or call.twilio_ws is None:
-            return
-        try:
-            await call.twilio_ws.send_text(json.dumps(obj))
-        except (WebSocketDisconnectError, RuntimeError) as e:
-            self.logger.debug(f"Failed to send to Twilio: {e}", conversation_id=conv_id)
-
     async def _cleanup_call(self, conv_id: str) -> None:
         call = self._calls.pop(conv_id, None)
         if call is not None and call.model_ws is not None:
@@ -655,15 +508,3 @@ class OpenAIRealtimeProvider(VoiceProvider):
             except Exception as e:
                 self.logger.debug(f"Error closing model socket: {e}", conversation_id=conv_id)
         await self.channel._end_conversation(conv_id)
-
-    async def send_response(
-        self,
-        conversation_id: str,
-        response: str | AsyncGenerator[str | dict[str, Any], None],
-        role: str | None = None,
-    ) -> None:
-        """Not supported: the model streams audio to Twilio directly, so there
-        is no text response for this provider to send."""
-        raise NotImplementedError(
-            f"{type(self).__name__} produces audio via the model; it has no text send_response."
-        )

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -451,10 +451,11 @@ class OpenAIRealtimeProvider(MediaStreamsOpenAIProvider[_CallState]):
     async def _handle_function_call(self, conv_id: str, item: dict[str, Any]) -> None:
         """Run a model-requested tool call and hand the result back.
 
-        Always sends a function_call_output — even a tool that ran
-        successfully can return a non-JSON-serializable object (a datetime,
-        a Pydantic model, ...), and the model would otherwise be left
-        waiting on a call_id it never gets a result for.
+        Always sends a function_call_output when call_id is present — even a
+        tool that ran successfully can return a non-JSON-serializable object
+        (a datetime, a Pydantic model, ...), and the model would otherwise be
+        left waiting on a call_id it never gets a result for. Without a
+        call_id there's nothing to reply to, so the item is dropped instead.
         """
         call_id = item.get("call_id")
         if not call_id:

--- a/src/tac/channels/voice/media_streams/shared/__init__.py
+++ b/src/tac/channels/voice/media_streams/shared/__init__.py
@@ -1,0 +1,4 @@
+"""Code shared across Media Streams providers that doesn't belong to any one
+of them — e.g. ``MediaStreamsOpenAIProvider``, the base for providers
+bridging to an OpenAI real-time voice API.
+"""

--- a/src/tac/channels/voice/media_streams/shared/config.py
+++ b/src/tac/channels/voice/media_streams/shared/config.py
@@ -1,0 +1,56 @@
+"""``MediaStreamsOpenAIProviderConfig``: config fields shared by every ``VoiceProvider``
+bridging Twilio Media Streams to an OpenAI real-time voice API.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pydantic import Field, model_validator
+
+from tac.channels.voice.media_streams.config import MediaStreamsProviderConfig
+from tac.models.voice import TwiMLRequest
+from tac.tools import TACTool
+
+
+class MediaStreamsOpenAIProviderConfig(MediaStreamsProviderConfig):
+    """Shared configuration for a Media Streams provider bridging to an OpenAI
+    real-time voice API.
+    """
+
+    model_config = {"extra": "forbid", "arbitrary_types_allowed": True}
+
+    openai_api_key: str | None = Field(
+        default_factory=lambda: os.environ.get("OPENAI_API_KEY"),
+        description="OpenAI API key. Defaults to the OPENAI_API_KEY environment variable.",
+    )
+    tools: list[TACTool] = Field(
+        default_factory=list,
+        description="Executable TACTool implementations, looked up by name to run "
+        "mid-call tool requests.",
+    )
+    default_session_config: dict[str, Any] | None = Field(
+        default=None,
+        description="The session.update payload's 'session' body, sent once the model "
+        "connects — used for any call that doesn't supply its own via "
+        "`on_inbound_call_session_config`.",
+    )
+    on_inbound_call_session_config: (
+        Callable[[TwiMLRequest], Awaitable[dict[str, Any] | None]] | None
+    ) = Field(
+        default=None,
+        description="Per-inbound-call override for `default_session_config`, called with the "
+        "TwiMLRequest. Its return value is used verbatim (not merged with "
+        "`default_session_config`); return None to fall back to it.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_openai_api_key(self) -> MediaStreamsOpenAIProviderConfig:
+        if not self.openai_api_key:
+            raise ValueError(
+                f"openai_api_key is required. Set the OPENAI_API_KEY environment "
+                f"variable or provide openai_api_key in {type(self).__name__}."
+            )
+        return self

--- a/src/tac/channels/voice/media_streams/shared/models.py
+++ b/src/tac/channels/voice/media_streams/shared/models.py
@@ -1,0 +1,28 @@
+"""``MediaStreamsOpenAICallState``: per-call state shared by every ``VoiceProvider``
+bridging Twilio Media Streams to an OpenAI real-time voice API,
+not part of the public API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from websockets.asyncio.client import ClientConnection
+
+from tac.channels.websocket_protocol import WebSocketProtocol
+
+
+@dataclass
+class MediaStreamsOpenAICallState:
+    """Both legs of one call's audio bridge — the Twilio-facing socket and the
+    model-facing socket — live here together, rather than in two parallel
+    dicts keyed by conversation id that could drift out of sync.
+
+    ``stream_sid`` and ``transcript`` live on ``ConversationSession.metadata``
+    instead, not here — this dict is popped before ``on_conversation_ended``
+    fires, so anything a handler needs to read after the call ends must
+    survive on the session, not in here.
+    """
+
+    twilio_ws: WebSocketProtocol | None = None
+    model_ws: ClientConnection | None = None

--- a/src/tac/channels/voice/media_streams/shared/openai_provider.py
+++ b/src/tac/channels/voice/media_streams/shared/openai_provider.py
@@ -1,0 +1,233 @@
+"""``MediaStreamsOpenAIProvider``: pieces shared verbatim by every ``VoiceProvider``
+bridging Twilio Media Streams to an OpenAI real-time voice API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from tac import __version__
+from tac.channels.voice.media_streams.shared.config import MediaStreamsOpenAIProviderConfig
+from tac.channels.voice.media_streams.shared.models import MediaStreamsOpenAICallState
+from tac.channels.voice.media_streams.twiml import TwiMLBuilderMediaStreams
+from tac.channels.voice.provider import VoiceProvider
+from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
+from tac.core.config import TACConfig
+from tac.models.outbound import CallOptions
+from tac.models.voice import TwiMLRequest, VoiceTwiMLOptions, VoiceTwiMLOptionsMediaStreams
+from tac.tools import TACTool
+
+if TYPE_CHECKING:
+    from tac.channels.voice.channel import VoiceChannel
+
+
+#: Identifies this SDK to OpenAI on every WebSocket connection, per OpenAI's
+#: requested User-Agent pattern: [Company/Library name]/[Language] [Version].
+OPENAI_USER_AGENT = f"twilio-agent-connect-python/Python {__version__}"
+
+TCallState = TypeVar("TCallState", bound=MediaStreamsOpenAICallState)
+
+
+class MediaStreamsOpenAIProvider(VoiceProvider, Generic[TCallState]):
+    """Shared scaffolding for a Media Streams provider bridging to an OpenAI
+    real-time voice API. Holds only what's identical across every such
+    provider; each subclass still owns its own ``initiate_outbound_conversation``,
+    ``handle_websocket``, ``_register_call``, ``_connect_model``,
+    ``_dispatch_model_event``, ``_handle_function_call``, and ``_cleanup_call``.
+
+    Generic over ``TCallState`` (bound to ``MediaStreamsOpenAICallState``) so
+    ``_calls`` keeps each subclass's own call-state shape instead of widening
+    to the shared base everywhere it's read.
+    """
+
+    def __init__(
+        self,
+        channel: VoiceChannel,
+        tac_config: TACConfig,
+        config: MediaStreamsOpenAIProviderConfig,
+    ) -> None:
+        super().__init__(channel)
+
+        self.config = config
+        self.tac_config = tac_config
+        self._tools_by_name: dict[str, TACTool] = {tool.name: tool for tool in config.tools}
+        self._calls: dict[str, TCallState] = {}
+        self._twiml = TwiMLBuilderMediaStreams(tac_config, config)
+        # Keyed by call_sid (inbound) or a token rekeyed to call_sid on
+        # connect (outbound); set in handle_incoming_call or
+        # initiate_outbound_conversation, popped in _connect_model.
+        self._call_session_configs: dict[str, dict[str, Any]] = {}
+
+    def get_transcript(self, conversation_id: str) -> list[dict[str, str]]:
+        """Return the transcript captured so far for an in-progress call.
+
+        Lives on ``ConversationSession.metadata["transcript"]``, so once the
+        call ends (and the session is popped from ``channel._conversations``)
+        it's no longer reachable here — read it from the session an
+        ``on_conversation_ended`` handler receives instead.
+        """
+        session = self.channel._conversations.get(conversation_id)
+        return list(session.metadata.get("transcript", [])) if session else []
+
+    def get_websocket(self, conversation_id: str) -> WebSocketProtocol | None:
+        call = self._calls.get(conversation_id)
+        return call.twilio_ws if call else None
+
+    async def handle_incoming_call(
+        self,
+        twiml_request: TwiMLRequest | None = None,
+        *,
+        host_twiml_options: VoiceTwiMLOptions | None = None,
+    ) -> str:
+        """Build the ``<Connect><Stream>`` TwiML for an inbound call.
+
+        TwiML fields are merged per-field, highest precedence first:
+          1. Output of the customizer registered via
+             ``VoiceChannel.on_inbound_call_twiml(...)`` if configured
+             and ``twiml_request`` is given.
+          2. ``MediaStreamsProviderConfig.default_twiml_options`` — per-channel defaults.
+          3. ``host_twiml_options`` — per-call transport facts supplied by the host.
+          4. TAC defaults: the WebSocket URL derived from
+             ``TACConfig.voice_public_domain`` + ``voice_websocket_path``.
+
+        Also runs ``on_inbound_call_session_config`` (if set) and stashes its
+        result for ``_connect_model`` to pick up once the call connects.
+        """
+        if host_twiml_options is not None and not isinstance(
+            host_twiml_options, VoiceTwiMLOptionsMediaStreams
+        ):
+            raise TypeError(
+                "MediaStreamsOpenAIProvider.handle_incoming_call requires host_twiml_options "
+                f"to be a VoiceTwiMLOptionsMediaStreams, got {type(host_twiml_options).__name__}"
+            )
+
+        customized: VoiceTwiMLOptionsMediaStreams | None = None
+        if self.channel._on_inbound_call_twiml is not None and twiml_request is not None:
+            result = await self.channel._on_inbound_call_twiml(twiml_request)
+            if not isinstance(result, VoiceTwiMLOptionsMediaStreams):
+                raise TypeError(
+                    "MediaStreamsOpenAIProvider.handle_incoming_call requires the "
+                    "on_inbound_call_twiml customizer to return a "
+                    f"VoiceTwiMLOptionsMediaStreams, got {type(result).__name__}"
+                )
+            customized = result
+
+        if (
+            self.config.on_inbound_call_session_config is not None
+            and twiml_request is not None
+            and twiml_request.call_sid is not None
+        ):
+            session_config = await self.config.on_inbound_call_session_config(twiml_request)
+            if session_config is not None:
+                self._call_session_configs[twiml_request.call_sid] = session_config
+
+        return self._twiml.build(
+            "handle_incoming_call", host=host_twiml_options, per_call=customized
+        )
+
+    def _build_call_kwargs(self, call_options: CallOptions | None) -> dict[str, Any]:
+        """Build the extra kwargs for ``client.calls.create``.
+
+        Layers, highest precedence first: this call's ``call_options``, then
+        callback URLs derived from ``voice_public_domain`` + ``voice_call_event_path``,
+        one per registered handler.
+        """
+        call_kwargs = call_options.to_call_kwargs() if call_options else {}
+        return self._apply_call_event_callbacks(call_kwargs)
+
+    async def _handle_model_events(self, conv_id: str) -> None:
+        """Read model events until the socket closes, dispatching each one.
+
+        A failure handling one event is logged and skipped rather than
+        ending the loop — only the socket actually closing (raised by
+        ``async for`` itself, not from inside it) does.
+        """
+        call = self._calls.get(conv_id)
+        if call is None or call.model_ws is None:
+            return
+        try:
+            async for raw in call.model_ws:
+                try:
+                    event = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+                    session = self.channel._conversations.get(conv_id)
+                    if session is None:
+                        continue
+                    await self._dispatch_model_event(conv_id, session, event)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    self.logger.error(
+                        f"Error handling model event: {e}",
+                        conversation_id=conv_id,
+                        exc_info=True,
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.logger.debug(f"Model read loop ended: {e}", conversation_id=conv_id)
+
+    async def _dispatch_model_event(
+        self, conv_id: str, session: Any, event: dict[str, Any]
+    ) -> None:
+        """Interpret one event received from the model. Protocol-specific — implemented
+        by each subclass."""
+        raise NotImplementedError
+
+    async def _run_tool_call(
+        self, conv_id: str, name: str | None, arguments_json: str | None
+    ) -> object:
+        """Look up a model-requested tool by name, run it, and return its output.
+
+        Errors are returned as part of the output rather than raised, so a bad
+        tool call doesn't kill the call.
+        """
+        self.logger.debug(f"Tool call: {name}({arguments_json})", conversation_id=conv_id)
+
+        if not name:
+            return {"error": "Tool name is required"}
+
+        tool = self._tools_by_name.get(name)
+        if tool is None:
+            return {"error": f"Unknown tool '{name}'"}
+
+        try:
+            arguments = json.loads(arguments_json or "{}")
+            output = await tool(**arguments)
+            self.logger.debug(f"Tool result: {name} -> {output}", conversation_id=conv_id)
+            return output
+        except Exception as e:
+            self.logger.error(f"Tool '{name}' failed: {e}", conversation_id=conv_id, exc_info=True)
+            return {"error": f"Tool '{name}' failed to execute."}
+
+    async def _model_send(self, conv_id: str, obj: dict[str, Any]) -> None:
+        call = self._calls.get(conv_id)
+        if call is None or call.model_ws is None:
+            return
+        try:
+            await call.model_ws.send(json.dumps(obj))
+        except Exception as e:
+            self.logger.debug(f"Failed to send to model: {e}", conversation_id=conv_id)
+
+    async def _twilio_send(self, conv_id: str, obj: dict[str, Any]) -> None:
+        call = self._calls.get(conv_id)
+        if call is None or call.twilio_ws is None:
+            return
+        try:
+            await call.twilio_ws.send_text(json.dumps(obj))
+        except (WebSocketDisconnectError, RuntimeError) as e:
+            self.logger.debug(f"Failed to send to Twilio: {e}", conversation_id=conv_id)
+
+    async def send_response(
+        self,
+        conversation_id: str,
+        response: str | AsyncGenerator[str | dict[str, Any], None],
+        role: str | None = None,
+    ) -> None:
+        """Not supported: the model streams audio to Twilio directly, so there
+        is no text response for this provider to send."""
+        raise NotImplementedError(
+            f"{type(self).__name__} produces audio via the model; it has no text send_response."
+        )

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -1,7 +1,5 @@
 """``VoiceProvider``: the interface that lets ``VoiceChannel`` host more than
 one kind of real-time media provider.
-
-``ConversationRelayProvider`` is the only implementation today.
 """
 
 from __future__ import annotations
@@ -114,12 +112,7 @@ class VoiceProvider:
 
 
 class VoiceProviderConfig(BaseModel):
-    """Base configuration for a ``VoiceChannel``'s real-time media provider.
-
-    ``ConversationRelayProviderConfig`` is the only subclass today. Lives
-    here (not in ``config.py``) so a future provider's config only needs to
-    import this module, not anything ConversationRelay-specific.
-    """
+    """Base configuration for a ``VoiceChannel``'s real-time media provider."""
 
     memory_mode: MemoryMode = Field(
         default="never", description="Memory retrieval mode for this channel"

--- a/tests/test_openai_realtime_provider.py
+++ b/tests/test_openai_realtime_provider.py
@@ -428,6 +428,57 @@ class TestToolCalls:
         assert "error" in payload
         assert {"type": "response.create"} in model_ws.sent
 
+    @pytest.mark.asyncio
+    async def test_missing_call_id_is_dropped_without_sending_anything(self) -> None:
+        """No call_id means we can't tell the model which pending function
+        call this answers — sending one with call_id=None would likely be
+        rejected and leaves the real pending call still hanging."""
+
+        @function_tool()
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        channel = make_channel(tools=[add])
+        provider = channel._provider
+
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA10"] = _CallState(model_ws=model_ws)
+
+        await provider._handle_function_call(
+            "CA10", {"name": "add", "arguments": json.dumps({"a": 2, "b": 3})}
+        )
+
+        assert model_ws.sent == []
+
+    @pytest.mark.asyncio
+    async def test_missing_name_sends_structured_error_without_running_a_tool(self) -> None:
+        ran = False
+
+        @function_tool()
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            nonlocal ran
+            ran = True
+            return a + b
+
+        channel = make_channel(tools=[add])
+        provider = channel._provider
+
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA11"] = _CallState(model_ws=model_ws)
+
+        await provider._handle_function_call(
+            "CA11", {"call_id": "call_1", "arguments": json.dumps({"a": 2, "b": 3})}
+        )
+
+        assert ran is False
+        outputs = [m for m in model_ws.sent if m["type"] == "conversation.item.create"]
+        assert len(outputs) == 1
+        assert outputs[0]["item"]["call_id"] == "call_1"
+        payload = json.loads(outputs[0]["item"]["output"])
+        assert "error" in payload
+
 
 class TestConfigValidation:
     """OpenAIRealtimeProviderConfig fails fast on unusable combinations."""


### PR DESCRIPTION
## Summary
- Extracts `MediaStreamsOpenAIProviderConfig`, `MediaStreamsOpenAICallState`, and `MediaStreamsOpenAIProvider` into a new `media_streams/shared/` package, and updates `OpenAIRealtimeProviderConfig`/`_CallState`/`OpenAIRealtimeProvider` to inherit from them instead of duplicating fields/scaffolding.
- Behavior change: `_handle_function_call` now validates `call_id`/`name` before replying — a malformed item missing `call_id` is dropped (nothing to reply to), and one missing `name` sends back a structured `{"error": ...}` function_call_output instead of attempting to run a tool. Previously a malformed item could reach `_run_tool_call` with `name=None`.
- Trims a few module/class docstrings that named specific subclasses or asserted "the only implementation today" — that phrasing goes stale the moment a new subclass is added and creates comment upkeep with no payoff.

## Test plan
- [x] `make lint`
- [x] `make type-check`
- [x] `make test` (948 passed)