### PR TITLE
feat: make TAC safe to run as N replicas with no shared datastore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,16 +51,21 @@ Tests are in `tests/` — one test file per module (e.g., `test_tac.py`, `test_s
 
 - **Channel-based**: Messaging channels (SMS, RCS, WhatsApp, Chat) and Voice channel process Twilio webhooks, manage conversation lifecycle, and trigger `on_message_ready` / `on_conversation_ended` callbacks
 - **Callback responses**: Callbacks return `str` (auto-sent) or `None` (manual `channel.send_response()`)
-- **Memory modes**: Channels support three memory retrieval modes:
+- **Memory modes**:
   - `"never"` (default): No automatic memory retrieval
   - `"always"`: Fetch memory on every message with the user's query string for semantic search
-  - `"once"`: Fetch once with empty query, cache it. Cache invalidated on INACTIVE (when Orchestrator updates memory). Uses `cache_lock` to coordinate concurrent async access
+  - `"once"` (**Voice only**): Fetch once with empty query, cache it on the session. Invalidated on INACTIVE; uses `cache_lock` for concurrent async access. Needs a session outliving one request, which only voice has — messaging channels raise at construction.
+  - `memory_config.fetch_profile_traits=False` drops the `get_profile` call when prompts don't use `build_profile_prompt()`.
 - **Memory fallback**: `TAC.retrieve_memory()` tries Conversation Memory first, gracefully falls back to Conversation Orchestrator's `list_communications()` on any failure
 - **Profile resolution**: Automatic profile lookup by phone/email if `profile_id` not present in webhook
 - **Memory auto-init**: Memory client is always initialized from Conversation Orchestrator configuration's `memory_store_id`
 - **Auth**: All API clients use HTTP Basic Auth (API Key as username, API Token as password)
 - **BaseAPIClient**: All API clients (ConversationClient, MemoryClient, KnowledgeClient) inherit from `BaseAPIClient`, which provides shared HTTP client configuration, authentication, and User-Agent header management following Twilio SDK conventions
-- **Horizontal scaling limitation**: Channels track active conversations in instance-local memory (`self._conversations`). Works perfectly for single-instance deployments. In multi-instance deployments behind a load balancer, webhooks may route to a different instance than the one that handled the connection/message, preventing proper conversation cleanup and causing memory leaks. Recommended solutions: sticky sessions (route by conversation_id) or shared state store (Redis/database). Voice call events (status/AMD/recording) are a second, independently-arriving traffic class with the same constraint — they carry only the `CallSid`, so `VoiceChannel.end_call()` resolves the session by scanning `self._conversations` and finds nothing when the event lands on an instance that never saw the call. The Twilio-side hangup still succeeds; only local session cleanup is missed.
+- **Horizontal scaling**: N replicas behind a load balancer, **no shared datastore**. See `docs/deployment.md`.
+  - **Messaging is stateless** — `MessagingChannel` has no session store; each webhook derives a `ConversationSession` from the payload, config, and one `list_participants` call it needs anyway. The idempotency LRU is per-process, so a retry landing elsewhere is reprocessed: `on_message_ready` handlers must be idempotent.
+  - **Voice is instance-local**, correctly: a WebSocket pins a call to one process. Safe because teardown is guaranteed — `_release_session()` runs on every disconnect path and fires `on_call_ended` (invariant: `assert_no_residual_state` in `tests/voice_invariants.py`). `VoiceChannel.aclose()` drains at shutdown, wired by `TACFastAPIServer`.
+  - **Out-of-band call webhooks** (status/AMD/recording, `<Connect action>`) carry only a `CallSid`. Set `TACConfig.instance_public_domain` and TAC mints every callback URL against it; otherwise route by `CallSid` at the balancer.
+  - **`on_conversation_ended`** fires on whichever replica gets CO's CLOSED webhook — both families rebuild the session from CO. `on_call_ended` is the only hook carrying live in-memory state (transcript, metadata).
 - **ConversationRelay-only mode**: When `conversation_configuration_id` is omitted from TACConfig, TAC runs with just the Voice channel (messaging channels raise at construction), `TAC.retrieve_memory()` returns an empty `TACMemoryResponse`, and the ConversationRelay callback handles session cleanup. Use `tac.is_orchestrator_enabled()` to check mode at runtime.
 
 ## OpenAI Adapter

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,162 @@
+# Deploying TAC at scale
+
+TAC runs as N replicas behind an ordinary load balancer and **needs no shared
+datastore** — no Redis, no database, not even as an option.
+
+## The short version
+
+| | Messaging (SMS, RCS, WhatsApp, Chat) | Voice |
+|---|---|---|
+| Where state lives | nowhere — derived per request | in the process holding the call's WebSocket |
+| Load balancer | any replica, no stickiness | any replica for the WebSocket; see [instance affinity](#instance-affinity-for-voice) for the rest |
+| Shutdown | nothing to drain | call `aclose()` — [drain](#draining-on-shutdown) |
+| Extra API calls vs. a single instance | none by default | none |
+
+## Messaging is stateless
+
+A messaging channel keeps no conversation state between webhooks. Each request
+builds its own `ConversationSession` from three things it has anyway: the
+webhook payload, your channel configuration, and one `list_participants` call
+the self-message check and reconciliation already needed. Nothing a session
+holds is unrecoverable, so there is nothing to route stickily and nothing to
+leak.
+
+### The API-call budget
+
+Per inbound message, in steady state:
+
+| `memory_mode` | Calls | Which |
+|---|---|---|
+| `"never"` (default) | 2 | `GET /Participants`, `POST /Actions` |
+| `"always"` | 4 | the above, plus the profile-trait fetch and `/Recall` |
+| `"always"` with `fetch_profile_traits=False` | 3 | drops the trait fetch |
+
+TAC's own outbound echo costs **zero** — the author address matches the
+configured agent address, so it's discarded before any call is made.
+
+`/Recall` never returns traits, so the trait fetch is a genuinely separate
+call. If your prompts don't use `build_profile_prompt()`, turn it off:
+
+```python
+TACConfig(
+    ...,
+    memory_config=TwilioMemoryConfig(fetch_profile_traits=False),
+)
+```
+
+The customer's `profile_id` is read straight off the participant list — no
+profile lookup, and more reliable than resolving it from the address (which
+guesses the identifier type and misses on CHAT and RCS).
+
+### Reply with the session, not the id
+
+```python
+async def on_message(message: str, session: ConversationSession, memory) -> None:
+    reply = await my_llm(message)
+    await channel.send_response(session, reply)  # no extra API call
+```
+
+`send_response` still accepts a bare conversation id, but with no session to
+consult it spends a `list_participants` call rebuilding one.
+
+### Handlers must be idempotent
+
+TAC deduplicates webhook retries with Twilio's `i-twilio-idempotency-token`,
+in a bounded in-process cache. That catches a retry landing on the **same**
+replica — the common case, and free. It cannot catch one landing elsewhere.
+
+!!! warning "Contract"
+    `on_message_ready` may be called twice for the same message in a
+    multi-instance deployment. The blast radius is one extra LLM call and
+    possibly one duplicate outbound message.
+
+Tolerating that in the handler is cheaper than a distributed lock. If you
+genuinely can't, route by `conversation_id` at the load balancer.
+
+## Voice is pinned to one process, deliberately
+
+A live WebSocket ties a call to the process that accepted it for the call's
+whole lifetime, so that state is *correct* where it is. What matters is that it
+is always cleaned up and that the call's other traffic can find it.
+
+### Teardown is guaranteed
+
+However the WebSocket closes, TAC frees the session, the socket registry, the
+session manager entry, and any provider call state, then fires
+`on_call_ended`.
+
+### The three end-of-call hooks
+
+They are not interchangeable:
+
+| Hook | Fires | Instance | Carries |
+|---|---|---|---|
+| `VoiceChannel.on_call_ended` | WebSocket teardown, always | the one holding the call | the live session — transcript, `call_sid`, your `metadata` |
+| `TAC.on_conversation_ended` | when the *conversation* closes: Conversation Orchestrator's CLOSED webhook in orchestrated mode, at teardown in relay-only and Media Streams | any instance | the session, rebuilt from Conversation Orchestrator if the call ended elsewhere |
+| `VoiceChannel.on_call_status` | Twilio's Calls-API `status_callback`, only if registered before the call was placed | any instance | a `CallStatusEvent` — no session |
+
+`on_call_ended` is the only place late-call in-memory state is still reachable:
+a rebuild from Conversation Orchestrator restores identity — conversation id,
+`call_sid`, profile, both participants — but not a transcript.
+
+### Instance affinity for voice
+
+A call's out-of-band webhooks — status, AMD, recording, and the
+ConversationRelay `<Connect action>` callback — carry only a `CallSid` and
+arrive independently of the WebSocket. Pointed at a load balancer they land on
+an arbitrary replica, where `get_conversation_session_by_call_sid` finds
+nothing. TAC mints those URLs, so it can make them instance-specific:
+
+```python
+TACConfig(
+    ...,
+    voice_public_domain="voice.example.com",           # the load balancer
+    instance_public_domain=os.environ["POD_ADDRESS"],  # this pod, directly
+)
+```
+
+The WebSocket URL, the action URL, and every call-event callback then point at
+this process, so a call's webhooks come back to the replica holding it.
+
+This needs per-pod addressability — on Kubernetes, a headless Service plus
+`POD_IP`/`POD_NAME`. Without it, leave the setting unset (the load balancer
+domain remains the default) and route by `CallSid` at the balancer.
+
+### Draining on shutdown
+
+Without a drain, a scale-in or redeploy drops live calls with no callback at
+all: the socket dies with the process and nothing fires.
+
+`TACFastAPIServer` wires this up for you — it registers
+`VoiceChannel.aclose()` on the app's shutdown event, with the grace period from
+`TACServerConfig.shutdown_grace_period` (30s by default).
+
+```python
+server = TACFastAPIServer(tac=tac, voice_channel=voice_channel)
+server.start()  # aclose() runs on shutdown
+```
+
+Two cases need you to do it yourself:
+
+- **You passed a FastAPI app with its own `lifespan=`.** Starlette ignores
+  event handlers on such an app, so `await server.aclose()` in your lifespan's
+  shutdown half.
+- **You're not using `TACFastAPIServer`.** Call
+  `await voice_channel.aclose()` from your framework's shutdown hook.
+
+Draining refuses new WebSocket connections, waits up to the grace period for
+calls to end naturally, then force-releases whatever remains so the hooks fire.
+Fail your readiness probe *before* it runs so the balancer stops routing here,
+and keep the grace period below your orchestrator's termination grace period or
+the process is killed mid-drain.
+
+## What TAC does not do
+
+- **No shared state store.** Deliberately — it would put a distributed-systems
+  dependency into an SDK whose appeal is dropping into an existing app, and
+  there is almost nothing left worth caching.
+- **No live session migration.** A call belongs to one process until it ends.
+- **`memory_mode="once"` on messaging.** It caches a recall on a long-lived
+  session, which messaging doesn't have. Statelessly it would cost the same as
+  `"always"` with worse relevance, so messaging channels raise at construction
+  rather than degrade silently. Use `"always"`.

--- a/getting_started/examples/features/chat/app.py
+++ b/getting_started/examples/features/chat/app.py
@@ -110,7 +110,8 @@ async def handle_message_ready(
             }
             conversation_history[conv_id].append(assistant_msg)
 
-            await chat_channel.send_response(conv_id, llm_response)
+            # Hand back the session the callback received — no extra API call.
+            await chat_channel.send_response(context, llm_response)
 
     except Exception as e:
         logger.error("Error processing message", conversation_id=conv_id, error=str(e))

--- a/getting_started/examples/features/dashboard/app.py
+++ b/getting_started/examples/features/dashboard/app.py
@@ -49,6 +49,11 @@ openai_client = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
 conversation_history: dict[str, list[ChatCompletionMessageParam]] = {}
 
+# Messaging channels are stateless — they derive a session per webhook and keep
+# nothing — so the dashboard's live messaging panel is fed by the app instead.
+# Cleared in on_conversation_ended below.
+messaging_sessions: dict[str, ConversationSession] = {}
+
 SYSTEM_MESSAGE: ChatCompletionSystemMessageParam = {
     "role": "system",
     "content": (
@@ -66,6 +71,8 @@ async def handle_message_ready(
     memory_response: TACMemoryResponse | None,
 ) -> str:
     conv_id = context.conversation_id
+    if context.channel != voice_channel.get_channel_name():
+        messaging_sessions[conv_id] = context
 
     try:
         if conv_id not in conversation_history:
@@ -96,7 +103,13 @@ async def handle_message_ready(
         return "Sorry, I encountered an error processing your message."
 
 
+async def handle_conversation_ended(context: ConversationSession) -> None:
+    messaging_sessions.pop(context.conversation_id, None)
+    conversation_history.pop(context.conversation_id, None)
+
+
 tac.on_message_ready(handle_message_ready)
+tac.on_conversation_ended(handle_conversation_ended)
 
 if __name__ == "__main__":
     from tac.server.config import TACServerConfig
@@ -112,7 +125,11 @@ if __name__ == "__main__":
     from dashboard import mount_dashboard  # type: ignore[import-not-found]
 
     mount_dashboard(
-        server.app, tac, channels=[sms_channel, voice_channel], messages=conversation_history
+        server.app,
+        tac,
+        channels=[sms_channel, voice_channel],
+        messages=conversation_history,
+        messaging_sessions=messaging_sessions,
     )
 
     logger.info(f"Dashboard: http://localhost:{server.config.port}/dashboard")

--- a/getting_started/examples/features/dashboard/dashboard.py
+++ b/getting_started/examples/features/dashboard/dashboard.py
@@ -320,6 +320,7 @@ def mount_dashboard(
     tac: Any,
     channels: list[Any] | None = None,
     messages: dict[str, list[Any]] | None = None,
+    messaging_sessions: dict[str, ConversationSession] | None = None,
 ) -> None:
     """Mount the dashboard onto a FastAPI app in one call.
 
@@ -328,21 +329,22 @@ def mount_dashboard(
         tac: TAC instance. Uses ``conversation_memory_client`` and
             ``conversation_orchestrator_client`` for data fetches.
         channels: Channel instances (SMSChannel, VoiceChannel, ChatChannel, etc.).
-            Sessions are read from each channel's ``_conversations`` dict.
+            Voice sessions are read live from the channel — a call is pinned to
+            this process for its lifetime, so the channel holds them.
         messages: Conversation message history ``{conv_id: [{role, content}, ...]}``.
+        messaging_sessions: Sessions the *application* is keeping for messaging
+            conversations. Messaging channels are stateless — each webhook
+            derives its own session and discards it — so there is nothing to
+            read off the channel. Populate this from ``on_message_ready`` if
+            you want a live messaging panel.
     """
-    from tac.channels.sms import SMSChannel
     from tac.channels.voice import VoiceChannel
 
-    sms_channels = [c for c in (channels or []) if isinstance(c, SMSChannel)]
     voice_channels = [c for c in (channels or []) if isinstance(c, VoiceChannel)]
-    other_channels = [c for c in (channels or []) if not isinstance(c, (SMSChannel, VoiceChannel))]
+    tracked_messaging = messaging_sessions if messaging_sessions is not None else {}
 
     def _get_sms_sessions() -> dict[str, ConversationSession]:
-        result: dict[str, ConversationSession] = {}
-        for ch in sms_channels + other_channels:
-            result.update(ch._conversations)
-        return result
+        return dict(tracked_messaging)
 
     def _get_voice_sessions() -> dict[str, ConversationSession]:
         result: dict[str, ConversationSession] = {}
@@ -356,7 +358,7 @@ def mount_dashboard(
     ci_events: dict[str, list[dict[str, Any]]] = {}
 
     router = create_dashboard_router(
-        get_sms_sessions=_get_sms_sessions if (sms_channels or other_channels) else None,
+        get_sms_sessions=_get_sms_sessions if messaging_sessions is not None else None,
         get_voice_sessions=_get_voice_sessions if voice_channels else None,
         get_messages=(
             (lambda conv_id: list(messages.get(conv_id, []))) if messages is not None else None

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Deploying at scale: deployment.md
   - API Reference:
       - Core: api/core.md
       - Channels: api/channels.md

--- a/src/tac/channels/base.py
+++ b/src/tac/channels/base.py
@@ -28,8 +28,12 @@ class BaseChannel(ABC):
     Channels handle protocol-specific webhook processing and response delivery
     for different communication channels (SMS, Voice, etc.).
 
-    This class provides common conversation lifecycle management that is shared
-    across all channel types.
+    Provides only what every channel family shares: webhook deduplication,
+    participant-matching helpers, and memory retrieval.
+
+    Session storage deliberately isn't here. ``VoiceChannel`` owns its
+    sessions (a call is pinned to one process); messaging channels derive a
+    session per request and hold nothing between them.
     """
 
     def __init__(
@@ -45,8 +49,8 @@ class BaseChannel(ABC):
             tac: TAC instance for memory/context operations
             memory_mode: Memory retrieval mode. Default is "never".
                 - "always": Retrieve memory for every message with the query string
-                - "once": Retrieve memory once at conversation start with empty query and cache it.
-                         Cache is invalidated when conversation becomes INACTIVE.
+                - "once" (Voice only): Retrieve once with an empty query and cache it on
+                         the session. Invalidated when the conversation becomes INACTIVE.
                 - "never": Skip memory retrieval
             dedup_capacity: Maximum number of idempotency tokens to track for
                 webhook deduplication. Default 10000. Must be positive.
@@ -57,9 +61,6 @@ class BaseChannel(ABC):
         self.tac = tac
         self.logger = get_logger(self.__class__.__module__)
         self.memory_mode = memory_mode
-
-        # Track active conversations (shared across all channel types)
-        self._conversations: dict[str, ConversationSession] = {}
 
         # Webhook deduplication
         self._processed_tokens: OrderedDict[str, bool] = OrderedDict()
@@ -138,8 +139,10 @@ class BaseChannel(ABC):
         """Self-filtering: check if webhook event belongs to this channel.
 
         For COMMUNICATION_CREATED: require author.channel matches this channel type.
-        For CONVERSATION_UPDATED: only process if conversation is tracked locally.
-        Other events pass through.
+        Other events pass through, including CONVERSATION_UPDATED — the
+        per-channel handler filters that one. Filtering it here on locally
+        tracked state would drop it on any instance that didn't serve the
+        conversation's messages.
         """
         event_type = webhook_data.get("eventType")
         event_data = webhook_data.get("data")
@@ -154,13 +157,6 @@ class BaseChannel(ABC):
             if not author_channel:
                 return False
             return bool(author_channel == self.get_channel_name())
-
-        if event_type == "CONVERSATION_UPDATED":
-            if not isinstance(event_data, dict):
-                return False
-            conv_id = event_data.get("id")
-            if conv_id and conv_id not in self._conversations:
-                return False
 
         return True
 
@@ -211,71 +207,20 @@ class BaseChannel(ABC):
             None,
         )
 
-    def _start_conversation(
-        self,
-        conv_id: str,
-        profile_id: str | None = None,
-    ) -> ConversationSession:
+    async def _trigger_conversation_ended(self, session: ConversationSession) -> None:
+        """Fire ``on_conversation_ended`` for a session, swallowing handler errors.
+
+        A developer callback raising must not abort the channel's own cleanup
+        or fail the webhook, so the exception is logged and dropped here.
         """
-        Initialize new conversation session with optional profile_id.
-
-        Profile data is fetched lazily during retrieve_memory() when needed.
-
-        Args:
-            conv_id: Conversation ID
-            profile_id: Profile ID for the conversation (optional)
-
-        Returns:
-            The new or existing ConversationSession.
-        """
-        if conv_id in self._conversations:
-            self.logger.debug(
-                "Conversation already exists, skipping initialization",
-                conversation_id=conv_id,
-                channel=self.get_channel_name(),
-            )
-            return self._conversations[conv_id]
-
-        # Store conversation session
-        self._conversations[conv_id] = ConversationSession(
-            conversation_id=conv_id,
-            profile_id=profile_id,
-            channel=self.get_channel_name(),
-        )
-
-        self.logger.info(
-            f"CONVERSATION | Started {self.get_channel_name()} conversation",
-            conversation_id=conv_id,
-            profile_id=profile_id,
-        )
-        return self._conversations[conv_id]
-
-    async def _end_conversation(self, conv_id: str) -> None:
-        """
-        Clean up conversation session.
-
-        Pops the session from the conversation dict, then triggers the
-        on_conversation_ended callback with the removed session data.
-
-        Args:
-            conv_id: Conversation ID
-        """
-        session = self._conversations.pop(conv_id, None)
-        if session is not None:
-            try:
-                await self.tac.trigger_conversation_ended(session)
-            except Exception as e:
-                self.logger.error(
-                    "Error in conversation ended callback",
-                    conversation_id=conv_id,
-                    error=str(e),
-                    exc_info=True,
-                )
-
-            self.logger.debug(
-                "Ended conversation",
-                conversation_id=conv_id,
-                channel=self.get_channel_name(),
+        try:
+            await self.tac.trigger_conversation_ended(session)
+        except Exception as e:
+            self.logger.error(
+                "Error in conversation ended callback",
+                conversation_id=session.conversation_id,
+                error=str(e),
+                exc_info=True,
             )
 
     async def _retrieve_memory_if_enabled(

--- a/src/tac/channels/chat.py
+++ b/src/tac/channels/chat.py
@@ -63,9 +63,10 @@ class ChatChannel(MessagingChannel):
     def is_default_agent_address(self, author_address: str) -> bool:
         return author_address == self.agent_address
 
-    def get_agent_address(self, conversation_id: str) -> ParticipantAddress:
-        session = self._conversations.get(conversation_id)
-        channel_id = session.metadata.get("channel_id") if session else None
+    def get_agent_address(self, session: ConversationSession) -> ParticipantAddress:
+        # channelId is per-conversation, so it comes off the session rather
+        # than config — the inbound webhook puts it there.
+        channel_id = session.metadata.get("channel_id")
         return ParticipantAddress(
             channel="CHAT",
             address=self.agent_address,

--- a/src/tac/channels/messaging.py
+++ b/src/tac/channels/messaging.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 from pydantic import BaseModel, Field
@@ -27,6 +27,13 @@ from tac.models.outbound import InitiateConversationResult, InitiateMessagingCon
 from tac.models.session import AuthorInfo, ConversationSession
 from tac.utils.redaction import mask_address
 
+MessagingMemoryMode = Literal["never", "always"]
+"""Memory modes a messaging channel supports.
+
+Narrower than :data:`~tac.models.memory.MemoryMode`: ``"once"`` caches a recall
+on a long-lived session, which only voice has.
+"""
+
 
 class MessagingChannelConfig(BaseModel):
     """Base configuration for messaging channels (SMS, RCS, WhatsApp, Chat).
@@ -35,13 +42,13 @@ class MessagingChannelConfig(BaseModel):
         dedup_capacity: Maximum number of idempotency tokens to track.
             Default 10000 is suitable for most applications.
             Uses Twilio's i-twilio-idempotency-token header for deduplication.
-        memory_mode: Memory retrieval mode. Default is "never".
-            - "always": Retrieve memory for every message with the query string
-            - "once": Retrieve memory once at conversation start with empty query and cache it.
-                     Cache is invalidated when conversation becomes INACTIVE and is fetched
-                     again the next time a message triggers memory retrieval after the
-                     conversation becomes ACTIVE.
-            - "never": Skip memory retrieval
+        memory_mode: Memory retrieval mode. Default is `"never"`.
+
+            - `"always"`: Retrieve memory for every message with the query string
+            - `"never"`: Skip memory retrieval
+
+            `"once"` is **not** available on messaging channels — see
+            `MessagingMemoryMode`.
     """
 
     dedup_capacity: int = Field(
@@ -49,7 +56,7 @@ class MessagingChannelConfig(BaseModel):
         gt=0,
         description="Maximum number of idempotency tokens to track for deduplication",
     )
-    memory_mode: MemoryMode = Field(
+    memory_mode: MessagingMemoryMode = Field(
         default="never",
         description="Memory retrieval mode for this channel",
     )
@@ -62,17 +69,24 @@ class MessagingChannel(BaseChannel):
     Conversation Orchestrator webhooks with COMMUNICATION_CREATED
     and CONVERSATION_UPDATED event types.
 
-    Subclasses must implement:
-    - is_default_agent_address(): Fast-path check for the channel's default agent address
-    - get_agent_address(conversation_id): Return the agent's ParticipantAddress for a conversation
-    - get_channel_name(): Return channel name ("SMS", "RCS", "WHATSAPP", "CHAT")
+    **Stateless by construction.** No conversation state is kept between
+    webhooks: each request derives its own `ConversationSession` from the
+    payload, config, and one `list_participants` call it needs anyway. So any
+    replica can serve any webhook — no sticky sessions, no shared datastore.
 
-    send_response() is provided here as a shared implementation. Subclasses may
-    override _build_channel_settings() to customize how ActionChannelSettings
-    is built for the outbound send (e.g. chat requires channel_id).
+    Subclasses must implement:
+
+    - `is_default_agent_address()`: Fast-path check for the channel's default agent address
+    - `get_agent_address(session)`: Return the agent's `ParticipantAddress` for a session
+    - `get_channel_name()`: Return channel name (`"SMS"`, `"RCS"`, `"WHATSAPP"`, `"CHAT"`)
+
+    `send_response()` is provided here as a shared implementation. Subclasses may
+    override `_build_channel_settings()` to customize how `ActionChannelSettings`
+    is built for the outbound send (e.g. chat requires `channel_id`).
 
     Subclass class attributes:
-    - reconcile_customer_type: If True, reconciliation will also promote a
+
+    - `reconcile_customer_type`: If True, reconciliation will also promote a
       channel-matching UNKNOWN participant (not owning the agent address) to
       CUSTOMER. Set False for channels where the customer is identified
       author-driven (e.g. chat).
@@ -90,6 +104,12 @@ class MessagingChannel(BaseChannel):
             raise ValueError(
                 f"{type(self).__name__} requires Conversation Orchestrator to be configured. "
                 "Set `conversation_configuration_id` on TACConfig to enable messaging channels."
+            )
+        if memory_mode == "once":
+            raise ValueError(
+                f'{type(self).__name__} does not support memory_mode="once" — it caches a '
+                "recall on a long-lived session, and messaging channels hold none between "
+                'webhooks. Use "always". ("once" is still available on the Voice channel.)'
             )
         self.conversation_orchestrator_client: ConversationClient = (
             tac.conversation_orchestrator_client
@@ -111,52 +131,60 @@ class MessagingChannel(BaseChannel):
         """
         pass
 
-    async def _is_own_message(
+    def _is_own_message(
         self,
-        author_address: str,
-        conversation_id: str,
         author_participant_id: str | None,
+        participants: list[ParticipantResponse],
+        conversation_id: str,
     ) -> bool:
-        """Check if a message is from the bot itself (2-tier).
+        """Whether the author is TAC, judged from an already-fetched list.
 
-        1. Default agent address (stateless, no API call)
-        2. API fallback via listParticipants (cross-process / multi-worker)
+        The caller does the free check (author address == configured agent
+        address) first; this catches TAC speaking from some other address.
         """
-        if self.is_default_agent_address(author_address):
-            return True
+        if not author_participant_id:
+            return False
 
-        if author_participant_id:
-            try:
-                participants = await self.conversation_orchestrator_client.list_participants(
-                    conversation_id
-                )
-                author_p = next((p for p in participants if p.id == author_participant_id), None)
-                if author_p:
-                    if author_p.type is None:
-                        self.logger.warning(
-                            "Participant type is undefined",
-                            conversation_id=conversation_id,
-                            participant_id=author_participant_id,
-                        )
-                    if author_p.type in AGENT_TYPES:
-                        return True
-            except Exception as e:
-                self.logger.warning(
-                    "Failed to look up participant type for self-message check",
-                    conversation_id=conversation_id,
-                    participant_id=author_participant_id,
-                    error=str(e),
-                )
+        author = next((p for p in participants if p.id == author_participant_id), None)
+        if author is None:
+            return False
+        if author.type is None:
+            self.logger.warning(
+                "Participant type is undefined",
+                conversation_id=conversation_id,
+                participant_id=author_participant_id,
+            )
+        return author.type in AGENT_TYPES
 
-        return False
+    async def _list_participants(self, conversation_id: str) -> list[ParticipantResponse] | None:
+        """Fetch a conversation's participants, returning None on failure.
+
+        One call per inbound message, shared by the self-message check,
+        reconciliation, and profile resolution. None of them can proceed
+        without it, so a failure is a hard stop for the caller.
+        """
+        try:
+            return await self.conversation_orchestrator_client.list_participants(conversation_id)
+        except Exception as e:
+            self.logger.error(
+                "Failed to list participants",
+                conversation_id=conversation_id,
+                error=str(e),
+            )
+            return None
 
     @abstractmethod
-    def get_agent_address(self, conversation_id: str) -> ParticipantAddress:
-        """Return the agent-side ParticipantAddress for this conversation.
+    def get_agent_address(self, session: ConversationSession) -> ParticipantAddress:
+        """Return the agent-side ParticipantAddress for this session.
 
-        Used by `_reconcile_participants` to identify which participant (by
-        channel + address) represents the agent. May read from session state
-        (e.g. chat's per-conversation channelId) to build the address.
+        Identifies which participant represents the agent, and supplies the
+        `from` address for outbound sends. Reads the session where the address
+        isn't pure config — chat's per-conversation `channelId`, for instance.
+
+        !!! warning "Breaking change"
+            Was `get_agent_address(conversation_id: str)`. It takes the session
+            now because the channel no longer holds one to look up. Subclasses
+            outside TAC must update their override.
         """
         pass
 
@@ -176,65 +204,140 @@ class MessagingChannel(BaseChannel):
             else None
         )
 
+    def _participant_ref(
+        self, address: str | None, participant_id: str | None
+    ) -> ActionParticipantRef:
+        """Build an Actions API participant reference.
+
+        Conversation Orchestrator resolves by participant id or by explicit
+        `(channel, address)`. Prefer the id — reconciliation has already
+        established it — and fall back to the address when there isn't one.
+        """
+        channel_name = self.get_channel_name()
+        if participant_id:
+            return ActionParticipantRef(channel=channel_name, participant_id=participant_id)
+        return ActionParticipantRef(channel=channel_name, address=address)
+
+    def _session_from_participants(
+        self, conversation_id: str, participants: list[ParticipantResponse]
+    ) -> ConversationSession | None:
+        """Rebuild a session for a conversation this process never handled.
+
+        Returns ``None`` when no participant is on this channel, which is how
+        another channel's conversation is filtered out.
+        """
+        channel_name = self.get_channel_name()
+        session = ConversationSession(conversation_id=conversation_id, channel=channel_name)
+        agent_address = self.get_agent_address(session)
+
+        def _matches_channel(p: ParticipantResponse) -> bool:
+            return any(a.channel == channel_name for a in p.addresses)
+
+        if not any(_matches_channel(p) for p in participants):
+            return None
+
+        agent = self._find_agent_participant(participants, channel_name, agent_address.address)
+        session.ai_agent_info = AuthorInfo(
+            address=agent_address.address,
+            participant_id=agent.id if agent else None,
+        )
+
+        customer = next(
+            (
+                p
+                for p in participants
+                if p.type == "CUSTOMER"
+                and _matches_channel(p)
+                and not self._owns_address(p, channel_name, agent_address.address)
+            ),
+            None,
+        )
+        if customer is not None:
+            session.profile_id = customer.profile_id
+            customer_address = next(
+                (a.address for a in customer.addresses if a.channel == channel_name),
+                None,
+            )
+            if customer_address:
+                session.author_info = AuthorInfo(
+                    address=customer_address, participant_id=customer.id
+                )
+        return session
+
     async def send_response(
         self,
-        conversation_id: str,
+        conversation: str | ConversationSession,
         response: str | AsyncGenerator[str | dict[str, Any], None],
         role: str | None = None,
     ) -> None:
         """Send a text response using the Conversation Orchestrator Send API.
 
-        Reads the agent and customer participant ids stashed on the session
-        by inbound reconciliation or outbound initiation. Missing ids are a
-        misuse — send_response is only expected to be called after an inbound
-        webhook (COMMUNICATION_CREATED → reconcile) or after
-        `initiate_outbound_conversation`, both of which populate the session.
+        **Pass the session, not the id.** Hand back the one `on_message_ready`
+        gave you (or that `initiate_outbound_conversation` returned) and the
+        send costs no extra API call — it already carries both participants.
+        A bare id still works, but the channel keeps no session to look up, so
+        it spends a `list_participants` call rebuilding one.
 
         Args:
-            conversation_id: Conversation ID to send response to
+            conversation: The `ConversationSession` to reply within
+                (preferred), or the conversation id.
             response: Message content. Must be ``str`` — messaging channels send a
                 single complete message via the Conversation Orchestrator Send API
                 and do not support streaming (unlike the Voice channel).
             role: Optional message role (unused by messaging channels)
 
+        !!! warning "Breaking change"
+            The first parameter was named `conversation_id`. Positional calls
+            are unaffected; a call passing `conversation_id=` needs updating.
+
         Raises:
             TypeError: If response is not a string (e.g. an async generator is
                 passed, since messaging channels don't support streaming)
-            RuntimeError: If the session or participant ids are missing
+            RuntimeError: If no recipient can be resolved for the conversation.
         """
         channel_name = self.get_channel_name()
         if not isinstance(response, str):
             raise TypeError(f"{channel_name} channel only supports string responses")
 
-        session = self._conversations.get(conversation_id)
-        if session is None or not session.author_info or not session.ai_agent_info:
+        if isinstance(conversation, ConversationSession):
+            session: ConversationSession | None = conversation
+            conversation_id = conversation.conversation_id
+        else:
+            conversation_id = conversation
+            participants = await self._list_participants(conversation_id)
+            if participants is None:
+                raise RuntimeError(
+                    f"Unable to send {channel_name} message: could not read participants for "
+                    f"conversation {conversation_id}. Pass the ConversationSession from "
+                    "on_message_ready or initiate_outbound_conversation to avoid this lookup."
+                )
+            session = self._session_from_participants(conversation_id, participants)
+
+        if session is None or session.author_info is None:
             raise RuntimeError(
-                f"Unable to send {channel_name} message: send_response called without a "
-                f"reconciled session for conversation {conversation_id}. Wait for an "
-                "inbound webhook or call initiate_outbound_conversation first."
+                f"Unable to send {channel_name} message: no recipient resolved for "
+                f"conversation {conversation_id}. Pass the ConversationSession you were "
+                "handed by on_message_ready or initiate_outbound_conversation."
             )
 
-        customer_participant_id = session.author_info.participant_id
-        agent_participant_id = session.ai_agent_info.participant_id
-        if not customer_participant_id or not agent_participant_id:
-            raise RuntimeError(
-                f"Unable to send {channel_name} message: session for conversation "
-                f"{conversation_id} is missing participant ids."
-            )
-
+        agent_address = (
+            session.ai_agent_info.address
+            if session.ai_agent_info
+            else self.get_agent_address(session).address
+        )
         channel_settings = self._build_channel_settings(conversation_id, session)
 
         try:
             action_request = SendMessageActionRequest(
                 payload=SendMessageActionPayload(
-                    from_=ActionParticipantRef(
-                        channel=channel_name,
-                        participant_id=agent_participant_id,
+                    from_=self._participant_ref(
+                        agent_address,
+                        session.ai_agent_info.participant_id if session.ai_agent_info else None,
                     ),
                     to=[
-                        ActionParticipantRef(
-                            channel=channel_name,
-                            participant_id=customer_participant_id,
+                        self._participant_ref(
+                            session.author_info.address,
+                            session.author_info.participant_id,
                         )
                     ],
                     content=ActionTextContent(text=response),
@@ -266,12 +369,15 @@ class MessagingChannel(BaseChannel):
         """Process messaging channel webhook event and manage conversation lifecycle.
 
         Handles:
-        - COMMUNICATION_CREATED: Process incoming messages from customers
-        - CONVERSATION_UPDATED: Clean up when conversation is closed
 
-        Note: Conversation tracking uses instance-local memory. In multi-instance
-        deployments, webhooks may route to a different instance, preventing cleanup.
-        See CLAUDE.md for horizontal scaling considerations.
+        - COMMUNICATION_CREATED: Process incoming messages from customers
+        - CONVERSATION_UPDATED: Fire `on_conversation_ended` when the
+          conversation closes
+
+        Any replica can handle any webhook. The idempotency cache is
+        per-process, though, so a Twilio retry landing on a different replica
+        is processed again — `on_message_ready` handlers must tolerate being
+        called twice for the same message.
 
         Args:
             webhook_data: Raw webhook event data from Twilio
@@ -299,6 +405,26 @@ class MessagingChannel(BaseChannel):
         elif event_type == "CONVERSATION_UPDATED":
             await self._handle_conversation_updated(event_data)
 
+    def _resolve_session(self, conv_id: str, communication: Communication) -> ConversationSession:
+        """Build this request's session from the webhook payload and config.
+
+        Network-free — the author, the agent address and `channel_id` are all
+        in hand already. Reconciliation layers the participant ids on after.
+        """
+        session = ConversationSession(
+            conversation_id=conv_id,
+            channel=self.get_channel_name(),
+        )
+        session.author_info = AuthorInfo(
+            address=communication.author.address,
+            participant_id=communication.author.participant_id,
+        )
+        # Set before get_agent_address: chat's agent address carries channelId.
+        if communication.channel_id:
+            session.metadata["channel_id"] = communication.channel_id
+        session.ai_agent_info = AuthorInfo(address=self.get_agent_address(session).address)
+        return session
+
     async def _handle_communication_created(self, event_data: Any) -> None:
         """Handle COMMUNICATION_CREATED event (incoming message)."""
         communication_data = Communication.model_validate(event_data)
@@ -308,68 +434,56 @@ class MessagingChannel(BaseChannel):
         if not message_text or not message_text.strip():
             return
 
-        if await self._is_own_message(
-            communication_data.author.address,
-            conv_id,
-            communication_data.author.participant_id,
-        ):
+        # TAC's own echo costs zero API calls — the address is right there.
+        if self.is_default_agent_address(communication_data.author.address):
             return
 
-        if conv_id not in self._conversations:
-            self._start_conversation(conv_id, profile_id=None)
+        session = self._resolve_session(conv_id, communication_data)
+        channel = self.get_channel_name()
 
-        session = self._conversations[conv_id]
+        # One participant fetch per message, shared by the self-message check,
+        # reconciliation, and profile resolution. All three need it, and none
+        # can proceed without it.
+        participants = await self._list_participants(conv_id)
+        if participants is None:
+            await self._drop_inbound(
+                conv_id, channel, "Could not read participants; inbound message dropped"
+            )
+            return
 
-        session.author_info = AuthorInfo(
-            address=communication_data.author.address,
-            participant_id=communication_data.author.participant_id,
-        )
-
-        # Store channelId in session metadata for outbound reply channelSettings
-        if communication_data.channel_id:
-            session.metadata["channel_id"] = communication_data.channel_id
+        if self._is_own_message(communication_data.author.participant_id, participants, conv_id):
+            return
 
         # Reconcile participant types pre-LLM so v1-bridge's UNKNOWN gets
-        # promoted to CUSTOMER (with a Conversation Memory profile attached when possible)
-        # and to stash both participant ids on the session for send_response.
-        # If reconciliation can't identify both sides, any eventual reply would
-        # fail too — skip the callback so the LLM doesn't waste a turn on an
-        # un-replyable conversation.
-        #
-        # Skip reconcile entirely when both sides are already stashed from a
-        # prior turn — Conversation Orchestrator's state was written by us and doesn't drift.
-        if session.ai_agent_info is None or session.author_info is None:
-            resolved = await self._reconcile_participants(conv_id)
-            if resolved is None:
-                channel = self.get_channel_name()
-                self.logger.error(
-                    "Reconciliation failed; dropping inbound message",
-                    conversation_id=conv_id,
-                    channel=channel,
-                )
-                await self.tac.trigger_error(
-                    RuntimeError("Participant reconciliation failed; inbound message dropped"),
-                    {
-                        "conversation_id": conv_id,
-                        "channel": channel,
-                        "dropped_inbound": True,
-                    },
-                )
-                return
-
-            agent_participant, customer_participant = resolved
-            session.ai_agent_info = AuthorInfo(
-                address=self.get_agent_address(conv_id).address,
-                participant_id=agent_participant.id,
+        # promoted to CUSTOMER (with a Conversation Memory profile attached when
+        # possible) and to resolve both participant ids for the reply. If it
+        # can't identify both sides, any eventual reply would fail too — skip
+        # the callback rather than waste an LLM turn on an un-replyable
+        # conversation. Running it every message is free: it reuses the list
+        # above, and the happy-path row issues no writes.
+        resolved = await self._reconcile_participants(session, participants)
+        if resolved is None:
+            await self._drop_inbound(
+                conv_id, channel, "Participant reconciliation failed; inbound message dropped"
             )
-            # When reconcile resolved a customer (SMS path — chat disables
-            # customer reconciliation and uses the author_info captured from
-            # the webhook above), use its authoritative participant id and
-            # lift any resolved profile.
-            if customer_participant is not None and session.author_info is not None:
-                session.author_info.participant_id = customer_participant.id
-                if customer_participant.profile_id and not session.profile_id:
-                    session.profile_id = customer_participant.profile_id
+            return
+
+        agent_participant, customer_participant = resolved
+        assert session.ai_agent_info is not None  # set by _resolve_session
+        session.ai_agent_info.participant_id = agent_participant.id
+        # When reconcile resolved a customer (chat disables customer
+        # reconciliation and keeps the webhook author), its participant id is
+        # the authoritative reply recipient — the author of an inbound message
+        # is not necessarily the customer.
+        if customer_participant is not None and session.author_info is not None:
+            session.author_info.participant_id = customer_participant.id
+            if customer_participant.profile_id:
+                session.profile_id = customer_participant.profile_id
+
+        if session.profile_id is None and self.memory_mode != "never":
+            # Free, and more reliable than Memory's address-based lookup, which
+            # infers the identifier type and misses on CHAT and RCS.
+            session.profile_id = self._profile_id_from_participants(session, participants)
 
         memory_response = await self._retrieve_memory_if_enabled(session, message_text, conv_id)
 
@@ -377,7 +491,7 @@ class MessagingChannel(BaseChannel):
             response = await self.tac.trigger_message_ready(message_text, session, memory_response)
             # Auto-send if callback returned a string (None = manual send_response flow)
             if response is not None:
-                await self.send_response(conv_id, response, role="assistant")
+                await self.send_response(session, response, role="assistant")
         except Exception as e:
             self.logger.error(
                 "Error in message ready callback",
@@ -386,35 +500,50 @@ class MessagingChannel(BaseChannel):
                 exc_info=True,
             )
 
+    def _profile_id_from_participants(
+        self, session: ConversationSession, participants: list[ParticipantResponse]
+    ) -> str | None:
+        """Read the customer's profile id off the participant list already fetched."""
+        author_participant_id = session.author_info.participant_id if session.author_info else None
+        if not author_participant_id:
+            return None
+        author = next((p for p in participants if p.id == author_participant_id), None)
+        return author.profile_id if author else None
+
+    async def _drop_inbound(self, conv_id: str, channel: str, reason: str) -> None:
+        """Log a dropped inbound message and surface it via ``on_error``."""
+        self.logger.error(reason, conversation_id=conv_id, channel=channel)
+        await self.tac.trigger_error(
+            RuntimeError(reason),
+            {"conversation_id": conv_id, "channel": channel, "dropped_inbound": True},
+        )
+
     async def _handle_conversation_updated(self, event_data: Any) -> None:
         """Handle CONVERSATION_UPDATED event.
 
-        - CLOSED: Remove session (clears cache)
-        - INACTIVE: Invalidate cached memory (Orchestrator updates memory on INACTIVE)
+        Only CLOSED is acted on, and only when an `on_conversation_ended`
+        handler is registered, so the common case costs nothing. The rebuild
+        also confirms the conversation belongs to this channel (a CHAT close
+        must not fire on SMS), and is what lets the hook fire on whichever
+        replica Twilio picked.
         """
         conversation_data = ConversationResponse.model_validate(event_data)
         conv_id = conversation_data.id
-        status = conversation_data.status
 
         if conversation_data.configuration_id != self.tac.config.conversation_configuration_id:
             return
-
-        session = self._conversations.get(conv_id)
-        if not session or session.channel != self.get_channel_name():
+        if conversation_data.status != "CLOSED":
+            return
+        if not self.tac._has_conversation_ended_callback():
             return
 
-        if status == "CLOSED":
-            await self._end_conversation(conv_id)
-        elif status == "INACTIVE" and self.memory_mode == "once":
-            # Invalidate cached memory when conversation becomes inactive
-            # Memory is updated by Conversation Orchestrator on INACTIVE transition
-            async with session.cache_lock:
-                if session.cached_memory is not None:
-                    session.cached_memory = None
-                    self.logger.debug(
-                        "Invalidated cached memory on INACTIVE status",
-                        conversation_id=conv_id,
-                    )
+        participants = await self._list_participants(conv_id)
+        if participants is None:
+            return
+        session = self._session_from_participants(conv_id, participants)
+        if session is None:
+            return
+        await self._trigger_conversation_ended(session)
 
     async def _initiate_messaging_conversation(
         self,
@@ -484,7 +613,10 @@ class MessagingChannel(BaseChannel):
             if not agent:
                 raise RuntimeError("Agent participant not found after conversation creation")
 
-            session = self._start_conversation(conversation_id)
+            session = ConversationSession(
+                conversation_id=conversation_id,
+                channel=channel_type,
+            )
             session.author_info = AuthorInfo(address=options.to, participant_id=customer.id)
             session.ai_agent_info = AuthorInfo(address=from_address, participant_id=agent.id)
             session.metadata.update(
@@ -515,8 +647,6 @@ class MessagingChannel(BaseChannel):
             return InitiateConversationResult(conversation_id=conversation_id, session=session)
 
         except Exception:
-            if conversation_id:
-                self._conversations.pop(conversation_id, None)
             if conversation_id and not reused:
                 try:
                     await self.conversation_orchestrator_client.update_conversation(
@@ -532,7 +662,8 @@ class MessagingChannel(BaseChannel):
 
     async def _reconcile_participants(
         self,
-        conversation_id: str,
+        session: ConversationSession,
+        participants: list[ParticipantResponse],
     ) -> tuple[ParticipantResponse, ParticipantResponse | None] | None:
         """Reconcile Conversation Orchestrator's participants to the types TAC needs for sending.
 
@@ -568,21 +699,14 @@ class MessagingChannel(BaseChannel):
             (`_handle_communication_created`) treats `None` as a hard stop
             and skips the message-ready callback, since any eventual reply
             would fail too.
+
+        Args:
+            session: Supplies the conversation id and agent address to match on.
+            participants: Already fetched by the caller — reusing that response
+                is what makes running this on every message free.
         """
-        agent_address = self.get_agent_address(conversation_id)
-
-        try:
-            participants = await self.conversation_orchestrator_client.list_participants(
-                conversation_id
-            )
-        except Exception as e:
-            self.logger.error(
-                "Failed to list participants for reconciliation",
-                conversation_id=conversation_id,
-                error=str(e),
-            )
-            return None
-
+        conversation_id = session.conversation_id
+        agent_address = self.get_agent_address(session)
         channel = agent_address.channel
 
         def _owns_agent_address(p: ParticipantResponse) -> bool:

--- a/src/tac/channels/rcs.py
+++ b/src/tac/channels/rcs.py
@@ -11,6 +11,7 @@ from tac.models.outbound import (
     InitiateConversationResult,
     InitiateMessagingConversationOptions,
 )
+from tac.models.session import ConversationSession
 
 
 class RCSChannelConfig(MessagingChannelConfig):
@@ -67,7 +68,7 @@ class RCSChannel(MessagingChannel):
             raise RuntimeError("rcs_sender_id is required for RCS channel.")
         return author_address == self.tac.config.rcs_sender_id
 
-    def get_agent_address(self, conversation_id: str) -> ParticipantAddress:
+    def get_agent_address(self, session: ConversationSession) -> ParticipantAddress:
         """Get the agent's participant address for this conversation."""
         if not self.tac.config.rcs_sender_id:
             raise RuntimeError("rcs_sender_id is required for RCS channel.")

--- a/src/tac/channels/sms.py
+++ b/src/tac/channels/sms.py
@@ -11,6 +11,7 @@ from tac.models.outbound import (
     InitiateConversationResult,
     InitiateMessagingConversationOptions,
 )
+from tac.models.session import ConversationSession
 
 
 class SMSChannelConfig(MessagingChannelConfig):
@@ -62,7 +63,7 @@ class SMSChannel(MessagingChannel):
     def is_default_agent_address(self, author_address: str) -> bool:
         return author_address == self.tac.config.phone_number
 
-    def get_agent_address(self, conversation_id: str) -> ParticipantAddress:
+    def get_agent_address(self, session: ConversationSession) -> ParticipantAddress:
         return ParticipantAddress(channel="SMS", address=self.tac.config.phone_number)
 
     async def initiate_outbound_conversation(

--- a/src/tac/channels/voice/__init__.py
+++ b/src/tac/channels/voice/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from tac._deprecation import resolve_deprecated_alias
 from tac.channels.voice.channel import (
     AmdHandler,
+    CallEndedHandler,
     CallStatusHandler,
     InboundCallTwiMLHandler,
     RecordingHandler,
@@ -36,6 +37,7 @@ from tac.models.voice import (
 __all__ = [
     "AmdEvent",
     "AmdHandler",
+    "CallEndedHandler",
     "CallOptions",
     "CallStatusEvent",
     "CallStatusHandler",

--- a/src/tac/channels/voice/channel.py
+++ b/src/tac/channels/voice/channel.py
@@ -14,7 +14,7 @@ from tac.models.outbound import (
     InitiateVoiceConversationOptions,
     InitiateVoiceConversationResult,
 )
-from tac.models.session import ConversationSession
+from tac.models.session import AuthorInfo, ConversationSession
 from tac.models.voice import (
     AmdEvent,
     CallStatusEvent,
@@ -30,6 +30,14 @@ InboundCallTwiMLHandler = Callable[[TwiMLRequest], Awaitable[VoiceTwiMLOptions]]
 CallStatusHandler = Callable[[CallStatusEvent], Awaitable[None]]
 AmdHandler = Callable[[AmdEvent], Awaitable[None]]
 RecordingHandler = Callable[[RecordingEvent], Awaitable[None]]
+CallEndedHandler = Callable[[ConversationSession], Awaitable[None]]
+
+#: Channel name Conversation Orchestrator uses for voice participants. Not
+#: ``get_channel_name()``, which is provider-specific.
+CO_VOICE_CHANNEL = "VOICE"
+
+#: Default seconds :meth:`VoiceChannel.aclose` waits for calls to end.
+DEFAULT_DRAIN_GRACE_PERIOD = 30.0
 
 
 class VoiceChannel(BaseChannel):
@@ -84,12 +92,17 @@ class VoiceChannel(BaseChannel):
             config = ConversationRelayProviderConfig()
 
         super().__init__(tac, memory_mode=config.memory_mode)
+        # Live sessions by conversation id. Instance-local by design: a call
+        # is pinned to the process holding its WebSocket.
+        self._conversations: dict[str, ConversationSession] = {}
         self._provider = config.create_provider(self, tac.config)
         self._on_inbound_call_twiml: InboundCallTwiMLHandler | None = None
         self._on_call_status: CallStatusHandler | None = None
         self._on_amd: AmdHandler | None = None
         self._on_recording: RecordingHandler | None = None
+        self._on_call_ended: CallEndedHandler | None = None
         self._twilio_client: Client | None = None
+        self._accepting_calls = True  # cleared by aclose()
 
     def on_inbound_call_twiml(self, callback: InboundCallTwiMLHandler) -> None:
         """Register a callback that produces per-call overrides for the
@@ -176,6 +189,30 @@ class VoiceChannel(BaseChannel):
             ```
         """
         self._on_recording = callback
+
+    def on_call_ended(self, callback: CallEndedHandler) -> None:
+        """Register a handler for WebSocket teardown.
+
+        Fires once per call, always, on the instance that held the call. It
+        receives the live session just before it is discarded, so it is the
+        only place late-call in-memory state — the transcript, `call_sid`,
+        anything you put on `metadata` — is still reachable.
+
+        Not the same as `on_conversation_ended` (fires when the *conversation*
+        closes, on any instance, from a session that may be rebuilt) or
+        `on_call_status` (a Twilio Calls-API webhook, no session). Handler
+        exceptions are logged and swallowed.
+
+        Example:
+            ```python
+            async def on_call_ended(session: ConversationSession) -> None:
+                await archive(session.call_sid, session.metadata.get("transcript", []))
+
+
+            voice_channel.on_call_ended(on_call_ended)
+            ```
+        """
+        self._on_call_ended = callback
 
     def _get_twilio_client(self) -> Client:
         if self._twilio_client is None:
@@ -342,8 +379,174 @@ class VoiceChannel(BaseChannel):
 
         session = self.get_conversation_session_by_call_sid(call_sid)
         if session is not None:
-            await self._end_conversation(session.conversation_id)
+            await self._release_session(session.conversation_id)
         return hung_up
+
+    def _start_conversation(
+        self,
+        conv_id: str,
+        profile_id: str | None = None,
+    ) -> ConversationSession:
+        """Track a new session for a call, or return the existing one.
+
+        Profile data is fetched lazily during retrieve_memory() when needed.
+        """
+        if conv_id in self._conversations:
+            self.logger.debug(
+                "Conversation already exists, skipping initialization",
+                conversation_id=conv_id,
+                channel=self.get_channel_name(),
+            )
+            return self._conversations[conv_id]
+
+        self._conversations[conv_id] = ConversationSession(
+            conversation_id=conv_id,
+            profile_id=profile_id,
+            channel=self.get_channel_name(),
+        )
+
+        self.logger.info(
+            f"CONVERSATION | Started {self.get_channel_name()} conversation",
+            conversation_id=conv_id,
+            profile_id=profile_id,
+        )
+        return self._conversations[conv_id]
+
+    async def _release_session(self, conv_id: str) -> ConversationSession | None:
+        """Free a finished call's session and fire the end-of-call hooks.
+
+        Called from every teardown path and idempotent, so a second call is a
+        no-op returning ``None``. Always fires ``on_call_ended``; also fires
+        ``on_conversation_ended`` unless a Conversation Orchestrator CLOSED
+        webhook will do that later (see
+        ``VoiceProvider._conversation_closed_by_orchestrator``).
+        """
+        session = self._conversations.pop(conv_id, None)
+        if session is None:
+            return None
+
+        if self._on_call_ended is not None:
+            try:
+                await self._on_call_ended(session)
+            except Exception as e:
+                self.logger.error(
+                    "Error in call ended callback",
+                    conversation_id=conv_id,
+                    error=str(e),
+                    exc_info=True,
+                )
+
+        if not self._provider._conversation_closed_by_orchestrator:
+            await self._trigger_conversation_ended(session)
+
+        self.logger.debug(
+            "Released voice session",
+            conversation_id=conv_id,
+            channel=self.get_channel_name(),
+        )
+        return session
+
+    async def _handle_conversation_closed(self, conv_id: str, call_sid: str | None = None) -> None:
+        """Fire ``on_conversation_ended`` for a CLOSED webhook.
+
+        The session is normally already released (the socket closed when the
+        caller hung up), so the usual path is a rebuild from Conversation
+        Orchestrator — which is also what lets the hook fire on whichever
+        instance received the webhook.
+        """
+        session = self._conversations.pop(conv_id, None)
+        if session is None:
+            if not self.tac._has_conversation_ended_callback():
+                return
+            session = await self._rebuild_session(conv_id, call_sid)
+            if session is None:
+                return
+        await self._trigger_conversation_ended(session)
+
+    async def _rebuild_session(
+        self, conv_id: str, call_sid: str | None = None
+    ) -> ConversationSession | None:
+        """Reconstruct a session from Conversation Orchestrator.
+
+        Carries identity only — conversation id, call_sid, profile, both
+        participants. Live in-memory state (transcript, metadata) is gone by
+        now; use ``on_call_ended`` for that. Returns ``None`` if no
+        participant is on the voice channel, which is how another channel's
+        CLOSED is filtered out.
+        """
+        client = self.tac.conversation_orchestrator_client
+        if client is None:
+            return None
+
+        try:
+            participants = await client.list_participants(conv_id)
+        except Exception as e:
+            self.logger.error(
+                "Failed to list participants while rebuilding a closed voice conversation",
+                conversation_id=conv_id,
+                error=str(e),
+            )
+            return None
+
+        if not any(a.channel == CO_VOICE_CHANNEL for p in participants for a in p.addresses):
+            return None
+
+        customer = next((p for p in participants if p.type == "CUSTOMER"), None)
+        agent = self._find_agent_participant(
+            participants, CO_VOICE_CHANNEL, self.tac.config.phone_number
+        )
+
+        session = ConversationSession(
+            conversation_id=conv_id,
+            call_sid=call_sid,
+            channel=self.get_channel_name(),
+            profile_id=customer.profile_id if customer else None,
+        )
+
+        if customer is not None:
+            customer_address = next(
+                (a.address for a in customer.addresses if a.channel == CO_VOICE_CHANNEL), None
+            )
+            if customer_address:
+                session.author_info = AuthorInfo(
+                    address=customer_address, participant_id=customer.id
+                )
+        if agent is not None:
+            session.ai_agent_info = AuthorInfo(
+                address=next(
+                    (a.address for a in agent.addresses if a.channel == CO_VOICE_CHANNEL),
+                    self.tac.config.phone_number,
+                ),
+                participant_id=agent.id,
+            )
+        return session
+
+    async def aclose(self, *, grace_period: float = DEFAULT_DRAIN_GRACE_PERIOD) -> None:
+        """Drain live calls at shutdown: refuse new ones, wait up to
+        ``grace_period`` seconds for the rest to end, then force-release them.
+
+        Without this a scale-in drops live calls with no callback at all.
+        Fail your readiness probe before calling it, so the load balancer
+        stops routing here first. Idempotent.
+
+        Args:
+            grace_period: Seconds to wait for calls to end on their own.
+        """
+        self._accepting_calls = False
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + max(grace_period, 0.0)
+        while self._conversations and loop.time() < deadline:
+            await asyncio.sleep(0.1)
+
+        remaining = list(self._conversations)
+        if remaining:
+            self.logger.warning(
+                "Draining voice sessions still active at shutdown",
+                count=len(remaining),
+            )
+        for conv_id in remaining:
+            await self._release_session(conv_id)
 
     def get_conversation_session_by_call_sid(self, call_sid: str) -> ConversationSession | None:
         """Look up the active voice session for a Twilio Call SID.
@@ -360,10 +563,11 @@ class VoiceChannel(BaseChannel):
         fires. Either way, treat this as racy and use :meth:`end_call` to hang
         up, which works whether or not a session exists yet.
 
-        At the other end, orchestrator mode keeps the session until Conversation
-        Orchestrator's CLOSED webhook, so it outlives the call and
-        ``on_call_status`` / ``on_recording`` do resolve. Relay-only mode tears
-        down on the provider's out-of-band callback instead, which races them.
+        At the other end the session is released as soon as the call's
+        WebSocket closes, in every mode — so out-of-band events that arrive
+        after the hangup (``on_call_status``, ``on_recording``) generally find
+        nothing here. Read late-call state from the session ``on_call_ended``
+        hands you instead.
 
         Named for ``ConversationSession``; ``session_manager`` deals in
         ``SessionState``, a different type.
@@ -396,9 +600,16 @@ class VoiceChannel(BaseChannel):
         Handle voice streaming WebSocket connection lifecycle. Delegates to
         the active provider.
 
+        Refuses the connection outright once :meth:`aclose` has been called —
+        a draining instance must not adopt a call it is about to drop.
+
         Args:
             websocket: Any WebSocket implementation satisfying WebSocketProtocol
         """
+        if not self._accepting_calls:
+            self.logger.warning("Refusing voice WebSocket: channel is draining for shutdown")
+            await websocket.close()
+            return
         await self._provider.handle_websocket(websocket)
 
     async def initiate_outbound_conversation(
@@ -418,13 +629,15 @@ class VoiceChannel(BaseChannel):
         """Process conversation webhooks for cleanup and cache invalidation.
 
         Voice channel processes CONVERSATION_UPDATED events:
-        - CLOSED status: Clean up local session state
-        - INACTIVE status: Invalidate cached memory (memory will be updated by
-          Conversation Orchestrator)
 
-        Note: Conversation tracking uses instance-local memory. In multi-instance
-        deployments, webhooks may route to a different instance, preventing cleanup.
-        See CLAUDE.md for horizontal scaling considerations.
+        - **CLOSED**: fire ``on_conversation_ended``. The call's session is
+          normally already released (the WebSocket closed when the caller hung
+          up), so this rebuilds it from Conversation Orchestrator — which is
+          also what makes the hook fire on whichever instance received the
+          webhook rather than only on the one that held the call.
+        - **INACTIVE**: invalidate cached memory, if this instance holds the
+          session. A call is pinned to one instance for its lifetime, so an
+          INACTIVE landing elsewhere has no cache to clear and is ignored.
 
         Args:
             webhook_data: Raw webhook event data from Twilio
@@ -447,29 +660,37 @@ class VoiceChannel(BaseChannel):
             )
             return
 
-        if event_type == "CONVERSATION_UPDATED":
-            conv_id = event_data.get("id")
-            status = event_data.get("status")
+        if event_type != "CONVERSATION_UPDATED":
+            return
 
-            if not conv_id:
+        conv_id = event_data.get("id")
+        status = event_data.get("status")
+        if not conv_id:
+            return
+
+        if event_data.get("configurationId") != self.tac.config.conversation_configuration_id:
+            return
+
+        if status == "CLOSED":
+            if not self._provider._conversation_closed_by_orchestrator:
+                # This provider has no Conversation Orchestrator conversation
+                # behind its calls; on_conversation_ended already fired at
+                # teardown and firing again here would double it.
                 return
-
+            await self._handle_conversation_closed(conv_id, event_data.get("channelId"))
+        elif status == "INACTIVE" and self.memory_mode == "once":
             session = self._conversations.get(conv_id)
-            if not session or session.channel != self.get_channel_name():
+            if session is None:
                 return
-
-            if status == "CLOSED":
-                await self._end_conversation(conv_id)
-            elif status == "INACTIVE" and self.memory_mode == "once":
-                # Invalidate cached memory when conversation becomes inactive
-                # Memory is updated by Conversation Orchestrator on INACTIVE transition
-                async with session.cache_lock:
-                    if session.cached_memory is not None:
-                        session.cached_memory = None
-                        self.logger.debug(
-                            "Invalidated cached memory on INACTIVE status",
-                            conversation_id=conv_id,
-                        )
+            # Memory is updated by Conversation Orchestrator on the INACTIVE
+            # transition, so the cached copy is stale from here on.
+            async with session.cache_lock:
+                if session.cached_memory is not None:
+                    session.cached_memory = None
+                    self.logger.debug(
+                        "Invalidated cached memory on INACTIVE status",
+                        conversation_id=conv_id,
+                    )
 
     async def send_response(
         self,

--- a/src/tac/channels/voice/conversation_relay/provider.py
+++ b/src/tac/channels/voice/conversation_relay/provider.py
@@ -72,6 +72,13 @@ class ConversationRelayProvider(VoiceProvider):
     def channel_name(self) -> str:
         return "VOICE"
 
+    @property
+    def _conversation_closed_by_orchestrator(self) -> bool:
+        # ConversationRelay asks Conversation Orchestrator to create the
+        # conversation whenever TAC is orchestrated; in relay-only mode there
+        # is no CO conversation and nothing will ever close it for us.
+        return self.channel.tac.is_orchestrator_enabled()
+
     @staticmethod
     def _caller_address(setup_msg: SetupMessage) -> str | None:
         """Return the phone number of the remote caller/callee from the setup message."""
@@ -200,8 +207,9 @@ class ConversationRelayProvider(VoiceProvider):
         )
 
         if payload.call_status == "completed" and not self.channel.tac.is_orchestrator_enabled():
-            if payload.call_sid in self.channel._conversations:
-                await self.channel._end_conversation(payload.call_sid)
+            # Relay-only: conv_id == call_sid. No-ops when the WebSocket
+            # teardown already released the session, which is the usual case.
+            await self.channel._release_session(payload.call_sid)
 
     async def _initialize_conversation(
         self,
@@ -824,12 +832,13 @@ class ConversationRelayProvider(VoiceProvider):
 
     async def _cleanup_connection(self, conv_id: str) -> None:
         """
-        Clean up WebSocket and session resources when connection closes.
+        Clean up WebSocket and session resources when the connection closes.
 
-        In orchestrated mode, the conversation remains tracked in
-        self.channel._conversations until the CONVERSATION_UPDATED/CLOSED webhook
-        arrives from Conversation Orchestrator. In relay-only mode there is no such webhook,
-        so we also end the conversation here.
+        Runs unconditionally — the call is over in every mode once its socket
+        is gone, so nothing local is kept waiting for a Conversation
+        Orchestrator webhook that may land on a different instance.
+        ``_release_session`` fires ``on_call_ended`` here and defers
+        ``on_conversation_ended`` to CO's CLOSED webhook when orchestrated.
 
         Args:
             conv_id: Conversation ID
@@ -845,11 +854,7 @@ class ConversationRelayProvider(VoiceProvider):
             await session_state.cancel_stream_task()
             self.session_manager.remove_session(conv_id)
 
-        if (
-            not self.channel.tac.is_orchestrator_enabled()
-            and conv_id in self.channel._conversations
-        ):
-            await self.channel._end_conversation(conv_id)
+        await self.channel._release_session(conv_id)
 
         self.logger.debug(
             "Cleaned up WebSocket and session resources",

--- a/src/tac/channels/voice/conversation_relay/twiml.py
+++ b/src/tac/channels/voice/conversation_relay/twiml.py
@@ -320,10 +320,9 @@ class TwiMLBuilderConversationRelay(TwiMLBuilderBase):
                 self.tac_config.account_sid,
                 self.tac_config.studio_handoff_flow_sid,
             )
-        # Channel default. None if voice_public_domain isn't set; that's fine
+        # Channel default. None if no public domain is set; that's fine
         # because every layer above this one is already exhausted.
-        if self.tac_config.voice_public_domain:
-            return (
-                f"https://{self.tac_config.voice_public_domain}{self.tac_config.voice_action_path}"
-            )
+        domain = self.tac_config.voice_callback_domain
+        if domain:
+            return f"https://{domain}{self.tac_config.voice_action_path}"
         return None

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -35,6 +35,7 @@ from tac.models.session import ConversationSession
 from tac.models.stream import StreamStartMessage
 from tac.models.voice import TwiMLRequest, VoiceTwiMLOptions, VoiceTwiMLOptionsMediaStreams
 from tac.tools import TACTool
+from tac.utils.expiring_dict import ExpiringDict
 from tac.utils.redaction import mask_phone, redact_twiml_parameters
 
 if TYPE_CHECKING:
@@ -57,11 +58,11 @@ TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu"}
 #: this constant alone, regardless of session_config.
 _PCMU_BYTES_PER_MS = 8
 
-#: Reserved <Stream> custom_parameters key used to correlate an outbound
-#: call's session_config override to its WebSocket start event. calls.create()
-#: returning call.sid doesn't happen-before Twilio connecting the stream, so
-#: call.sid can't be the correlation key — this token, embedded in the TwiML
-#: before the call is placed, can.
+#: Reserved <Stream> custom_parameters key correlating a call's session_config
+#: override to its WebSocket start event. CallSid can't be the key: outbound,
+#: calls.create() returning it doesn't happen-before Twilio connecting the
+#: stream; inbound, the TwiML request and the stream can reach different
+#: replicas, so the config has to travel on the TwiML.
 _SESSION_CONFIG_TOKEN_PARAM = "_tac_session_config_token"
 
 
@@ -87,8 +88,10 @@ class OpenAIRealtimeProvider(VoiceProvider):
         self._tools_by_name: dict[str, TACTool] = {tool.name: tool for tool in config.tools}
         self._calls: dict[str, _CallState] = {}
         self._twiml = TwiMLBuilderMediaStreams(tac_config, config)
-        # Keyed by call_sid; set in handle_incoming_call, popped in _connect_model.
-        self._call_session_configs: dict[str, dict[str, Any]] = {}
+        # Per-call session config, minted by one Twilio request and consumed
+        # when the call's WebSocket connects. Bounded and expiring so a call
+        # that never connects doesn't leave its entry here forever.
+        self._call_session_configs: ExpiringDict[dict[str, Any]] = ExpiringDict()
 
     @property
     def channel_name(self) -> str:
@@ -98,9 +101,9 @@ class OpenAIRealtimeProvider(VoiceProvider):
         """Return the transcript captured so far for an in-progress call.
 
         Lives on ``ConversationSession.metadata["transcript"]``, so once the
-        call ends (and the session is popped from ``channel._conversations``)
-        it's no longer reachable here — read it from the session an
-        ``on_conversation_ended`` handler receives instead.
+        call ends (and the session is released at WebSocket teardown) it's no
+        longer reachable here — read it from the session a
+        ``VoiceChannel.on_call_ended`` handler receives instead.
         """
         session = self.channel._conversations.get(conversation_id)
         return list(session.metadata.get("transcript", [])) if session else []
@@ -148,14 +151,22 @@ class OpenAIRealtimeProvider(VoiceProvider):
                 )
             customized = result
 
-        if (
-            self.config.on_inbound_call_session_config is not None
-            and twiml_request is not None
-            and twiml_request.call_sid is not None
-        ):
+        session_config: dict[str, Any] | None = None
+        if self.config.on_inbound_call_session_config is not None and twiml_request is not None:
             session_config = await self.config.on_inbound_call_session_config(twiml_request)
-            if session_config is not None:
-                self._call_session_configs[twiml_request.call_sid] = session_config
+
+        if session_config is not None:
+            # Ride the config out on the TwiML under a token, as outbound
+            # does, so it travels with the call rather than being stranded on
+            # whichever replica served this HTTP request.
+            token = uuid.uuid4().hex
+            existing_params = (customized.custom_parameters or {}) if customized else {}
+            customized = (customized or VoiceTwiMLOptionsMediaStreams()).model_copy(
+                update={
+                    "custom_parameters": {**existing_params, _SESSION_CONFIG_TOKEN_PARAM: token}
+                }
+            )
+            self._call_session_configs[token] = session_config
 
         return self._twiml.build(
             "handle_incoming_call", host=host_twiml_options, per_call=customized
@@ -654,7 +665,10 @@ class OpenAIRealtimeProvider(VoiceProvider):
                 await call.model_ws.close()
             except Exception as e:
                 self.logger.debug(f"Error closing model socket: {e}", conversation_id=conv_id)
-        await self.channel._end_conversation(conv_id)
+        # Drop any session config that was stashed for this call but never
+        # consumed (_connect_model raised, or the stream stopped before it ran).
+        self._call_session_configs.pop(conv_id, None)
+        await self.channel._release_session(conv_id)
 
     async def send_response(
         self,

--- a/src/tac/channels/voice/provider.py
+++ b/src/tac/channels/voice/provider.py
@@ -42,6 +42,18 @@ class VoiceProvider:
         """
         return "VOICE"
 
+    @property
+    def _conversation_closed_by_orchestrator(self) -> bool:
+        """Whether a Conversation Orchestrator ``CLOSED`` webhook will end this
+        provider's conversations.
+
+        Decides who owns ``on_conversation_ended``. ``False`` (the default):
+        no CO conversation exists, so ``VoiceChannel`` fires it itself at
+        teardown. ``True``: only ``on_call_ended`` fires at teardown and the
+        CLOSED webhook — which may reach another instance — does the rest.
+        """
+        return False
+
     async def handle_incoming_call(
         self,
         twiml_request: TwiMLRequest | None = None,

--- a/src/tac/channels/voice/twiml.py
+++ b/src/tac/channels/voice/twiml.py
@@ -33,6 +33,13 @@ class TwiMLBuilderBase:
         )
 
     def _default_websocket_url(self) -> str | None:
-        if not self.tac_config.voice_public_domain:
+        """The WebSocket URL derived from config.
+
+        Uses `voice_callback_domain`, so a deployment that sets
+        `instance_public_domain` pins the call to this process from its very
+        first connection.
+        """
+        domain = self.tac_config.voice_callback_domain
+        if not domain:
             return None
-        return f"wss://{self.tac_config.voice_public_domain}{self.tac_config.voice_websocket_path}"
+        return f"wss://{domain}{self.tac_config.voice_websocket_path}"

--- a/src/tac/channels/whatsapp.py
+++ b/src/tac/channels/whatsapp.py
@@ -11,6 +11,7 @@ from tac.models.outbound import (
     InitiateConversationResult,
     InitiateMessagingConversationOptions,
 )
+from tac.models.session import ConversationSession
 
 
 class WhatsAppChannelConfig(MessagingChannelConfig):
@@ -68,7 +69,7 @@ class WhatsAppChannel(MessagingChannel):
             raise RuntimeError("whatsapp_number is required for WhatsApp channel.")
         return author_address == self.tac.config.whatsapp_number
 
-    def get_agent_address(self, conversation_id: str) -> ParticipantAddress:
+    def get_agent_address(self, session: ConversationSession) -> ParticipantAddress:
         """Get the agent's participant address for this conversation."""
         if not self.tac.config.whatsapp_number:
             raise RuntimeError("whatsapp_number is required for WhatsApp channel.")

--- a/src/tac/core/config.py
+++ b/src/tac/core/config.py
@@ -103,6 +103,14 @@ class TwilioMemoryConfig(BaseModel):
         description="Min relevance score for observations and summaries (0.0-1.0).",
     )
 
+    fetch_profile_traits: bool = Field(
+        default=True,
+        description="Whether to fetch profile traits alongside a recall. Recall returns "
+        "observations, summaries and communications but never traits, so this is a second "
+        "API call. Traits populate `ConversationSession.profile`, which is what "
+        "`build_profile_prompt()` renders — set False if your prompts don't use them.",
+    )
+
     phone_trait_group: str = Field(
         default="Contact",
         description="Trait group name that holds the phone identifier on newly created profiles. "
@@ -292,6 +300,17 @@ class TACConfig(BaseModel):
         "are stripped automatically.",
     )
 
+    instance_public_domain: str | None = Field(
+        default=None,
+        description="Directly-routable host for *this process* (e.g. a Kubernetes pod's own "
+        "address). When set, every URL TAC hands Twilio for a live call — WebSocket, action "
+        "callback, status/AMD/recording — points here instead of at `voice_public_domain`, so "
+        "a call's out-of-band webhooks return to the process holding its socket. Requires "
+        "per-pod addressability; without it, leave this unset and route by `CallSid` at the "
+        "load balancer. Schemes and trailing slashes are stripped, same as "
+        "`voice_public_domain`.",
+    )
+
     voice_websocket_path: str = Field(
         default="/ws",
         description="Path the voice WebSocket is served at. Combined with "
@@ -316,6 +335,14 @@ class TACConfig(BaseModel):
         "event. Same role as voice_action_path.",
     )
 
+    @property
+    def voice_callback_domain(self) -> str | None:
+        """Host Twilio should reach for a call in progress.
+
+        `instance_public_domain` if set, else the shared `voice_public_domain`.
+        """
+        return self.instance_public_domain or self.voice_public_domain
+
     def call_event_path(self, kind: CallEventKind) -> str:
         """Path a call-event callback is served at.
 
@@ -326,14 +353,15 @@ class TACConfig(BaseModel):
 
     def call_event_url(self, kind: CallEventKind) -> str | None:
         """Public URL for a call-event callback, or None without a public domain."""
-        if not self.voice_public_domain:
+        domain = self.voice_callback_domain
+        if not domain:
             return None
-        return f"https://{self.voice_public_domain}{self.call_event_path(kind)}"
+        return f"https://{domain}{self.call_event_path(kind)}"
 
-    @field_validator("voice_public_domain", mode="before")
+    @field_validator("voice_public_domain", "instance_public_domain", mode="before")
     @classmethod
     def _normalize_voice_public_domain(cls, v: str | None) -> str | None:
-        """Strip whitespace, schemes, and trailing slashes from voice_public_domain.
+        """Strip whitespace, schemes, and trailing slashes from a public domain.
 
         A naive copy-paste from a browser address bar produces values like
         ``https://example.ngrok.app/`` which would otherwise concatenate into
@@ -406,6 +434,8 @@ class TACConfig(BaseModel):
         - `TWILIO_REGION`: Twilio region for data residency (e.g., 'au1', 'ie1')
         - `TWILIO_STUDIO_HANDOFF_FLOW_SID`: Studio Flow SID (FWxxx...) for handoff tool
         - `TWILIO_VOICE_PUBLIC_DOMAIN`: Public domain for voice routes (required for voice)
+        - `TWILIO_INSTANCE_PUBLIC_DOMAIN`: This process's own directly-routable host, for
+          pinning a call's out-of-band webhooks to the instance holding its WebSocket
         - `TWILIO_VOICE_WEBSOCKET_PATH`: Path for voice WebSocket (default: /ws)
         - `TWILIO_VOICE_ACTION_PATH`: Path for ConversationRelay action callback
           (default: /conversation-relay-callback)
@@ -448,6 +478,7 @@ class TACConfig(BaseModel):
             region=os.environ.get("TWILIO_REGION"),
             studio_handoff_flow_sid=os.environ.get("TWILIO_STUDIO_HANDOFF_FLOW_SID"),
             voice_public_domain=os.environ.get("TWILIO_VOICE_PUBLIC_DOMAIN"),
+            instance_public_domain=os.environ.get("TWILIO_INSTANCE_PUBLIC_DOMAIN"),
             voice_websocket_path=os.environ.get("TWILIO_VOICE_WEBSOCKET_PATH", "/ws"),
             voice_action_path=os.environ.get(
                 "TWILIO_VOICE_ACTION_PATH", "/conversation-relay-callback"

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -134,6 +134,14 @@ class TAC:
         """True if TAC is configured with Conversation Orchestrator (not relay-only mode)."""
         return self.conversation_orchestrator_client is not None
 
+    def _has_conversation_ended_callback(self) -> bool:
+        """Whether an ``on_conversation_ended`` handler is registered.
+
+        Channels check this before rebuilding a session from Conversation
+        Orchestrator: with no handler, there is nothing to hand it to.
+        """
+        return self._conversation_ended_callback is not None
+
     async def retrieve_memory(
         self,
         conversation_context: ConversationSession,
@@ -197,7 +205,11 @@ class TAC:
                     )
                     raise ValueError("No profile_id or author_info available")
 
-            if conversation_context.profile_id and not conversation_context.profile:
+            if (
+                self.config.memory_config.fetch_profile_traits
+                and conversation_context.profile_id
+                and not conversation_context.profile
+            ):
                 try:
                     profile_response = await self.conversation_memory_client.get_profile(
                         profile_id=conversation_context.profile_id,

--- a/src/tac/server/config.py
+++ b/src/tac/server/config.py
@@ -26,6 +26,13 @@ class TACServerConfig(BaseModel):
         description="Path for Conversation Intelligence webhook endpoint. "
         "Set to enable CI webhook route (e.g., '/ci-webhook').",
     )
+    shutdown_grace_period: float = Field(
+        default=30.0,
+        ge=0,
+        description="Seconds to wait on shutdown for live voice calls to end before "
+        "force-releasing their sessions (see `VoiceChannel.aclose`). Keep it below your "
+        "orchestrator's termination grace period, or the process is killed mid-drain.",
+    )
 
     @classmethod
     def from_env(cls) -> "TACServerConfig":

--- a/src/tac/server/fastapi_server.py
+++ b/src/tac/server/fastapi_server.py
@@ -131,6 +131,20 @@ class TACFastAPIServer:
 
         self.app: FastAPI = app if app is not None else FastAPI(title="TAC Server")
         self._register_routes(self.app)
+        # Via the router: FastAPI doesn't re-export Starlette's
+        # add_event_handler in its own type surface.
+        self.app.router.add_event_handler("shutdown", self.aclose)
+
+    async def aclose(self) -> None:
+        """Drain live voice calls so shutdown doesn't drop them silently.
+
+        Registered on the app's ``shutdown`` event, so uvicorn runs it for
+        you. Starlette ignores event handlers on an app constructed with its
+        own ``lifespan=`` — if you passed one via ``app=``, await this in your
+        lifespan's shutdown half. See :meth:`VoiceChannel.aclose`.
+        """
+        if self.voice_channel is not None:
+            await self.voice_channel.aclose(grace_period=self.config.shutdown_grace_period)
 
     def _validate_voice_url_config(self) -> None:
         """Fail fast at server construction on voice URL misconfiguration.
@@ -145,10 +159,12 @@ class TACFastAPIServer:
         can't know what URL plumbing they're doing outside this server.
         """
         assert self.voice_channel is not None  # checked by caller
-        if not self.tac.config.voice_public_domain:
+        if not self.tac.config.voice_callback_domain:
             raise ValueError(
                 "Voice channel is configured but TACConfig.voice_public_domain is "
-                "not set. Set it directly or via the TWILIO_VOICE_PUBLIC_DOMAIN env var."
+                "not set. Set it directly or via the TWILIO_VOICE_PUBLIC_DOMAIN env var. "
+                "(TACConfig.instance_public_domain also satisfies this, if each replica "
+                "is directly addressable.)"
             )
         self._validate_call_event_paths()
 

--- a/src/tac/utils/expiring_dict.py
+++ b/src/tac/utils/expiring_dict.py
@@ -1,0 +1,88 @@
+"""A small bounded, time-expiring mapping for short-lived cross-request state."""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from typing import Generic, TypeVar
+
+_V = TypeVar("_V")
+
+#: Default entry lifetime. Sized for the gap between one Twilio request
+#: minting a value and the call's WebSocket connecting.
+DEFAULT_TTL_SECONDS = 900.0
+
+#: Default cap on live entries.
+DEFAULT_MAX_ENTRIES = 1000
+
+
+class ExpiringDict(Generic[_V]):
+    """A string-keyed mapping whose entries expire and whose size is bounded.
+
+    For state one Twilio request creates and a later one for the same call
+    consumes. Normally popped within seconds — but a call that is never
+    answered, or whose second request lands on another instance, leaves an
+    entry nobody will collect. The TTL and cap make that leak impossible
+    rather than unlikely.
+
+    Not thread-safe; single-event-loop use.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+    ) -> None:
+        if ttl_seconds <= 0:
+            raise ValueError(f"ttl_seconds must be positive, got {ttl_seconds}")
+        if max_entries <= 0:
+            raise ValueError(f"max_entries must be positive, got {max_entries}")
+        self._ttl = ttl_seconds
+        self._max_entries = max_entries
+        # Insertion-ordered, so the oldest entries are also the first to expire.
+        self._entries: OrderedDict[str, tuple[float, _V]] = OrderedDict()
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def _purge(self) -> None:
+        """Drop expired entries, then the oldest survivors if still over capacity."""
+        now = self._now()
+        while self._entries:
+            _key, (expires_at, _value) = next(iter(self._entries.items()))
+            if expires_at > now:
+                break
+            self._entries.popitem(last=False)
+        while len(self._entries) > self._max_entries:
+            self._entries.popitem(last=False)
+
+    def __setitem__(self, key: str, value: _V) -> None:
+        self._entries.pop(key, None)
+        self._entries[key] = (self._now() + self._ttl, value)
+        self._purge()
+
+    def __getitem__(self, key: str) -> _V:
+        entry = self._entries.get(key)
+        if entry is None or entry[0] <= self._now():
+            raise KeyError(key)
+        return entry[1]
+
+    def pop(self, key: str, default: _V | None = None) -> _V | None:
+        entry = self._entries.pop(key, None)
+        if entry is None:
+            return default
+        expires_at, value = entry
+        if expires_at <= self._now():
+            return default
+        return value
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        entry = self._entries.get(key)
+        return entry is not None and entry[0] > self._now()
+
+    def __len__(self) -> int:
+        self._purge()
+        return len(self._entries)

--- a/tests/test_chat_channel.py
+++ b/tests/test_chat_channel.py
@@ -158,7 +158,10 @@ class TestChatChannel:
         tac = TAC(get_test_config())
         channel = ChatChannel(tac)
 
-        tac.on_message_ready(lambda msg, ctx, mem: None)
+        from tac.models.conversation import ParticipantAddress, ParticipantResponse
+
+        captured: list[ConversationSession] = []
+        tac.on_message_ready(lambda msg, ctx, mem: captured.append(ctx))
 
         webhook = create_communication_created_webhook(
             "CH123",
@@ -167,10 +170,27 @@ class TestChatChannel:
             "2025-11-18T00:00:00.000Z",
             channel_id="CH_CHAT_SID_456",
         )
-        await channel.process_webhook(webhook)
+        agent = ParticipantResponse(
+            id="PA_AGENT",
+            account_id="ACtest123",
+            conversation_id="CH123",
+            name="Test Agent",
+            type="AI_AGENT",
+            addresses=[
+                ParticipantAddress(
+                    channel="CHAT", address="ai-assistant", channel_id="CH_CHAT_SID_456"
+                )
+            ],
+        )
+        with patch.object(
+            tac.conversation_orchestrator_client,
+            "list_participants",
+            new=AsyncMock(return_value=[agent]),
+        ):
+            await channel.process_webhook(webhook)
 
-        session = channel._conversations["CH123"]
-        assert session.metadata["channel_id"] == "CH_CHAT_SID_456"
+        assert len(captured) == 1
+        assert captured[0].metadata["channel_id"] == "CH_CHAT_SID_456"
 
     @pytest.mark.asyncio
     async def test_ignores_sms_messages(self) -> None:
@@ -228,17 +248,18 @@ class TestChatChannel:
 
     @pytest.mark.asyncio
     async def test_process_conversation_ended(self) -> None:
+        """No handler registered → fast exit with no rebuild."""
         tac = TAC(get_test_config())
         channel = ChatChannel(tac)
 
-        channel._conversations["CH123"] = ConversationSession(
-            conversation_id="CH123", channel="CHAT", profile_id="profile_123"
-        )
+        with patch.object(
+            tac.conversation_orchestrator_client, "list_participants", new=AsyncMock()
+        ) as mock_list:
+            await channel.process_webhook(
+                create_conversation_updated_webhook("CH123", "CLOSED", "2025-11-18T00:10:00.000Z")
+            )
 
-        await channel.process_webhook(
-            create_conversation_updated_webhook("CH123", "CLOSED", "2025-11-18T00:10:00.000Z")
-        )
-        assert "CH123" not in channel._conversations
+        mock_list.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_conversation_ended_callback(self) -> None:
@@ -248,16 +269,30 @@ class TestChatChannel:
 
         tac.on_conversation_ended(lambda ctx: captured.append(ctx))
 
-        channel._conversations["CH123"] = ConversationSession(
-            conversation_id="CH123", channel="CHAT", profile_id="profile_123"
+        from tac.models.conversation import ParticipantAddress, ParticipantResponse
+
+        customer = ParticipantResponse(
+            id="PA_USER",
+            account_id="ACtest123",
+            conversation_id="CH123",
+            name="user@example.com",
+            type="CUSTOMER",
+            profile_id="profile_123",
+            addresses=[ParticipantAddress(channel="CHAT", address="user@example.com")],
         )
-        await channel.process_webhook(
-            create_conversation_updated_webhook("CH123", "CLOSED", "2025-11-18T00:10:00.000Z")
-        )
+        with patch.object(
+            tac.conversation_orchestrator_client,
+            "list_participants",
+            new=AsyncMock(return_value=[customer]),
+        ):
+            await channel.process_webhook(
+                create_conversation_updated_webhook("CH123", "CLOSED", "2025-11-18T00:10:00.000Z")
+            )
 
         assert len(captured) == 1
         assert captured[0].conversation_id == "CH123"
         assert captured[0].channel == "CHAT"
+        assert captured[0].profile_id == "profile_123"
 
     @pytest.mark.asyncio
     async def test_send_response_uses_stashed_ids(self) -> None:
@@ -265,8 +300,8 @@ class TestChatChannel:
         tac = TAC(get_test_config())
         channel = ChatChannel(tac)
 
-        # Session is pre-populated as if reconcile (or outbound initiation) ran.
-        channel._conversations["CH123"] = ConversationSession(
+        # Session shaped the way an inbound webhook (or outbound initiation) leaves it.
+        session = ConversationSession(
             conversation_id="CH123",
             channel="CHAT",
             author_info=AuthorInfo(address="user@example.com", participant_id="PA_USER"),
@@ -275,7 +310,7 @@ class TestChatChannel:
         )
 
         with patch.object(tac.conversation_orchestrator_client, "create_action") as mock_send:
-            await channel.send_response("CH123", "Hello from bot!")
+            await channel.send_response(session, "Hello from bot!")
 
             mock_send.assert_called_once()
             call_args = mock_send.call_args
@@ -293,11 +328,47 @@ class TestChatChannel:
             assert request.payload.channel_settings.channel_id == "CH_CHAT_SID_123"
 
     @pytest.mark.asyncio
-    async def test_send_response_no_session(self) -> None:
-        """Missing session → send_response raises (no conversation to reply to)."""
+    async def test_send_response_by_id_rebuilds_from_participants(self) -> None:
+        """The bare-id form works, at the cost of one participant lookup."""
+        from tac.models.conversation import ParticipantAddress, ParticipantResponse
+
         tac = TAC(get_test_config())
         channel = ChatChannel(tac)
-        with pytest.raises(RuntimeError, match="without a reconciled session"):
+
+        customer = ParticipantResponse(
+            id="PA_USER",
+            account_id="ACtest123",
+            conversation_id="CH999",
+            name="user@example.com",
+            type="CUSTOMER",
+            addresses=[ParticipantAddress(channel="CHAT", address="user@example.com")],
+        )
+        with (
+            patch.object(
+                tac.conversation_orchestrator_client,
+                "list_participants",
+                new=AsyncMock(return_value=[customer]),
+            ),
+            patch.object(tac.conversation_orchestrator_client, "create_action") as mock_send,
+        ):
+            # CHAT still needs channelId, which only a session carries.
+            with pytest.raises(RuntimeError, match=r"channel_id"):
+                await channel.send_response("CH999", "Hello!")
+            mock_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_response_no_recipient(self) -> None:
+        """No customer participant → nothing to reply to."""
+        tac = TAC(get_test_config())
+        channel = ChatChannel(tac)
+        with (
+            patch.object(
+                tac.conversation_orchestrator_client,
+                "list_participants",
+                new=AsyncMock(return_value=[]),
+            ),
+            pytest.raises(RuntimeError, match="no recipient resolved"),
+        ):
             await channel.send_response("CH999", "Hello!")
 
     @pytest.mark.asyncio
@@ -306,7 +377,7 @@ class TestChatChannel:
         tac = TAC(get_test_config())
         channel = ChatChannel(tac)
 
-        channel._conversations["CH123"] = ConversationSession(
+        session = ConversationSession(
             conversation_id="CH123",
             channel="CHAT",
             author_info=AuthorInfo(address="user@example.com", participant_id="PA_USER"),
@@ -316,28 +387,33 @@ class TestChatChannel:
 
         with patch.object(tac.conversation_orchestrator_client, "create_action") as mock_send:
             with pytest.raises(RuntimeError, match=r"session\.metadata\['channel_id'\]"):
-                await channel.send_response("CH123", "Hello!")
+                await channel.send_response(session, "Hello!")
             mock_send.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_send_response_raises_when_missing_ai_agent_info(self) -> None:
-        """If author_info is stashed but ai_agent_info is not (reconcile failed),
-        send_response raises — it will not invent ids."""
+    async def test_send_response_falls_back_to_the_configured_agent_address(self) -> None:
+        """No agent participant id on the session → address-mode `from`.
+
+        Conversation Orchestrator resolves a `from` by explicit
+        (channel, address) too, so a session that never got an agent
+        participant id can still reply.
+        """
         tac = TAC(get_test_config())
         channel = ChatChannel(tac)
 
-        channel._conversations["CH123"] = ConversationSession(
+        session = ConversationSession(
             conversation_id="CH123",
             channel="CHAT",
             author_info=AuthorInfo(address="user@example.com", participant_id="PA_USER"),
-            # ai_agent_info is intentionally missing
             metadata={"channel_id": "CH_CHAT_SID_123"},
         )
 
         with patch.object(tac.conversation_orchestrator_client, "create_action") as mock_send:
-            with pytest.raises(RuntimeError, match="without a reconciled session"):
-                await channel.send_response("CH123", "Hello!")
-            mock_send.assert_not_called()
+            await channel.send_response(session, "Hello!")
+
+        request = mock_send.call_args[0][1]
+        assert request.payload.from_.participant_id is None
+        assert request.payload.from_.address == "ai-assistant"
 
     @pytest.mark.asyncio
     async def test_send_response_rejects_non_string(self) -> None:
@@ -401,7 +477,6 @@ class TestChatChannel:
         await channel.process_webhook({"eventType": "COMMUNICATION_CREATED", "data": None})
 
         assert len(captured) == 0
-        assert len(channel._conversations) == 0
 
     @pytest.mark.asyncio
     async def test_memory_mode(self) -> None:
@@ -416,11 +491,6 @@ class TestChatChannel:
         )
         channel = ChatChannel(tac, config={"memory_mode": "always"})
 
-        # Pre-seed session with profile_id so retrieve_memory skips the
-        # lookup_profile fallback path.
-        channel._conversations["CH123"] = ConversationSession(
-            conversation_id="CH123", channel="CHAT", profile_id="profile_test_123"
-        )
         tac.conversation_memory_client.get_profile = AsyncMock(
             side_effect=Exception("skip profile")
         )
@@ -453,17 +523,40 @@ class TestChatChannel:
             }
         )
 
+        # Chat identities are opaque strings, so Memory's address-based
+        # lookup can't find the profile — it has to come off the participant.
+        author = ParticipantResponse(
+            id="PA_USER",
+            account_id="ACtest123",
+            conversation_id="CH123",
+            name="user@example.com",
+            type="CUSTOMER",
+            profile_id="profile_test_123",
+            addresses=[ParticipantAddress(channel="CHAT", address="user@example.com")],
+        )
+
         webhook = create_communication_created_webhook(
             "CH123", "PA_USER", "Memory test", "2025-11-18T00:00:02.000Z"
         )
-        with patch.object(
-            channel,
-            "_reconcile_participants",
-            new=AsyncMock(return_value=(mock_agent, None)),
+        with (
+            patch.object(
+                tac.conversation_orchestrator_client,
+                "list_participants",
+                new=AsyncMock(return_value=[mock_agent, author]),
+            ),
+            patch.object(
+                channel,
+                "_reconcile_participants",
+                new=AsyncMock(return_value=(mock_agent, None)),
+            ),
         ):
             await channel.process_webhook(webhook)
 
         tac.conversation_memory_client.retrieve_memory.assert_called_once()
+        assert (
+            tac.conversation_memory_client.retrieve_memory.call_args.kwargs["profile_id"]
+            == "profile_test_123"
+        )
 
     @pytest.mark.asyncio
     async def test_callback_auto_send_response(self) -> None:

--- a/tests/test_expiring_dict.py
+++ b/tests/test_expiring_dict.py
@@ -1,0 +1,98 @@
+"""Tests for ExpiringDict — the bound that keeps cross-request state from leaking."""
+
+import pytest
+
+from tac.utils.expiring_dict import ExpiringDict
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def make_dict(clock: FakeClock, **kwargs: float | int) -> ExpiringDict[str]:
+    d: ExpiringDict[str] = ExpiringDict(**kwargs)  # type: ignore[arg-type]
+    d._now = lambda: clock.now  # type: ignore[method-assign]
+    return d
+
+
+class TestBasics:
+    def test_set_get_pop(self) -> None:
+        d: ExpiringDict[str] = ExpiringDict()
+        d["a"] = "one"
+
+        assert "a" in d
+        assert d["a"] == "one"
+        assert d.pop("a") == "one"
+        assert "a" not in d
+        assert d.pop("a") is None
+        assert d.pop("a", "fallback") == "fallback"
+
+    def test_getitem_raises_for_missing_key(self) -> None:
+        d: ExpiringDict[str] = ExpiringDict()
+        with pytest.raises(KeyError):
+            d["nope"]
+
+    def test_reassigning_a_key_keeps_one_entry(self) -> None:
+        d: ExpiringDict[str] = ExpiringDict()
+        d["a"] = "one"
+        d["a"] = "two"
+
+        assert len(d) == 1
+        assert d.pop("a") == "two"
+
+    def test_rejects_nonsense_construction(self) -> None:
+        with pytest.raises(ValueError):
+            ExpiringDict(ttl_seconds=0)
+        with pytest.raises(ValueError):
+            ExpiringDict(max_entries=0)
+
+    def test_non_string_key_is_never_contained(self) -> None:
+        d: ExpiringDict[str] = ExpiringDict()
+        d["a"] = "one"
+
+        assert 1 not in d
+
+
+class TestExpiry:
+    def test_entry_expires_after_its_ttl(self) -> None:
+        clock = FakeClock()
+        d = make_dict(clock, ttl_seconds=60)
+        d["a"] = "one"
+
+        clock.advance(59)
+        assert d.pop("a") == "one"
+
+        d["b"] = "two"
+        clock.advance(61)
+        assert d.pop("b") is None
+        assert "b" not in d
+        assert len(d) == 0
+
+    def test_expired_entries_are_purged_on_write(self) -> None:
+        """A call that is never answered must not keep its entry forever."""
+        clock = FakeClock()
+        d = make_dict(clock, ttl_seconds=60)
+        for i in range(5):
+            d[f"abandoned_{i}"] = "config"
+
+        clock.advance(61)
+        d["fresh"] = "config"
+
+        assert len(d) == 1
+        assert d.pop("fresh") == "config"
+
+
+class TestCapacity:
+    def test_oldest_entries_are_evicted_over_capacity(self) -> None:
+        d: ExpiringDict[str] = ExpiringDict(max_entries=3)
+        for i in range(5):
+            d[f"k{i}"] = str(i)
+
+        assert len(d) == 3
+        assert "k0" not in d
+        assert "k1" not in d
+        assert d.pop("k4") == "4"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -251,7 +251,6 @@ class TestTACIntegration:
         ):
             await channel.process_webhook(message_webhook)
 
-        assert "CH999999" in channel._conversations
         assert callback_invoked
 
     @pytest.mark.asyncio
@@ -293,20 +292,24 @@ class TestTACIntegration:
         assert not callback_invoked
 
     @pytest.mark.asyncio
-    async def test_sms_channel_conversation_cleanup(self) -> None:
-        """CONVERSATION_UPDATED closed event cleans up local session."""
+    async def test_sms_channel_conversation_closed(self) -> None:
+        """CLOSED fires on_conversation_ended with a session rebuilt from
+        Conversation Orchestrator, whichever instance the webhook lands on."""
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
+        ended: list[ConversationSession] = []
+        tac.on_conversation_ended(lambda ctx: ended.append(ctx))
 
-        channel._conversations["CH222"] = ConversationSession(
-            conversation_id="CH222", channel="SMS"
-        )
+        with patch.object(
+            tac.conversation_orchestrator_client,
+            "list_participants",
+            return_value=make_sms_participants(conv_id="CH222"),
+        ):
+            await channel.process_webhook(
+                create_conversation_updated_webhook("CH222", "CLOSED", "2025-11-18T00:10:00.000Z")
+            )
 
-        await channel.process_webhook(
-            create_conversation_updated_webhook("CH222", "CLOSED", "2025-11-18T00:10:00.000Z")
-        )
-
-        assert "CH222" not in channel._conversations
+        assert [s.conversation_id for s in ended] == ["CH222"]
 
     @pytest.mark.asyncio
     async def test_sms_channel_multiple_concurrent_conversations(self) -> None:

--- a/tests/test_memory_mode_once.py
+++ b/tests/test_memory_mode_once.py
@@ -1,24 +1,33 @@
-"""Tests for 'once' memory mode caching and invalidation.
+"""Tests for `memory_mode="once"` — a Voice-only mode.
 
-Tests memory caching behavior: fetch once with empty query, cache it,
-invalidate on INACTIVE, task-safe with an async lock.
+`"once"` primes a recall with no query and caches it on the session for the
+rest of the call. It needs a session that outlives a single request, which
+only voice has: a call is pinned to the instance holding its WebSocket. The
+messaging channels hold nothing between webhooks, so they reject the mode at
+construction rather than silently degrading to a cacheless, query-less recall.
 """
 
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from tac import TAC
+from tac.channels.chat import ChatChannel
+from tac.channels.messaging import MessagingChannel
+from tac.channels.rcs import RCSChannel
 from tac.channels.sms import SMSChannel
-from tac.models.conversation import ParticipantAddress, ParticipantResponse
+from tac.channels.voice import VoiceChannel
+from tac.channels.voice.conversation_relay import ConversationRelayProviderConfig
+from tac.channels.whatsapp import WhatsAppChannel
+from tac.context.memory import MemoryClient
+from tac.models.conversation import ParticipantAddress
 from tac.models.memory import MemoryRetrievalMeta, MemoryRetrievalResponse
 from tac.models.session import ConversationSession
 from tac.models.tac import TACMemoryResponse
 
 
 def get_test_config() -> dict[str, Any]:
-    """Get a valid test configuration."""
     from tac.core.config import TwilioMemoryConfig
 
     return {
@@ -28,633 +37,163 @@ def get_test_config() -> dict[str, Any]:
         "api_secret": "test_api_token",
         "conversation_configuration_id": "conv_configuration_test123",
         "phone_number": "+15551234567",
+        "rcs_sender_id": "rcs_sender_test",
+        "whatsapp_number": "whatsapp:+15551234567",
         "memory_config": TwilioMemoryConfig(trait_groups=["Contact"]),
     }
 
 
-def create_communication_created_webhook(
-    conversation_id: str,
-    participant_id: str,
-    message_text: str,
-    timestamp: str,
-    author_address: str = "+12345678901",
-) -> dict[str, Any]:
-    """Create a COMMUNICATION_CREATED webhook event."""
-    # Generate unique communication ID using timestamp to avoid deduplication
-    comm_id = f"comms_communication_{timestamp.replace(':', '').replace('.', '').replace('-', '')}"
-    return {
-        "eventType": "COMMUNICATION_CREATED",
-        "timestamp": timestamp,
-        "data": {
-            "id": comm_id,
-            "conversationId": conversation_id,
-            "accountId": "ACtest123",
-            "serviceId": "IStest123",
-            "author": {
-                "address": author_address,
-                "channel": "SMS",
-                "participantId": participant_id,
-            },
-            "content": {"type": "TEXT", "text": message_text},
-            "channelId": None,
-            "recipients": [
-                {
-                    "address": "+15551234567",
-                    "channel": "SMS",
-                    "participantId": "comms_participant_agent",
-                    "deliveryStatus": "DELIVERED",
-                }
-            ],
-            "createdAt": timestamp,
-            "updatedAt": timestamp,
-        },
-    }
-
-
-@pytest.mark.asyncio
-async def test_once_mode_caches_memory_on_first_retrieval() -> None:
-    """Test that 'once' mode fetches memory once and caches it."""
+def make_voice_channel() -> tuple[TAC, VoiceChannel, AsyncMock]:
+    """A voice channel in `"once"` mode with the Memory recall call mocked."""
     tac = TAC(get_test_config())
-
-    from tac.context.memory import MemoryClient
-
     tac.conversation_memory_client = MemoryClient(
         store_id="MGtest123",
         api_key=tac.config.api_key,
         api_secret=tac.config.api_secret,
     )
-
-    channel = SMSChannel(tac, config={"memory_mode": "once"})
-
-    captured_memory_responses = []
-
-    def message_callback(
-        user_message: str,
-        context: ConversationSession,
-        memory_response: TACMemoryResponse | None,
-    ) -> None:
-        captured_memory_responses.append(memory_response)
-
-    tac.on_message_ready(message_callback)
-
-    empty_response = MemoryRetrievalResponse(
-        observations=[],
-        summaries=[],
-        meta=MemoryRetrievalMeta(queryTime=0),
-    )
-    # Mock at memory client level so TAC.retrieve_memory() wraps it in TACMemoryResponse
-    retrieve_memory_mock = AsyncMock(return_value=empty_response)
-    tac.conversation_memory_client.retrieve_memory = retrieve_memory_mock
-
-    # Mock reconcile
-    mock_agent = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_AGENT",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "Test Agent",
-            "type": "AI_AGENT",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+15551234567").model_dump(by_alias=True)
-            ],
-        }
-    )
-    mock_customer = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_CUSTOMER",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "+12345678901",
-            "type": "CUSTOMER",
-            "profileId": "mem_profile_00000000000000000000000000",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+12345678901").model_dump(by_alias=True)
-            ],
-        }
-    )
-
-    with patch.object(
-        channel,
-        "_reconcile_participants",
-        new=AsyncMock(return_value=(mock_agent, mock_customer)),
-    ):
-        # First message - should fetch memory
-        webhook1 = create_communication_created_webhook(
-            "CH123456", "MB001", "First message", "2025-11-18T00:00:00.000Z"
+    recall = AsyncMock(
+        return_value=MemoryRetrievalResponse(
+            observations=[],
+            summaries=[],
+            meta=MemoryRetrievalMeta(queryTime=0),
         )
-        await channel.process_webhook(webhook1, idempotency_token="token1")
-
-        # Second message - should use cached memory
-        webhook2 = create_communication_created_webhook(
-            "CH123456", "MB002", "Second message", "2025-11-18T00:00:01.000Z"
-        )
-        await channel.process_webhook(webhook2, idempotency_token="token2")
-
-        # Third message - should still use cached memory
-        webhook3 = create_communication_created_webhook(
-            "CH123456", "MB003", "Third message", "2025-11-18T00:00:02.000Z"
-        )
-        await channel.process_webhook(webhook3, idempotency_token="token3")
-
-    # Verify retrieve_memory was only called once (on first message)
-    assert retrieve_memory_mock.call_count == 1
-    # "once" mode's cache-priming fetch has no per-turn topic, so
-    # conversation_id is left unset to avoid triggering server-side
-    # query expansion.
-    assert retrieve_memory_mock.call_args.kwargs["conversation_id"] is None
-
-    # Verify all callbacks received memory response
-    assert len(captured_memory_responses) == 3
-    assert all(resp is not None for resp in captured_memory_responses)
-
-    # Verify session has cached memory
-    session = channel._conversations["CH123456"]
-    assert session.cached_memory is not None
-
-
-@pytest.mark.asyncio
-async def test_once_mode_uses_empty_query() -> None:
-    """Test that 'once' mode uses empty query (None) for memory retrieval."""
-    tac = TAC(get_test_config())
-
-    from tac.context.memory import MemoryClient
-
-    tac.conversation_memory_client = MemoryClient(
-        store_id="MGtest123",
-        api_key=tac.config.api_key,
-        api_secret=tac.config.api_secret,
     )
-
-    channel = SMSChannel(tac, config={"memory_mode": "once"})
-
-    def message_callback(
-        user_message: str,
-        context: ConversationSession,
-        memory_response: TACMemoryResponse | None,
-    ) -> None:
-        pass
-
-    tac.on_message_ready(message_callback)
-
-    empty_response = MemoryRetrievalResponse(
-        observations=[],
-        summaries=[],
-        meta=MemoryRetrievalMeta(queryTime=0),
-    )
-
-    # Mock TAC.retrieve_memory directly but return a properly wrapped TACMemoryResponse
-    async def mock_retrieve_memory(
-        session: ConversationSession, query: str | None = None
-    ) -> TACMemoryResponse:
-        return TACMemoryResponse(empty_response)
-
-    retrieve_memory_mock = AsyncMock(side_effect=mock_retrieve_memory)
-    tac.retrieve_memory = retrieve_memory_mock
-
-    # Mock reconcile
-    mock_agent = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_AGENT",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "Test Agent",
-            "type": "AI_AGENT",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+15551234567").model_dump(by_alias=True)
-            ],
-        }
-    )
-    mock_customer = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_CUSTOMER",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "+12345678901",
-            "type": "CUSTOMER",
-            "profileId": "mem_profile_00000000000000000000000000",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+12345678901").model_dump(by_alias=True)
-            ],
-        }
-    )
-
-    with patch.object(
-        channel,
-        "_reconcile_participants",
-        new=AsyncMock(return_value=(mock_agent, mock_customer)),
-    ):
-        webhook = create_communication_created_webhook(
-            "CH123456", "MB001", "Test message with query", "2025-11-18T00:00:00.000Z"
-        )
-        await channel.process_webhook(webhook, idempotency_token="token1")
-
-    # Verify retrieve_memory was called with None query
-    retrieve_memory_mock.assert_called_once()
-    call_args = retrieve_memory_mock.call_args
-    assert call_args.kwargs["query"] is None
+    tac.conversation_memory_client.retrieve_memory = recall
+    tac.conversation_memory_client.get_profile = AsyncMock(side_effect=RuntimeError("no profile"))
+    channel = VoiceChannel(tac, config=ConversationRelayProviderConfig(memory_mode="once"))
+    return tac, channel, recall
 
 
-@pytest.mark.asyncio
-async def test_once_mode_invalidates_cache_on_inactive() -> None:
-    """Test that cached memory is invalidated when conversation becomes INACTIVE."""
-    tac = TAC(get_test_config())
+class TestMessagingRejectsOnce:
+    """Fail loudly at construction — a silent downgrade shows up in production
+    as "the bot forgot things"."""
 
-    from tac.context.memory import MemoryClient
+    @pytest.mark.parametrize("channel_cls", [SMSChannel, RCSChannel, WhatsAppChannel, ChatChannel])
+    def test_config_rejects_once(self, channel_cls: type) -> None:
+        tac = TAC(get_test_config())
+        with pytest.raises(Exception) as exc_info:
+            channel_cls(tac, config={"memory_mode": "once"})
+        assert "once" in str(exc_info.value)
 
-    tac.conversation_memory_client = MemoryClient(
-        store_id="MGtest123",
-        api_key=tac.config.api_key,
-        api_secret=tac.config.api_secret,
-    )
+    def test_custom_subclass_passing_once_directly_is_rejected(self) -> None:
+        """The config field's Literal can't see a subclass that bypasses it."""
 
-    channel = SMSChannel(tac, config={"memory_mode": "once"})
+        class CustomChannel(MessagingChannel):
+            def get_channel_name(self) -> str:
+                return "SMS"
 
-    captured_memory_responses = []
+            def is_default_agent_address(self, author_address: str) -> bool:
+                return False
 
-    def message_callback(
-        user_message: str,
-        context: ConversationSession,
-        memory_response: TACMemoryResponse | None,
-    ) -> None:
-        captured_memory_responses.append(memory_response)
+            def get_agent_address(self, session: ConversationSession) -> ParticipantAddress:
+                return ParticipantAddress(channel="SMS", address="+15551234567")
 
-    tac.on_message_ready(message_callback)
+        with pytest.raises(ValueError, match='does not support memory_mode="once"'):
+            CustomChannel(TAC(get_test_config()), memory_mode="once")
 
-    empty_response = MemoryRetrievalResponse(
-        observations=[],
-        summaries=[],
-        meta=MemoryRetrievalMeta(queryTime=0),
-    )
-    # Mock at memory client level so TAC.retrieve_memory() wraps it in TACMemoryResponse
-    retrieve_memory_mock = AsyncMock(return_value=empty_response)
-    tac.conversation_memory_client.retrieve_memory = retrieve_memory_mock
 
-    # Mock reconcile
-    mock_agent = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_AGENT",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "Test Agent",
-            "type": "AI_AGENT",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+15551234567").model_dump(by_alias=True)
-            ],
-        }
-    )
-    mock_customer = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_CUSTOMER",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "+12345678901",
-            "type": "CUSTOMER",
-            "profileId": "mem_profile_00000000000000000000000000",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+12345678901").model_dump(by_alias=True)
-            ],
-        }
-    )
+class TestVoiceOnceMode:
+    @pytest.mark.asyncio
+    async def test_caches_after_the_first_retrieval(self) -> None:
+        _tac, channel, recall = make_voice_channel()
+        session = channel._start_conversation("CA_once", "mem_profile_1")
 
-    with patch.object(
-        channel,
-        "_reconcile_participants",
-        new=AsyncMock(return_value=(mock_agent, mock_customer)),
-    ):
-        # First message - should fetch and cache memory
-        webhook1 = create_communication_created_webhook(
-            "CH123456", "MB001", "First message", "2025-11-18T00:00:00.000Z"
-        )
-        await channel.process_webhook(webhook1, idempotency_token="token1")
+        for prompt in ("first", "second", "third"):
+            response = await channel._retrieve_memory_if_enabled(session, prompt, "CA_once")
+            assert isinstance(response, TACMemoryResponse)
 
-        # Verify cache is populated
-        session = channel._conversations["CH123456"]
+        assert recall.call_count == 1
         assert session.cached_memory is not None
-        assert retrieve_memory_mock.call_count == 1
 
-        # Send CONVERSATION_UPDATED with INACTIVE status
-        inactive_webhook = {
-            "eventType": "CONVERSATION_UPDATED",
-            "data": {
-                "id": "CH123456",
-                "accountId": "ACtest123",
-                "configurationId": tac.config.conversation_configuration_id,
-                "status": "INACTIVE",
-                "name": None,
-                "createdAt": "2025-11-18T00:00:00.000Z",
-                "updatedAt": "2025-11-18T00:01:00.000Z",
-            },
-        }
-        await channel.process_webhook(inactive_webhook, idempotency_token="token_inactive")
+    @pytest.mark.asyncio
+    async def test_primes_with_no_query_and_no_conversation_id(self) -> None:
+        """No per-turn topic justifies Memory's server-side query expansion."""
+        _tac, channel, recall = make_voice_channel()
+        session = channel._start_conversation("CA_once", "mem_profile_1")
 
-        # Verify cache is invalidated
+        await channel._retrieve_memory_if_enabled(session, "what's my balance?", "CA_once")
+
+        assert recall.call_args.kwargs["query"] is None
+        assert recall.call_args.kwargs["conversation_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_inactive_webhook_invalidates_the_cache(self) -> None:
+        """Conversation Orchestrator rewrites memory on the INACTIVE transition,
+        so the cached copy is stale from then on."""
+        _tac, channel, recall = make_voice_channel()
+        session = channel._start_conversation("CH_once", "mem_profile_1")
+
+        await channel._retrieve_memory_if_enabled(session, "first", "CH_once")
+        assert session.cached_memory is not None
+
+        await channel.process_webhook(
+            {
+                "eventType": "CONVERSATION_UPDATED",
+                "data": {
+                    "id": "CH_once",
+                    "status": "INACTIVE",
+                    "configurationId": "conv_configuration_test123",
+                },
+            }
+        )
         assert session.cached_memory is None
 
-        # Send another message after INACTIVE - should fetch memory again
-        webhook2 = create_communication_created_webhook(
-            "CH123456", "MB002", "Message after inactive", "2025-11-18T00:02:00.000Z"
+        await channel._retrieve_memory_if_enabled(session, "second", "CH_once")
+        assert recall.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_active_webhook_leaves_the_cache_alone(self) -> None:
+        _tac, channel, recall = make_voice_channel()
+        session = channel._start_conversation("CH_once", "mem_profile_1")
+        await channel._retrieve_memory_if_enabled(session, "first", "CH_once")
+
+        await channel.process_webhook(
+            {
+                "eventType": "CONVERSATION_UPDATED",
+                "data": {
+                    "id": "CH_once",
+                    "status": "ACTIVE",
+                    "configurationId": "conv_configuration_test123",
+                },
+            }
         )
-        await channel.process_webhook(webhook2, idempotency_token="token2")
 
-        # Verify memory was fetched again
-        assert retrieve_memory_mock.call_count == 2
-
-        # Verify cache is populated again
         assert session.cached_memory is not None
+        await channel._retrieve_memory_if_enabled(session, "second", "CH_once")
+        assert recall.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_concurrent_prompts_prime_the_cache_once(self) -> None:
+        """Two utterances racing must not both issue the priming recall."""
+        import asyncio
 
-@pytest.mark.asyncio
-async def test_once_mode_does_not_invalidate_on_active() -> None:
-    """Test that cached memory is NOT invalidated when conversation becomes ACTIVE."""
-    tac = TAC(get_test_config())
+        _tac, channel, recall = make_voice_channel()
+        session = channel._start_conversation("CA_race", "mem_profile_1")
 
-    from tac.context.memory import MemoryClient
+        slow_recall_started = asyncio.Event()
+        release = asyncio.Event()
+        original = recall.side_effect
 
-    tac.conversation_memory_client = MemoryClient(
-        store_id="MGtest123",
-        api_key=tac.config.api_key,
-        api_secret=tac.config.api_secret,
-    )
+        async def slow_recall(**kwargs: Any) -> MemoryRetrievalResponse:
+            slow_recall_started.set()
+            await release.wait()
+            return MemoryRetrievalResponse(
+                observations=[], summaries=[], meta=MemoryRetrievalMeta(queryTime=0)
+            )
 
-    channel = SMSChannel(tac, config={"memory_mode": "once"})
+        recall.side_effect = slow_recall
+        try:
+            first = asyncio.create_task(
+                channel._retrieve_memory_if_enabled(session, "a", "CA_race")
+            )
+            await slow_recall_started.wait()
+            second = asyncio.create_task(
+                channel._retrieve_memory_if_enabled(session, "b", "CA_race")
+            )
+            await asyncio.sleep(0)
+            release.set()
+            await asyncio.gather(first, second)
+        finally:
+            recall.side_effect = original
 
-    def message_callback(
-        user_message: str,
-        context: ConversationSession,
-        memory_response: TACMemoryResponse | None,
-    ) -> None:
-        pass
-
-    tac.on_message_ready(message_callback)
-
-    empty_response = MemoryRetrievalResponse(
-        observations=[],
-        summaries=[],
-        meta=MemoryRetrievalMeta(queryTime=0),
-    )
-    # Mock at memory client level so TAC.retrieve_memory() wraps it in TACMemoryResponse
-    retrieve_memory_mock = AsyncMock(return_value=empty_response)
-    tac.conversation_memory_client.retrieve_memory = retrieve_memory_mock
-
-    # Mock reconcile
-    mock_agent = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_AGENT",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "Test Agent",
-            "type": "AI_AGENT",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+15551234567").model_dump(by_alias=True)
-            ],
-        }
-    )
-    mock_customer = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_CUSTOMER",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "+12345678901",
-            "type": "CUSTOMER",
-            "profileId": "mem_profile_00000000000000000000000000",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+12345678901").model_dump(by_alias=True)
-            ],
-        }
-    )
-
-    with patch.object(
-        channel,
-        "_reconcile_participants",
-        new=AsyncMock(return_value=(mock_agent, mock_customer)),
-    ):
-        # First message - should fetch and cache memory
-        webhook1 = create_communication_created_webhook(
-            "CH123456", "MB001", "First message", "2025-11-18T00:00:00.000Z"
-        )
-        await channel.process_webhook(webhook1, idempotency_token="token1")
-
-        # Store reference to cached memory
-        session = channel._conversations["CH123456"]
-        cached_memory_before = session.cached_memory
-        assert cached_memory_before is not None
-
-        # Send CONVERSATION_UPDATED with ACTIVE status
-        active_webhook = {
-            "eventType": "CONVERSATION_UPDATED",
-            "data": {
-                "id": "CH123456",
-                "accountId": "ACtest123",
-                "configurationId": tac.config.conversation_configuration_id,
-                "status": "ACTIVE",
-                "name": None,
-                "createdAt": "2025-11-18T00:00:00.000Z",
-                "updatedAt": "2025-11-18T00:01:00.000Z",
-            },
-        }
-        await channel.process_webhook(active_webhook, idempotency_token="token_active")
-
-        # Verify cache is NOT invalidated
-        assert session.cached_memory is not None
-        assert session.cached_memory is cached_memory_before
-
-
-@pytest.mark.asyncio
-async def test_once_mode_clears_cache_on_closed() -> None:
-    """Test that conversation cleanup (CLOSED) also clears the cached memory."""
-    tac = TAC(get_test_config())
-
-    from tac.context.memory import MemoryClient
-
-    tac.conversation_memory_client = MemoryClient(
-        store_id="MGtest123",
-        api_key=tac.config.api_key,
-        api_secret=tac.config.api_secret,
-    )
-
-    channel = SMSChannel(tac, config={"memory_mode": "once"})
-
-    def message_callback(
-        user_message: str,
-        context: ConversationSession,
-        memory_response: TACMemoryResponse | None,
-    ) -> None:
-        pass
-
-    tac.on_message_ready(message_callback)
-
-    empty_response = MemoryRetrievalResponse(
-        observations=[],
-        summaries=[],
-        meta=MemoryRetrievalMeta(queryTime=0),
-    )
-    # Mock at memory client level so TAC.retrieve_memory() wraps it in TACMemoryResponse
-    retrieve_memory_mock = AsyncMock(return_value=empty_response)
-    tac.conversation_memory_client.retrieve_memory = retrieve_memory_mock
-
-    # Mock reconcile
-    mock_agent = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_AGENT",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "Test Agent",
-            "type": "AI_AGENT",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+15551234567").model_dump(by_alias=True)
-            ],
-        }
-    )
-    mock_customer = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_CUSTOMER",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "+12345678901",
-            "type": "CUSTOMER",
-            "profileId": "mem_profile_00000000000000000000000000",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+12345678901").model_dump(by_alias=True)
-            ],
-        }
-    )
-
-    with patch.object(
-        channel,
-        "_reconcile_participants",
-        new=AsyncMock(return_value=(mock_agent, mock_customer)),
-    ):
-        # First message - should fetch and cache memory
-        webhook1 = create_communication_created_webhook(
-            "CH123456", "MB001", "First message", "2025-11-18T00:00:00.000Z"
-        )
-        await channel.process_webhook(webhook1, idempotency_token="token1")
-
-        # Verify cache is populated and conversation exists
-        assert "CH123456" in channel._conversations
-        session = channel._conversations["CH123456"]
-        assert session.cached_memory is not None
-
-        # Send CONVERSATION_UPDATED with CLOSED status
-        closed_webhook = {
-            "eventType": "CONVERSATION_UPDATED",
-            "data": {
-                "id": "CH123456",
-                "accountId": "ACtest123",
-                "configurationId": tac.config.conversation_configuration_id,
-                "status": "CLOSED",
-                "name": None,
-                "createdAt": "2025-11-18T00:00:00.000Z",
-                "updatedAt": "2025-11-18T00:01:00.000Z",
-            },
-        }
-        await channel.process_webhook(closed_webhook, idempotency_token="token_closed")
-
-        # Verify conversation is removed (which also clears the cache)
-        assert "CH123456" not in channel._conversations
-
-
-@pytest.mark.asyncio
-async def test_once_mode_lock_prevents_race_conditions() -> None:
-    """Test that cache_lock is present and functions correctly for 'once' mode.
-
-    Verifies that:
-    - ConversationSession has a cache_lock field
-    - The lock can be acquired successfully
-    - INACTIVE webhook processing respects the lock when clearing cache
-    """
-    tac = TAC(get_test_config())
-
-    from tac.context.memory import MemoryClient
-
-    tac.conversation_memory_client = MemoryClient(
-        store_id="MGtest123",
-        api_key=tac.config.api_key,
-        api_secret=tac.config.api_secret,
-    )
-
-    channel = SMSChannel(tac, config={"memory_mode": "once"})
-
-    def message_callback(
-        user_message: str,
-        context: ConversationSession,
-        memory_response: TACMemoryResponse | None,
-    ) -> None:
-        pass
-
-    tac.on_message_ready(message_callback)
-
-    empty_response = MemoryRetrievalResponse(
-        observations=[],
-        summaries=[],
-        meta=MemoryRetrievalMeta(queryTime=0),
-    )
-    # Mock at memory client level so TAC.retrieve_memory() wraps it in TACMemoryResponse
-    retrieve_memory_mock = AsyncMock(return_value=empty_response)
-    tac.conversation_memory_client.retrieve_memory = retrieve_memory_mock
-
-    # Mock reconcile
-    mock_agent = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_AGENT",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "Test Agent",
-            "type": "AI_AGENT",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+15551234567").model_dump(by_alias=True)
-            ],
-        }
-    )
-    mock_customer = ParticipantResponse(
-        **{  # type: ignore[arg-type]
-            "id": "PA_CUSTOMER",
-            "accountId": "ACtest123",
-            "conversationId": "CH123456",
-            "name": "+12345678901",
-            "type": "CUSTOMER",
-            "profileId": "mem_profile_00000000000000000000000000",
-            "addresses": [
-                ParticipantAddress(channel="SMS", address="+12345678901").model_dump(by_alias=True)
-            ],
-        }
-    )
-
-    with patch.object(
-        channel,
-        "_reconcile_participants",
-        new=AsyncMock(return_value=(mock_agent, mock_customer)),
-    ):
-        # First message - should fetch and cache memory
-        webhook1 = create_communication_created_webhook(
-            "CH123456", "MB001", "First message", "2025-11-18T00:00:00.000Z"
-        )
-        await channel.process_webhook(webhook1, idempotency_token="token1")
-
-        # Verify session has cache_lock
-        session = channel._conversations["CH123456"]
-        assert hasattr(session, "cache_lock")
-        assert session.cache_lock is not None
-
-        # Verify lock can be acquired (not deadlocked)
-        async with session.cache_lock:
-            # Lock acquired successfully
-            assert session.cached_memory is not None
-
-        # Send INACTIVE webhook - should acquire lock before clearing cache
-        inactive_webhook = {
-            "eventType": "CONVERSATION_UPDATED",
-            "data": {
-                "id": "CH123456",
-                "accountId": "ACtest123",
-                "configurationId": tac.config.conversation_configuration_id,
-                "status": "INACTIVE",
-                "name": None,
-                "createdAt": "2025-11-18T00:00:00.000Z",
-                "updatedAt": "2025-11-18T00:01:00.000Z",
-            },
-        }
-        await channel.process_webhook(inactive_webhook, idempotency_token="token_inactive")
-
-        # Verify cache was safely cleared
-        assert session.cached_memory is None
+        assert recall.call_count == 1

--- a/tests/test_messaging_scaling.py
+++ b/tests/test_messaging_scaling.py
@@ -1,0 +1,431 @@
+"""Messaging behaviour that horizontal scaling depends on.
+
+Messaging is request/response: any replica can serve any webhook, because a
+channel derives its session per request and stores nothing. These tests pin
+the three things that makes true — no residual state, cross-instance
+`on_conversation_ended`, and an API-call budget that doesn't quietly grow to
+compensate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tac import TAC
+from tac.channels.chat import ChatChannel
+from tac.channels.sms import SMSChannel
+from tac.context.memory import MemoryClient
+from tac.models.conversation import ParticipantAddress, ParticipantResponse
+from tac.models.memory import (
+    MemoryRetrievalMeta,
+    MemoryRetrievalResponse,
+    ProfileLookupResponse,
+    ProfileResponse,
+)
+from tac.models.session import ConversationSession
+
+CONFIGURATION_ID = "conv_configuration_test123"
+AGENT_NUMBER = "+15551234567"
+CUSTOMER_NUMBER = "+12345678901"
+
+
+def get_test_config(**overrides: Any) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "account_sid": "ACtest123",
+        "auth_token": "test_token_123",
+        "api_key": "SK123",
+        "api_secret": "test_api_token",
+        "conversation_configuration_id": CONFIGURATION_ID,
+        "phone_number": AGENT_NUMBER,
+    }
+    config.update(overrides)
+    return config
+
+
+def participant(
+    pid: str,
+    ptype: str,
+    address: str,
+    *,
+    conv_id: str = "CH123",
+    channel: str = "SMS",
+    profile_id: str | None = None,
+) -> ParticipantResponse:
+    return ParticipantResponse(
+        id=pid,
+        conversation_id=conv_id,
+        account_id="ACtest123",
+        name=address,
+        type=ptype,  # type: ignore[arg-type]
+        profile_id=profile_id,
+        addresses=[ParticipantAddress(channel=channel, address=address)],  # type: ignore[arg-type]
+    )
+
+
+def healthy_participants(
+    conv_id: str = "CH123", profile_id: str | None = None
+) -> list[ParticipantResponse]:
+    """Both sides correctly typed — reconciliation's happy-path row."""
+    return [
+        participant("PA_AGENT", "AI_AGENT", AGENT_NUMBER, conv_id=conv_id),
+        participant(
+            "PA_CUSTOMER", "CUSTOMER", CUSTOMER_NUMBER, conv_id=conv_id, profile_id=profile_id
+        ),
+    ]
+
+
+def inbound(
+    conv_id: str = "CH123",
+    *,
+    text: str = "hello",
+    author_address: str = CUSTOMER_NUMBER,
+    author_participant_id: str = "PA_CUSTOMER",
+    comm_id: str = "comms_communication_01",
+) -> dict[str, Any]:
+    return {
+        "eventType": "COMMUNICATION_CREATED",
+        "data": {
+            "id": comm_id,
+            "conversationId": conv_id,
+            "accountId": "ACtest123",
+            "author": {
+                "address": author_address,
+                "channel": "SMS",
+                "participantId": author_participant_id,
+            },
+            "content": {"type": "TEXT", "text": text},
+            "recipients": [],
+            "createdAt": "2026-04-27T00:00:00Z",
+        },
+    }
+
+
+def closed(conv_id: str = "CH123") -> dict[str, Any]:
+    return {
+        "eventType": "CONVERSATION_UPDATED",
+        "data": {
+            "id": conv_id,
+            "accountId": "ACtest123",
+            "configurationId": CONFIGURATION_ID,
+            "status": "CLOSED",
+        },
+    }
+
+
+class CallCounter:
+    """Counts every Conversation Orchestrator / Memory call a webhook makes."""
+
+    def __init__(self, tac: TAC, profile_id: str | None = None) -> None:
+        self.calls: list[str] = []
+        co = tac.conversation_orchestrator_client
+        assert co is not None
+        self._install(
+            co, "list_participants", lambda conv_id: healthy_participants(conv_id, profile_id)
+        )
+        self._install(co, "create_action", lambda *a, **k: None)
+        self._install(co, "update_participant", lambda *a, **k: None)
+        self._install(co, "add_participant", lambda *a, **k: None)
+        self._install(co, "list_communications", lambda *a, **k: [])
+
+        memory = tac.conversation_memory_client
+        if memory is not None:
+            self._install(
+                memory,
+                "retrieve_memory",
+                lambda *a, **k: MemoryRetrievalResponse(
+                    observations=[], summaries=[], meta=MemoryRetrievalMeta(queryTime=0)
+                ),
+            )
+            self._install(
+                memory,
+                "get_profile",
+                lambda *a, **k: ProfileResponse(id="profile_1", createdAt="2026-01-01T00:00:00Z"),
+            )
+            self._install(
+                memory,
+                "lookup_profile",
+                lambda *a, **k: ProfileLookupResponse(
+                    normalizedValue=CUSTOMER_NUMBER, profiles=["profile_1"]
+                ),
+            )
+
+    def _install(self, client: Any, name: str, result: Any) -> None:
+        async def call(*args: Any, **kwargs: Any) -> Any:
+            self.calls.append(name)
+            return result(*args, **kwargs)
+
+        setattr(client, name, call)
+
+    def count(self, name: str) -> int:
+        return self.calls.count(name)
+
+
+def make_sms_channel(
+    mode: str = "never", profile_id: str | None = None, **memory_overrides: Any
+) -> tuple[TAC, SMSChannel, CallCounter]:
+    from tac.core.config import TwilioMemoryConfig
+
+    tac = TAC(get_test_config(memory_config=TwilioMemoryConfig(**memory_overrides)))
+    tac.conversation_memory_client = MemoryClient(
+        store_id="MGtest123", api_key=tac.config.api_key, api_secret=tac.config.api_secret
+    )
+    channel = SMSChannel(tac, config={"memory_mode": mode})
+    return tac, channel, CallCounter(tac, profile_id)
+
+
+class TestNothingIsStored:
+    @pytest.mark.asyncio
+    async def test_channel_has_no_session_store_at_all(self) -> None:
+        """The regression guard: if this attribute comes back, so does the leak."""
+        tac = TAC(get_test_config())
+        channel = SMSChannel(tac)
+
+        assert not hasattr(channel, "_conversations")
+
+    @pytest.mark.asyncio
+    async def test_inbound_leaves_no_residue(self) -> None:
+        tac, channel, counter = make_sms_channel()
+        sessions: list[ConversationSession] = []
+        tac.on_message_ready(lambda msg, ctx, mem: sessions.append(ctx))
+
+        await channel.process_webhook(inbound())
+
+        assert len(sessions) == 1
+        assert not hasattr(channel, "_conversations")
+
+
+class TestTwoInstances:
+    """A and B share nothing but configuration — which is the point."""
+
+    @pytest.mark.asyncio
+    async def test_closed_fires_on_the_instance_that_never_saw_the_message(self) -> None:
+        tac_a = TAC(get_test_config())
+        tac_b = TAC(get_test_config())
+        instance_a = SMSChannel(tac_a)
+        instance_b = SMSChannel(tac_b)
+
+        ended: list[ConversationSession] = []
+        tac_b.on_conversation_ended(lambda ctx: ended.append(ctx))
+
+        # The message is handled by A.
+        tac_a.on_message_ready(lambda msg, ctx, mem: None)
+        with patch.object(
+            tac_a.conversation_orchestrator_client,
+            "list_participants",
+            new=AsyncMock(return_value=healthy_participants()),
+        ):
+            await instance_a.process_webhook(inbound())
+
+        # CLOSED is delivered to B.
+        with patch.object(
+            tac_b.conversation_orchestrator_client,
+            "list_participants",
+            new=AsyncMock(return_value=healthy_participants()),
+        ):
+            await instance_b.process_webhook(closed())
+
+        assert len(ended) == 1
+        assert ended[0].conversation_id == "CH123"
+        assert ended[0].channel == "SMS"
+        assert ended[0].author_info is not None
+        assert ended[0].author_info.address == CUSTOMER_NUMBER
+        assert ended[0].ai_agent_info is not None
+        assert ended[0].ai_agent_info.participant_id == "PA_AGENT"
+
+    @pytest.mark.asyncio
+    async def test_a_chat_close_does_not_fire_on_the_sms_channel(self) -> None:
+        tac = TAC(get_test_config())
+        channel = SMSChannel(tac)
+        ended: list[ConversationSession] = []
+        tac.on_conversation_ended(lambda ctx: ended.append(ctx))
+
+        with patch.object(
+            tac.conversation_orchestrator_client,
+            "list_participants",
+            new=AsyncMock(
+                return_value=[
+                    participant("PA_U", "CUSTOMER", "user-1", channel="CHAT"),
+                ]
+            ),
+        ):
+            await channel.process_webhook(closed())
+
+        assert ended == []
+
+    @pytest.mark.asyncio
+    async def test_reply_works_from_a_session_alone(self) -> None:
+        """The session `on_message_ready` receives is enough to reply with —
+        no channel state, so a reply from any replica behaves identically."""
+        tac, channel, counter = make_sms_channel()
+        sessions: list[ConversationSession] = []
+        tac.on_message_ready(lambda msg, ctx, mem: sessions.append(ctx))
+
+        await channel.process_webhook(inbound())
+        counter.calls.clear()
+
+        await channel.send_response(sessions[0], "hi back")
+
+        assert counter.calls == ["create_action"]
+
+
+class TestReplyRecipient:
+    @pytest.mark.asyncio
+    async def test_reply_goes_to_the_reconciled_customer_not_the_author(self) -> None:
+        """A non-customer can author an inbound message. The reply still goes
+        to the customer — the author's participant id is not the recipient."""
+        tac = TAC(get_test_config())
+        channel = SMSChannel(tac)
+        tac.on_message_ready(lambda msg, ctx, mem: "reply")
+
+        participants = [
+            participant("PA_AGENT", "AI_AGENT", AGENT_NUMBER),
+            participant("PA_CUSTOMER", "CUSTOMER", CUSTOMER_NUMBER),
+            participant("PA_HUMAN", "HUMAN_AGENT", "+15557778888"),
+        ]
+
+        with (
+            patch.object(
+                tac.conversation_orchestrator_client,
+                "list_participants",
+                new=AsyncMock(return_value=participants),
+            ),
+            patch.object(
+                tac.conversation_orchestrator_client, "create_action", new=AsyncMock()
+            ) as create_action,
+        ):
+            await channel.process_webhook(
+                inbound(author_address="+15557778888", author_participant_id="PA_HUMAN")
+            )
+
+        request = create_action.await_args.args[1]
+        assert request.payload.to[0].participant_id == "PA_CUSTOMER"
+
+    @pytest.mark.asyncio
+    async def test_chat_replies_to_the_author(self) -> None:
+        """Chat disables customer reconciliation deliberately — its identities
+        are opaque, so promoting some other UNKNOWN could pick the wrong thread."""
+        tac = TAC(get_test_config())
+        channel = ChatChannel(tac)
+        tac.on_message_ready(lambda msg, ctx, mem: "reply")
+
+        event = inbound(author_address="user@example.com", author_participant_id="PA_USER")
+        event["data"]["author"]["channel"] = "CHAT"
+        event["data"]["channelId"] = "CH_CHAT_SID"
+
+        participants = [
+            participant("PA_AGENT", "AI_AGENT", "ai-assistant", channel="CHAT"),
+            participant("PA_USER", "CUSTOMER", "user@example.com", channel="CHAT"),
+            participant("PA_OTHER", "UNKNOWN", "someone-else", channel="CHAT"),
+        ]
+
+        with (
+            patch.object(
+                tac.conversation_orchestrator_client,
+                "list_participants",
+                new=AsyncMock(return_value=participants),
+            ),
+            patch.object(
+                tac.conversation_orchestrator_client, "create_action", new=AsyncMock()
+            ) as create_action,
+        ):
+            await channel.process_webhook(event)
+
+        request = create_action.await_args.args[1]
+        assert request.payload.to[0].participant_id == "PA_USER"
+        assert request.payload.channel_settings.channel_id == "CH_CHAT_SID"
+
+
+class TestApiCallBudget:
+    """Statelessness must not be paid for with extra API calls.
+
+    These counts are the contract. If one moves, either the budget genuinely
+    changed and this test should be updated deliberately, or something started
+    re-fetching what it already had.
+    """
+
+    @pytest.mark.asyncio
+    async def test_memory_never_costs_two_calls(self) -> None:
+        tac, channel, counter = make_sms_channel()
+        tac.on_message_ready(lambda msg, ctx, mem: "reply")
+
+        await channel.process_webhook(inbound())
+
+        assert counter.calls == ["list_participants", "create_action"]
+
+    @pytest.mark.asyncio
+    async def test_own_echo_costs_nothing(self) -> None:
+        tac, channel, counter = make_sms_channel()
+        tac.on_message_ready(lambda msg, ctx, mem: "reply")
+
+        await channel.process_webhook(inbound(author_address=AGENT_NUMBER))
+
+        assert counter.calls == []
+
+    @pytest.mark.asyncio
+    async def test_reconcile_writes_nothing_when_both_sides_are_typed(self) -> None:
+        """Reconciliation runs on every message; on the happy path it writes
+        nothing, which is what makes running it every time free."""
+        tac, channel, counter = make_sms_channel()
+        tac.on_message_ready(lambda msg, ctx, mem: "reply")
+
+        for i in range(3):
+            await channel.process_webhook(inbound(comm_id=f"comm_{i}"))
+
+        assert counter.count("update_participant") == 0
+        assert counter.count("add_participant") == 0
+        assert counter.count("list_participants") == 3
+
+    @pytest.mark.asyncio
+    async def test_memory_always_costs_four_calls(self) -> None:
+        tac, channel, counter = make_sms_channel(mode="always", profile_id="profile_1")
+        tac.on_message_ready(lambda msg, ctx, mem: "reply")
+
+        await channel.process_webhook(inbound())
+
+        assert counter.calls == [
+            "list_participants",
+            "get_profile",
+            "retrieve_memory",
+            "create_action",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_profile_id_comes_off_the_participant_list(self) -> None:
+        """No `lookup_profile` — the id is already in the response we fetched."""
+        tac, channel, counter = make_sms_channel(mode="always", profile_id="profile_1")
+        tac.on_message_ready(lambda msg, ctx, mem: None)
+
+        await channel.process_webhook(inbound())
+
+        assert counter.count("lookup_profile") == 0
+
+    @pytest.mark.asyncio
+    async def test_disabling_trait_fetch_returns_to_three_calls(self) -> None:
+        tac, channel, counter = make_sms_channel(
+            mode="always", profile_id="profile_1", fetch_profile_traits=False
+        )
+        tac.on_message_ready(lambda msg, ctx, mem: "reply")
+
+        await channel.process_webhook(inbound())
+
+        assert counter.calls == ["list_participants", "retrieve_memory", "create_action"]
+
+    @pytest.mark.asyncio
+    async def test_closed_with_no_handler_costs_nothing(self) -> None:
+        tac, channel, counter = make_sms_channel()
+
+        await channel.process_webhook(closed())
+
+        assert counter.calls == []
+
+    @pytest.mark.asyncio
+    async def test_closed_with_a_handler_costs_one_call(self) -> None:
+        tac, channel, counter = make_sms_channel()
+        tac.on_conversation_ended(lambda ctx: None)
+
+        await channel.process_webhook(closed())
+
+        assert counter.calls == ["list_participants"]

--- a/tests/test_openai_realtime_provider.py
+++ b/tests/test_openai_realtime_provider.py
@@ -469,17 +469,29 @@ class TestInboundCallSessionConfig:
         channel = make_channel(on_inbound_call_session_config=customizer)
         provider = channel._provider
 
-        await provider.handle_incoming_call(
+        twiml = await provider.handle_incoming_call(
             twiml_request=TwiMLRequest(call_sid="CA_MX", caller_country="MX")
         )
-        assert provider._call_session_configs["CA_MX"] == {
+        # The config rides out on the TwiML under a token, so it reaches
+        # whichever replica Twilio opens the stream to.
+        token = _extract_custom_parameter(twiml, _SESSION_CONFIG_TOKEN_PARAM)
+        assert provider._call_session_configs[token] == {
             "model": "gpt-realtime-mx",
             "instructions": "Habla en español.",
             "audio": _VALID_AUDIO,
         }
 
         twilio_ws = FakeTwilioWebSocket(
-            events=[{"event": "start", "start": {"callSid": "CA_MX", "streamSid": "MZ_MX"}}]
+            events=[
+                {
+                    "event": "start",
+                    "start": {
+                        "callSid": "CA_MX",
+                        "streamSid": "MZ_MX",
+                        "customParameters": {_SESSION_CONFIG_TOKEN_PARAM: token},
+                    },
+                }
+            ]
         )
         model_ws = FakeModelWebSocket(events=[], stay_open=False)
 
@@ -496,6 +508,7 @@ class TestInboundCallSessionConfig:
             "instructions": "Habla en español.",
             "audio": _VALID_AUDIO,
         }
+        assert token not in provider._call_session_configs
         assert "CA_MX" not in provider._call_session_configs
 
     @pytest.mark.asyncio
@@ -506,10 +519,11 @@ class TestInboundCallSessionConfig:
         channel = make_channel(on_inbound_call_session_config=customizer)
         provider = channel._provider
 
-        await provider.handle_incoming_call(
+        twiml = await provider.handle_incoming_call(
             twiml_request=TwiMLRequest(call_sid="CA_US", caller_country="US")
         )
-        assert "CA_US" not in provider._call_session_configs
+        assert _SESSION_CONFIG_TOKEN_PARAM not in twiml
+        assert len(provider._call_session_configs) == 0
 
         twilio_ws = FakeTwilioWebSocket(
             events=[{"event": "start", "start": {"callSid": "CA_US", "streamSid": "MZ_US"}}]
@@ -526,16 +540,30 @@ class TestInboundCallSessionConfig:
         assert sent_session["session"] == {"model": "gpt-realtime-test", "audio": _VALID_AUDIO}
 
     @pytest.mark.asyncio
-    async def test_no_call_sid_skips_customizer(self) -> None:
-        customizer = AsyncMock(return_value={"model": "should-not-be-used"})
+    async def test_customizer_runs_without_a_call_sid(self) -> None:
+        """Correlation is by token now, so a CallSid isn't a prerequisite."""
+        customizer = AsyncMock(return_value={"model": "gpt-realtime-mx", "audio": _VALID_AUDIO})
 
         channel = make_channel(on_inbound_call_session_config=customizer)
         provider = channel._provider
 
-        await provider.handle_incoming_call(twiml_request=TwiMLRequest(caller_country="MX"))
+        twiml = await provider.handle_incoming_call(twiml_request=TwiMLRequest(caller_country="MX"))
 
-        customizer.assert_not_called()
-        assert provider._call_session_configs == {}
+        customizer.assert_awaited_once()
+        token = _extract_custom_parameter(twiml, _SESSION_CONFIG_TOKEN_PARAM)
+        assert provider._call_session_configs[token]["model"] == "gpt-realtime-mx"
+
+    @pytest.mark.asyncio
+    async def test_no_customizer_registered_adds_no_token(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        twiml = await provider.handle_incoming_call(
+            twiml_request=TwiMLRequest(call_sid="CA_US", caller_country="US")
+        )
+
+        assert _SESSION_CONFIG_TOKEN_PARAM not in twiml
+        assert len(provider._call_session_configs) == 0
 
     @pytest.mark.asyncio
     async def test_missing_model_field_raises_at_connect_time(self) -> None:
@@ -640,7 +668,7 @@ class TestOutboundCallSessionConfig:
             "model": "gpt-realtime-outbound4",
             "audio": _VALID_AUDIO,
         }
-        assert provider._call_session_configs == {}
+        assert len(provider._call_session_configs) == 0
 
     @pytest.mark.asyncio
     async def test_session_config_token_cleaned_up_if_call_creation_fails(self) -> None:
@@ -659,7 +687,7 @@ class TestOutboundCallSessionConfig:
                     )
                 )
 
-        assert provider._call_session_configs == {}
+        assert len(provider._call_session_configs) == 0
 
     @pytest.mark.asyncio
     async def test_session_config_token_not_leaked_if_twiml_build_fails(self) -> None:
@@ -682,7 +710,7 @@ class TestOutboundCallSessionConfig:
                 )
             )
 
-        assert provider._call_session_configs == {}
+        assert len(provider._call_session_configs) == 0
 
     @pytest.mark.asyncio
     async def test_plain_options_type_ignored_falls_back_to_default(self) -> None:
@@ -698,7 +726,7 @@ class TestOutboundCallSessionConfig:
                 InitiateVoiceConversationOptions(to="+15551234567")
             )
 
-        assert provider._call_session_configs == {}
+        assert len(provider._call_session_configs) == 0
 
     @pytest.mark.asyncio
     async def test_outbound_only_config_with_no_default_connects_via_per_call_override(

--- a/tests/test_outbound.py
+++ b/tests/test_outbound.py
@@ -60,6 +60,29 @@ def make_participant(
     )
 
 
+def _inbound_event(
+    conversation_id: str,
+    *,
+    author_address: str,
+    author_participant_id: str,
+    text: str = "hello",
+) -> dict:
+    """A COMMUNICATION_CREATED payload, as Conversation Orchestrator sends it."""
+    return {
+        "id": "comms_communication_01test",
+        "conversationId": conversation_id,
+        "accountId": "ACtest123",
+        "author": {
+            "address": author_address,
+            "channel": "SMS",
+            "participantId": author_participant_id,
+        },
+        "content": {"type": "TEXT", "text": text},
+        "recipients": [],
+        "createdAt": "2026-04-27T00:00:00Z",
+    }
+
+
 def make_action_response(conversation_id: str) -> ActionResponse:
     return ActionResponse(
         id="ACT_test",
@@ -193,7 +216,9 @@ class TestSMSOutbound:
         tac.conversation_orchestrator_client.create_action.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_creates_local_session(self) -> None:
+    async def test_returns_a_session_ready_to_reply_with(self) -> None:
+        """The channel stores nothing — the caller holds the session and hands
+        it back to send_response, which then needs no lookup."""
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
         _mock_sms_outbound(tac)
@@ -202,8 +227,11 @@ class TestSMSOutbound:
             InitiateMessagingConversationOptions(to="+15559876543", message="Hi")
         )
 
-        assert "CHsms_out" in channel._conversations
-        assert channel._conversations["CHsms_out"] is result.session
+        assert result.session.conversation_id == "CHsms_out"
+        assert result.session.author_info is not None
+        assert result.session.author_info.participant_id is not None
+        assert result.session.ai_agent_info is not None
+        assert result.session.ai_agent_info.participant_id is not None
 
     @pytest.mark.asyncio
     async def test_custom_metadata(self) -> None:
@@ -252,7 +280,6 @@ class TestSMSOutbound:
             )
 
         co.update_conversation.assert_not_called()
-        assert "CHreused" not in channel._conversations
 
     @pytest.mark.asyncio
     async def test_closes_new_conversation_on_failure(self) -> None:
@@ -270,7 +297,6 @@ class TestSMSOutbound:
             )
 
         co.update_conversation.assert_called_once_with("CHnew", "CLOSED")
-        assert "CHnew" not in channel._conversations
 
     @pytest.mark.asyncio
     async def test_passes_participants_in_create(self) -> None:
@@ -822,79 +848,59 @@ class TestInitiateVoiceConversationOptionsForbidsExtra:
 
 
 class TestIsOwnMessage:
-    @pytest.mark.asyncio
-    async def test_tier1_default_agent_address(self) -> None:
-        tac = TAC(get_test_config())
-        channel = SMSChannel(tac)
-
-        result = await channel._is_own_message("+15551234567", "CHtest", None)
-        assert result is True
+    """TAC must not reply to itself. The configured agent address catches the
+    common case for free; the participant list catches an agent speaking from
+    some other address."""
 
     @pytest.mark.asyncio
-    async def test_tier2_api_fallback(self) -> None:
+    async def test_default_agent_address_short_circuits_before_any_api_call(self) -> None:
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
+        tac.conversation_orchestrator_client.list_participants = AsyncMock()
+        tac.on_message_ready(lambda msg, ctx, mem: pytest.fail("own message reached the callback"))
 
-        tac.conversation_orchestrator_client.list_participants = AsyncMock(
-            return_value=[
-                make_participant(
-                    id="PAagent_custom",
-                    conversation_id="CHtest",
-                    type="AI_AGENT",
-                    channel="SMS",
-                    address="+15550009999",
-                ),
-            ]
+        await channel._handle_communication_created(
+            _inbound_event("CHtest", author_address="+15551234567", author_participant_id="PAme")
         )
 
-        # No local session — triggers API fallback
-        result = await channel._is_own_message("+15550009999", "CHtest", "PAagent_custom")
-        assert result is True
+        tac.conversation_orchestrator_client.list_participants.assert_not_awaited()
 
-    @pytest.mark.asyncio
-    async def test_returns_false_for_customer(self) -> None:
+    def test_agent_typed_participant_at_another_address_is_us(self) -> None:
+        tac = TAC(get_test_config())
+        channel = SMSChannel(tac)
+        participants = [
+            make_participant(
+                id="PAagent_custom",
+                conversation_id="CHtest",
+                type="AI_AGENT",
+                channel="SMS",
+                address="+15550009999",
+            )
+        ]
+
+        assert channel._is_own_message("PAagent_custom", participants, "CHtest") is True
+
+    def test_customer_participant_is_not_us(self) -> None:
+        tac = TAC(get_test_config())
+        channel = SMSChannel(tac)
+        participants = [
+            make_participant(
+                id="PAcust",
+                conversation_id="CHtest",
+                type="CUSTOMER",
+                channel="SMS",
+                address="+15559876543",
+            )
+        ]
+
+        assert channel._is_own_message("PAcust", participants, "CHtest") is False
+
+    def test_unknown_author_is_not_us(self) -> None:
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
 
-        channel._start_conversation("CHtest")
-
-        result = await channel._is_own_message("+15559876543", "CHtest", None)
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_tier2_fires_when_session_exists(self) -> None:
-        """API fallback fires when author is not the default agent address."""
-        tac = TAC(get_test_config())
-        channel = SMSChannel(tac)
-        tac.conversation_orchestrator_client.list_participants = AsyncMock(
-            return_value=[
-                make_participant(
-                    id="PAsomeid",
-                    conversation_id="CHtest",
-                    type="AI_AGENT",
-                    channel="SMS",
-                    address="+15559999999",
-                ),
-            ]
-        )
-
-        channel._start_conversation("CHtest")
-
-        result = await channel._is_own_message("+15559999999", "CHtest", "PAsomeid")
-        assert result is True
-        tac.conversation_orchestrator_client.list_participants.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_tier2_handles_api_error_gracefully(self) -> None:
-        tac = TAC(get_test_config())
-        channel = SMSChannel(tac)
-
-        tac.conversation_orchestrator_client.list_participants = AsyncMock(
-            side_effect=Exception("API error")
-        )
-
-        result = await channel._is_own_message("+15559999999", "CHtest", "PAsomeid")
-        assert result is False
+        assert channel._is_own_message("PAmissing", [], "CHtest") is False
+        assert channel._is_own_message(None, [], "CHtest") is False
 
 
 # =============================================================================
@@ -909,7 +915,7 @@ class TestChatSendResponseAfterOutbound:
         channel = ChatChannel(tac)
         _mock_chat_outbound(tac)
 
-        await channel.initiate_outbound_conversation(
+        result = await channel.initiate_outbound_conversation(
             InitiateChatConversationOptions(
                 to="customer@example.com",
                 channel_id="CHSIDabc",
@@ -921,7 +927,9 @@ class TestChatSendResponseAfterOutbound:
             return_value=make_action_response("CHchat_out")
         )
 
-        await channel.send_response("CHchat_out", "Follow-up")
+        # Hand back the session initiation returned — it already carries the
+        # channelId chat needs, so the follow-up costs no extra lookup.
+        await channel.send_response(result.session, "Follow-up")
 
         call_args = tac.conversation_orchestrator_client.create_action.call_args
         action_request = call_args.args[1]
@@ -969,7 +977,6 @@ class TestInitiateConversationActionFailure:
             )
 
         co.update_conversation.assert_called_once_with("CHnew_action", "CLOSED")
-        assert "CHnew_action" not in channel._conversations
 
     @pytest.mark.asyncio
     async def test_does_not_close_reused_conversation_on_action_failure(self) -> None:
@@ -1005,7 +1012,6 @@ class TestInitiateConversationActionFailure:
             )
 
         co.update_conversation.assert_not_called()
-        assert "CHreused_action" not in channel._conversations
 
 
 # =============================================================================

--- a/tests/test_participant_reconciliation.py
+++ b/tests/test_participant_reconciliation.py
@@ -4,6 +4,8 @@ Covers the matrix of participant states that v1-bridge capture can leave us
 with. The resolution rules were agreed with the Conversation Orchestrator team.
 """
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -13,6 +15,7 @@ import pytest
 from tac import TAC
 from tac.channels.sms import SMSChannel
 from tac.models.conversation import ParticipantAddress, ParticipantResponse
+from tac.models.session import ConversationSession
 
 
 def _participant(
@@ -35,6 +38,20 @@ def _participant(
             "addresses": [addr],
         }
     )
+
+
+@contextmanager
+def _participants(items: list[ParticipantResponse]) -> Iterator[list[ParticipantResponse]]:
+    """Hand `_reconcile_participants` its (already-fetched) participant list.
+
+    A context manager purely so it reads inline with the `patch.object(...)`
+    entries it replaced — the caller fetches the list now, not reconcile.
+    """
+    yield items
+
+
+def _session(conv_id: str = "CH123") -> ConversationSession:
+    return ConversationSession(conversation_id=conv_id, channel="SMS")
 
 
 def _tac() -> TAC:
@@ -83,14 +100,10 @@ async def test_agent_plus_customer_no_puts() -> None:
     customer = _participant("PA_C", "CUSTOMER", "+12345678901")
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            return_value=[agent, customer],
-        ),
+        _participants([agent, customer]) as participants,
         patch.object(tac.conversation_orchestrator_client, "update_participant") as mock_update,
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is not None
     assert result[0].id == "PA_A"
@@ -110,18 +123,14 @@ async def test_agent_plus_unknown_customer_promotes_customer() -> None:
     promoted = _participant("PA_C", "CUSTOMER", "+12345678901")
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            return_value=[agent, unknown_customer],
-        ),
+        _participants([agent, unknown_customer]) as participants,
         patch.object(
             tac.conversation_orchestrator_client,
             "update_participant",
             new=AsyncMock(return_value=promoted),
         ) as mock_update,
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is not None
     assert result[0].id == "PA_A"
@@ -145,18 +154,14 @@ async def test_unknown_agent_plus_customer_promotes_agent() -> None:
     promoted = _participant("PA_A", "AI_AGENT", "+15551234567")
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            return_value=[unknown_agent, customer],
-        ),
+        _participants([unknown_agent, customer]) as participants,
         patch.object(
             tac.conversation_orchestrator_client,
             "update_participant",
             new=AsyncMock(return_value=promoted),
         ) as mock_update,
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is not None
     assert result[0].id == "PA_A"
@@ -184,18 +189,14 @@ async def test_unknown_agent_plus_unknown_customer_promotes_both() -> None:
         return promoted_agent if kwargs["participant_id"] == "PA_A" else promoted_customer
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            return_value=[unknown_agent, unknown_customer],
-        ),
+        _participants([unknown_agent, unknown_customer]) as participants,
         patch.object(
             tac.conversation_orchestrator_client,
             "update_participant",
             new=AsyncMock(side_effect=update_side_effect),
         ) as mock_update,
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is not None
     assert result[0].type == "AI_AGENT"
@@ -225,15 +226,11 @@ async def test_non_agent_at_our_address_refuses_to_overwrite(
     customer = _participant("PA_C", "CUSTOMER", "+12345678901")
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            return_value=[conflicting, customer],
-        ),
+        _participants([conflicting, customer]) as participants,
         patch.object(tac.conversation_orchestrator_client, "update_participant") as mock_update,
         patch.object(tac.conversation_orchestrator_client, "add_participant") as mock_add,
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is None
     mock_update.assert_not_called()
@@ -250,11 +247,7 @@ async def test_solo_customer_posts_agent() -> None:
     created_agent = _participant("PA_A", "AI_AGENT", "+15551234567")
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            return_value=[customer],
-        ),
+        _participants([customer]) as participants,
         patch.object(
             tac.conversation_orchestrator_client,
             "add_participant",
@@ -262,7 +255,7 @@ async def test_solo_customer_posts_agent() -> None:
         ) as mock_add,
         patch.object(tac.conversation_orchestrator_client, "update_participant") as mock_update,
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is not None
     assert result[0].id == "PA_A"
@@ -292,18 +285,14 @@ async def test_add_agent_409_returns_none() -> None:
     conflict = httpx.HTTPStatusError("409", request=mock_response.request, response=mock_response)
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            new=AsyncMock(return_value=[customer]),
-        ),
+        _participants([customer]) as participants,
         patch.object(
             tac.conversation_orchestrator_client,
             "add_participant",
             new=AsyncMock(side_effect=conflict),
         ) as mock_add,
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is None
     mock_add.assert_awaited_once()
@@ -326,28 +315,41 @@ async def test_promote_409_returns_none() -> None:
     conflict = httpx.HTTPStatusError("409", request=mock_response.request, response=mock_response)
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            new=AsyncMock(return_value=[unknown_agent, customer]),
-        ),
+        _participants([unknown_agent, customer]) as participants,
         patch.object(
             tac.conversation_orchestrator_client,
             "update_participant",
             new=AsyncMock(side_effect=conflict),
         ) as mock_update,
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is None
     mock_update.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_list_participants_failure_returns_none() -> None:
-    """list_participants raising (e.g. Conversation Orchestrator down) skips the webhook."""
+async def test_list_participants_failure_drops_the_inbound_message() -> None:
+    """Conversation Orchestrator being down skips the webhook.
+
+    The fetch lives in `_handle_communication_created` now (one call shared by
+    the self-message check, reconciliation, and profile resolution), so this
+    exercises the whole inbound path rather than reconcile alone.
+    """
     tac = _tac()
     channel = SMSChannel(tac)
+    errors: list[dict] = []
+    tac.on_error(lambda err, ctx: errors.append(ctx))
+
+    webhook_event = {
+        "id": "comms_communication_01test",
+        "conversationId": "CH123",
+        "accountId": "ACtest",
+        "author": {"address": "+12345678901", "channel": "SMS", "participantId": "PA_C"},
+        "content": {"type": "TEXT", "text": "hi"},
+        "recipients": [],
+        "createdAt": "2026-04-27T00:00:00Z",
+    }
 
     with (
         patch.object(
@@ -356,11 +358,13 @@ async def test_list_participants_failure_returns_none() -> None:
             new=AsyncMock(side_effect=httpx.ConnectError("conversation orchestrator unreachable")),
         ),
         patch.object(tac.conversation_orchestrator_client, "update_participant") as mock_update,
+        patch.object(tac, "trigger_message_ready", new=AsyncMock()) as ready,
     ):
-        result = await channel._reconcile_participants("CH123")
+        await channel._handle_communication_created(webhook_event)
 
-    assert result is None
+    ready.assert_not_awaited()
     mock_update.assert_not_called()
+    assert errors and errors[0]["dropped_inbound"] is True
 
 
 @pytest.mark.asyncio
@@ -377,11 +381,7 @@ async def test_customer_promotion_creates_profile_on_lookup_miss() -> None:
     promoted = _participant("PA_C", "CUSTOMER", "+12345678901")
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            return_value=[agent, unknown_customer],
-        ),
+        _participants([agent, unknown_customer]) as participants,
         patch.object(
             tac.conversation_orchestrator_client,
             "update_participant",
@@ -403,7 +403,7 @@ async def test_customer_promotion_creates_profile_on_lookup_miss() -> None:
             new=AsyncMock(return_value="mem_profile_01new"),
         ) as mock_create,
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is not None
     mock_lookup.assert_awaited_once()
@@ -426,11 +426,7 @@ async def test_customer_promotion_proceeds_without_profile_on_errors() -> None:
     promoted = _participant("PA_C", "CUSTOMER", "+12345678901")
 
     with (
-        patch.object(
-            tac.conversation_orchestrator_client,
-            "list_participants",
-            return_value=[agent, unknown_customer],
-        ),
+        _participants([agent, unknown_customer]) as participants,
         patch.object(
             tac.conversation_orchestrator_client,
             "update_participant",
@@ -447,7 +443,7 @@ async def test_customer_promotion_proceeds_without_profile_on_errors() -> None:
             new=AsyncMock(side_effect=httpx.ConnectError("conversation memory down")),
         ),
     ):
-        result = await channel._reconcile_participants("CH123")
+        result = await channel._reconcile_participants(_session(), participants)
 
     assert result is not None
     kwargs = mock_update.await_args.kwargs
@@ -497,9 +493,9 @@ async def test_reconciliation_lifts_customer_profile_onto_session() -> None:
             "list_participants",
             return_value=[agent, customer],
         ),
-        patch.object(tac, "trigger_message_ready", new=AsyncMock(return_value=None)),
+        patch.object(tac, "trigger_message_ready", new=AsyncMock(return_value=None)) as ready,
     ):
         await channel._handle_communication_created(webhook_event)
 
-    session = channel._conversations["CH123"]
+    session = ready.await_args.args[1]
     assert session.profile_id == "mem_profile_01abc"

--- a/tests/test_profile_retrieval.py
+++ b/tests/test_profile_retrieval.py
@@ -313,9 +313,12 @@ class TestProfileInSMSChannel:
         assert received_context.profile.traits["Contact"]["firstName"] == "John"
 
     @pytest.mark.asyncio
-    async def test_sms_profile_cached_across_messages(self) -> None:
-        """Profile is fetched once per session, then cached."""
+    async def test_sms_profile_refetched_per_message(self) -> None:
+        """A stateless session can't cache traits across messages — so each
+        message sees the profile as it is now, not as it was at message one."""
         from unittest.mock import patch
+
+        sessions: list[ConversationSession] = []
 
         config = get_test_config_with_trait_groups()
         tac = TAC(config)
@@ -346,6 +349,7 @@ class TestProfileInSMSChannel:
                 meta=MemoryRetrievalMeta(queryTime=0),
             )
         )
+        tac.on_message_ready(lambda msg, ctx, mem: sessions.append(ctx))
 
         with patch.object(
             tac.conversation_orchestrator_client,
@@ -358,7 +362,7 @@ class TestProfileInSMSChannel:
                     "CH123456", "MB123", "Hello", "2025-11-18T00:00:01.000Z"
                 )
             )
-            session = channel._conversations["CH123456"]
+            session = sessions[-1]
             assert session.profile is not None
             assert session.profile.traits["Contact"]["firstName"] == "John"
 
@@ -368,9 +372,11 @@ class TestProfileInSMSChannel:
                     "CH123456", "MB123", "Hi again", "2025-11-18T00:00:02.000Z"
                 )
             )
-            session = channel._conversations["CH123456"]
-            # Cached → still v1 (John), not re-fetched to v2 (Jane).
-            assert session.profile.traits["Contact"]["firstName"] == "John"
+            session = sessions[-1]
+            # Each message derives its own session, so traits are current
+            # rather than frozen at the conversation's first message.
+            assert session.profile is not None
+            assert session.profile.traits["Contact"]["firstName"] == "Jane"
 
 
 class TestProfileInConversationSession:

--- a/tests/test_rcs_channel.py
+++ b/tests/test_rcs_channel.py
@@ -160,8 +160,7 @@ async def test_conversation_created_webhook(rcs_channel: RCSChannel) -> None:
     # CONVERSATION_CREATED events are ignored (no action needed)
     await rcs_channel.process_webhook(webhook)
 
-    # Conversations are not started until COMMUNICATION_CREATED
-    assert "conv_123" not in rcs_channel._conversations
+    # Nothing to assert on locally — the channel stores no sessions.
 
 
 @pytest.mark.asyncio
@@ -336,8 +335,6 @@ async def test_conversation_updated_closed(rcs_channel: RCSChannel) -> None:
         mock_reconcile.return_value = (mock_agent, mock_customer)
         await rcs_channel.process_webhook(webhook)
 
-    assert conversation_id in rcs_channel._conversations
-
     # Mock the conversation ended callback
     callback_called = False
     callback_context = None
@@ -355,10 +352,15 @@ async def test_conversation_updated_closed(rcs_channel: RCSChannel) -> None:
         timestamp="2025-01-15T10:20:30Z",
     )
 
-    await rcs_channel.process_webhook(close_webhook)
+    with patch.object(
+        rcs_channel.tac.conversation_orchestrator_client,
+        "list_participants",
+        new=AsyncMock(return_value=[mock_agent, mock_customer]),
+    ):
+        await rcs_channel.process_webhook(close_webhook)
 
-    # Verify conversation was ended
-    assert conversation_id not in rcs_channel._conversations
+    # The session handed to the callback is rebuilt from Conversation
+    # Orchestrator, so it fires on any instance — not just this one.
     assert callback_called
     assert callback_context.conversation_id == conversation_id
 

--- a/tests/test_sms_channel.py
+++ b/tests/test_sms_channel.py
@@ -7,6 +7,7 @@ import pytest
 
 from tac import TAC
 from tac.channels.sms import SMSChannel
+from tac.models.conversation import ParticipantAddress, ParticipantResponse
 from tac.models.memory import MemoryRetrievalMeta, MemoryRetrievalResponse
 from tac.models.session import AuthorInfo, ConversationSession
 from tac.models.tac import TACMemoryResponse
@@ -88,6 +89,45 @@ def create_conversation_updated_webhook(
             "configuration": {"intelligenceServiceIds": []},
         },
     }
+
+
+def participant(
+    pid: str,
+    ptype: str,
+    address: str,
+    conv_id: str = "CH123456",
+    profile_id: str | None = None,
+) -> ParticipantResponse:
+    return ParticipantResponse(
+        id=pid,
+        conversation_id=conv_id,
+        account_id="ACtest123",
+        name=address,
+        type=ptype,  # type: ignore[arg-type]
+        profile_id=profile_id,
+        addresses=[ParticipantAddress(channel="SMS", address=address)],
+    )
+
+
+def sms_participants(
+    conv_id: str = "CH123456", profile_id: str | None = None
+) -> list[ParticipantResponse]:
+    """The agent + customer pair Conversation Orchestrator holds for a healthy conversation."""
+    return [
+        participant("PA_AGENT", "AI_AGENT", "+15551234567", conv_id),
+        participant("PA_CUSTOMER", "CUSTOMER", "+12345678901", conv_id, profile_id),
+    ]
+
+
+def reconciled_session(conv_id: str = "CH123456", **kwargs: Any) -> ConversationSession:
+    """A session shaped the way an inbound webhook leaves it."""
+    return ConversationSession(
+        conversation_id=conv_id,
+        channel="SMS",
+        author_info=AuthorInfo(address="+12345678901", participant_id="PA_CUSTOMER"),
+        ai_agent_info=AuthorInfo(address="+15551234567", participant_id="PA_AGENT"),
+        **kwargs,
+    )
 
 
 def get_test_config(with_memory: bool = True) -> dict[str, Any]:
@@ -321,23 +361,20 @@ class TestSMSChannel:
 
     @pytest.mark.asyncio
     async def test_process_conversation_ended(self) -> None:
-        """Test processing onConversationRemoved event."""
+        """CLOSED with no handler registered is a no-op — and costs no API call."""
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
 
-        channel._conversations["CH123456"] = ConversationSession(
-            conversation_id="CH123456",
-            channel="SMS",
-            profile_id="profile_test_123",
-        )
-
-        # End conversation (status changed to CLOSED)
         end_webhook = create_conversation_updated_webhook(
             "CH123456", "CLOSED", "2025-11-18T00:10:00.000Z"
         )
 
-        # Should not raise
-        await channel.process_webhook(end_webhook)
+        with patch.object(
+            tac.conversation_orchestrator_client, "list_participants", new=AsyncMock()
+        ) as mock_list:
+            await channel.process_webhook(end_webhook)
+
+        mock_list.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_send_response_with_active_conversation(self) -> None:
@@ -345,18 +382,12 @@ class TestSMSChannel:
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
 
-        # Session is pre-populated as if reconcile (or outbound initiation) ran.
-        channel._conversations["CH123456"] = ConversationSession(
-            conversation_id="CH123456",
-            channel="SMS",
-            author_info=AuthorInfo(address="+12345678901", participant_id="PA_CUSTOMER"),
-            ai_agent_info=AuthorInfo(address="+15551234567", participant_id="PA_AGENT"),
-        )
+        session = reconciled_session()
 
         with patch.object(
             tac.conversation_orchestrator_client, "create_action"
         ) as mock_create_action:
-            await channel.send_response("CH123456", "Test response")
+            await channel.send_response(session, "Test response")
 
             # Verify create_action was called
             mock_create_action.assert_called_once()
@@ -384,20 +415,12 @@ class TestSMSChannel:
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
 
-        # Seed a session with participant ids + channel_id in metadata
-        # (as inbound ingestion + reconcile would).
-        channel._conversations["CH_WITH_CH_ID"] = ConversationSession(
-            conversation_id="CH_WITH_CH_ID",
-            channel="SMS",
-            author_info=AuthorInfo(address="+12345678901", participant_id="PA_CUSTOMER"),
-            ai_agent_info=AuthorInfo(address="+15551234567", participant_id="PA_AGENT"),
-            metadata={"channel_id": "SMabcdef"},
-        )
+        session = reconciled_session("CH_WITH_CH_ID", metadata={"channel_id": "SMabcdef"})
 
         with patch.object(
             tac.conversation_orchestrator_client, "create_action"
         ) as mock_create_action:
-            await channel.send_response("CH_WITH_CH_ID", "Test response")
+            await channel.send_response(session, "Test response")
 
             mock_create_action.assert_called_once()
             request = mock_create_action.call_args[0][1]
@@ -405,30 +428,23 @@ class TestSMSChannel:
             assert request.payload.channel_settings.channel_id == "SMabcdef"
 
     @pytest.mark.asyncio
-    async def test_multiple_concurrent_conversations(self) -> None:
-        """Test handling multiple concurrent conversations."""
+    async def test_closing_one_conversation_does_not_affect_another(self) -> None:
+        """Nothing is shared between conversations, because nothing is stored."""
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
+        ended: list[str] = []
+        tac.on_conversation_ended(lambda ctx: ended.append(ctx.conversation_id))
 
-        channel._conversations["CH111"] = ConversationSession(
-            conversation_id="CH111", channel="SMS", profile_id="PR111"
-        )
-        channel._conversations["CH222"] = ConversationSession(
-            conversation_id="CH222", channel="SMS", profile_id="PR222"
-        )
+        with patch.object(
+            tac.conversation_orchestrator_client,
+            "list_participants",
+            new=AsyncMock(side_effect=lambda conv_id: sms_participants(conv_id)),
+        ):
+            await channel.process_webhook(
+                create_conversation_updated_webhook("CH111", "CLOSED", "2025-11-18T00:10:00.000Z")
+            )
 
-        # Verify both conversations tracked.
-        assert "CH111" in channel._conversations
-        assert "CH222" in channel._conversations
-
-        # End first conversation (should not raise)
-        await channel.process_webhook(
-            create_conversation_updated_webhook("CH111", "CLOSED", "2025-11-18T00:10:00.000Z")
-        )
-
-        # Verify first conversation was removed
-        assert "CH111" not in channel._conversations
-        assert "CH222" in channel._conversations
+        assert ended == ["CH111"]
 
     @pytest.mark.asyncio
     async def test_ignores_unsupported_event_types(self) -> None:
@@ -457,23 +473,25 @@ class TestSMSChannel:
 
         tac.on_conversation_ended(handler)
 
-        channel._conversations["CH_CB1"] = ConversationSession(
-            conversation_id="CH_CB1", channel="SMS", profile_id="prof_cb1"
-        )
-
-        # Close conversation
-        await channel.process_webhook(
-            create_conversation_updated_webhook("CH_CB1", "CLOSED", "2025-11-18T00:10:00.000Z")
-        )
+        with patch.object(
+            tac.conversation_orchestrator_client,
+            "list_participants",
+            new=AsyncMock(return_value=sms_participants("CH_CB1", profile_id="prof_cb1")),
+        ):
+            await channel.process_webhook(
+                create_conversation_updated_webhook("CH_CB1", "CLOSED", "2025-11-18T00:10:00.000Z")
+            )
 
         assert len(captured) == 1
         assert captured[0].conversation_id == "CH_CB1"
         assert captured[0].profile_id == "prof_cb1"
         assert captured[0].channel == "SMS"
+        assert captured[0].author_info is not None
+        assert captured[0].author_info.address == "+12345678901"
 
     @pytest.mark.asyncio
-    async def test_conversation_ended_callback_error_does_not_prevent_cleanup(self) -> None:
-        """If on_conversation_ended callback raises, the session is still cleaned up."""
+    async def test_conversation_ended_callback_error_does_not_fail_the_webhook(self) -> None:
+        """A raising handler is logged, not propagated into the webhook response."""
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
 
@@ -482,15 +500,14 @@ class TestSMSChannel:
 
         tac.on_conversation_ended(bad_handler)
 
-        channel._conversations["CH_CB2"] = ConversationSession(
-            conversation_id="CH_CB2", channel="SMS", profile_id="prof_cb2"
-        )
-        await channel.process_webhook(
-            create_conversation_updated_webhook("CH_CB2", "CLOSED", "2025-11-18T00:10:00.000Z")
-        )
-
-        # Session should still be cleaned up despite the error
-        assert "CH_CB2" not in channel._conversations
+        with patch.object(
+            tac.conversation_orchestrator_client,
+            "list_participants",
+            new=AsyncMock(return_value=sms_participants("CH_CB2")),
+        ):
+            await channel.process_webhook(
+                create_conversation_updated_webhook("CH_CB2", "CLOSED", "2025-11-18T00:10:00.000Z")
+            )
 
     @pytest.mark.asyncio
     async def test_conversation_ended_async_callback(self) -> None:
@@ -504,12 +521,16 @@ class TestSMSChannel:
 
         tac.on_conversation_ended(async_handler)
 
-        channel._conversations["CH_ASYNC1"] = ConversationSession(
-            conversation_id="CH_ASYNC1", channel="SMS", profile_id="prof_async1"
-        )
-        await channel.process_webhook(
-            create_conversation_updated_webhook("CH_ASYNC1", "CLOSED", "2025-11-18T00:10:00.000Z")
-        )
+        with patch.object(
+            tac.conversation_orchestrator_client,
+            "list_participants",
+            new=AsyncMock(return_value=sms_participants("CH_ASYNC1")),
+        ):
+            await channel.process_webhook(
+                create_conversation_updated_webhook(
+                    "CH_ASYNC1", "CLOSED", "2025-11-18T00:10:00.000Z"
+                )
+            )
 
         assert len(captured) == 1
         assert captured[0].conversation_id == "CH_ASYNC1"
@@ -517,36 +538,33 @@ class TestSMSChannel:
 
     @pytest.mark.asyncio
     async def test_conversation_ended_no_callback_registered(self) -> None:
-        """Closing a conversation without a registered callback cleans up silently."""
+        """No handler → fast exit, no rebuild, no API call."""
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
 
-        # No callback registered — should not raise
-        channel._conversations["CH_NOCB"] = ConversationSession(
-            conversation_id="CH_NOCB", channel="SMS", profile_id="prof_nocb"
-        )
-        await channel.process_webhook(
-            create_conversation_updated_webhook("CH_NOCB", "CLOSED", "2025-11-18T00:10:00.000Z")
-        )
+        with patch.object(
+            tac.conversation_orchestrator_client, "list_participants", new=AsyncMock()
+        ) as mock_list:
+            await channel.process_webhook(
+                create_conversation_updated_webhook("CH_NOCB", "CLOSED", "2025-11-18T00:10:00.000Z")
+            )
 
-        assert "CH_NOCB" not in channel._conversations
+        mock_list.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_send_response_raises_when_no_customer_on_sms(self) -> None:
-        """If the session has no author_info, send_response raises — reconcile
-        (or outbound initiation) must stash both participant ids first."""
+        """A session with no recipient can't be replied to — say so, don't guess."""
         tac = TAC(get_test_config())
         channel = SMSChannel(tac)
 
-        # ai_agent_info is set, but author_info is missing — misuse.
-        channel._conversations["CH123456"] = ConversationSession(
+        session = ConversationSession(
             conversation_id="CH123456",
             channel="SMS",
             ai_agent_info=AuthorInfo(address="+15551234567", participant_id="PA_AGENT"),
         )
 
-        with pytest.raises(RuntimeError, match="without a reconciled session"):
-            await channel.send_response("CH123456", "Reply")
+        with pytest.raises(RuntimeError, match="no recipient resolved"):
+            await channel.send_response(session, "Reply")
 
     @pytest.mark.asyncio
     async def test_ignores_chat_messages(self) -> None:

--- a/tests/test_voice_channel.py
+++ b/tests/test_voice_channel.py
@@ -18,6 +18,7 @@ from tac.models.voice import (
     SetupMessage,
     VoiceTwiMLOptionsConversationRelay,
 )
+from tests.voice_invariants import assert_no_residual_state
 
 
 def get_test_config() -> dict:
@@ -314,28 +315,20 @@ class TestVoiceChannel:
         await channel.send_response("CALL123", "Hello there")
 
     @pytest.mark.asyncio
-    async def test_end_conversation_cleanup(self) -> None:
-        """Test ending conversation cleans up WebSocket but keeps conversation tracked."""
+    async def test_cleanup_connection_releases_everything(self) -> None:
+        """Disconnect frees every local resource — nothing waits on a webhook."""
         tac = TAC(get_test_config())
         channel = VoiceChannel(tac)
 
-        # Start conversation directly
         channel._start_conversation("CALL123", "profile_test")
+        channel._provider._websocket_manager.add_websocket("CALL123", MagicMock())
 
-        # Add a mock websocket to the manager
-        mock_websocket = MagicMock()
-        channel._provider._websocket_manager.add_websocket("CALL123", mock_websocket)
-
-        # Verify websocket is registered
         assert channel._provider._websocket_manager.has_websocket("CALL123")
         assert "CALL123" in channel._conversations
 
-        # Clean up connection (WebSocket only)
         await channel._provider._cleanup_connection("CALL123")
 
-        # Verify WebSocket cleanup but conversation still tracked
-        assert not channel._provider._websocket_manager.has_websocket("CALL123")
-        assert "CALL123" in channel._conversations
+        assert_no_residual_state(channel, "CALL123")
 
     @pytest.mark.asyncio
     async def test_process_webhook_conversation_closed(self) -> None:
@@ -350,7 +343,11 @@ class TestVoiceChannel:
         # Process CONVERSATION_UPDATED with CLOSED status
         webhook_data = {
             "eventType": "CONVERSATION_UPDATED",
-            "data": {"id": "CONV123", "status": "CLOSED"},
+            "data": {
+                "id": "CONV123",
+                "status": "CLOSED",
+                "configurationId": "conv_configuration_test123",
+            },
         }
         await channel.process_webhook(webhook_data)
 
@@ -378,7 +375,11 @@ class TestVoiceChannel:
         # Process CONVERSATION_UPDATED with INACTIVE status
         webhook_data = {
             "eventType": "CONVERSATION_UPDATED",
-            "data": {"id": "CONV123", "status": "INACTIVE"},
+            "data": {
+                "id": "CONV123",
+                "status": "INACTIVE",
+                "configurationId": "conv_configuration_test123",
+            },
         }
         await channel.process_webhook(webhook_data)
 
@@ -398,7 +399,11 @@ class TestVoiceChannel:
         # Process CONVERSATION_UPDATED for unknown conversation
         webhook_data = {
             "eventType": "CONVERSATION_UPDATED",
-            "data": {"id": "CONV_UNKNOWN", "status": "CLOSED"},
+            "data": {
+                "id": "CONV_UNKNOWN",
+                "status": "CLOSED",
+                "configurationId": "conv_configuration_test123",
+            },
         }
         await channel.process_webhook(webhook_data)
 
@@ -778,28 +783,24 @@ class TestVoiceChannel:
         assert len(channel._conversations) == 3
         assert len(channel._provider._websocket_manager) == 3
 
-        # Clean up CALL_B WebSocket only
+        # Clean up CALL_B only
         await channel._provider._cleanup_connection("CALL_B")
 
-        # Verify CALL_B WebSocket is cleaned up but conversation still tracked
-        assert not channel._provider._websocket_manager.has_websocket("CALL_B")
-        assert "CALL_B" in channel._conversations
-        assert len(channel._conversations) == 3
+        assert_no_residual_state(channel, "CALL_B")
+        assert len(channel._conversations) == 2
         assert len(channel._provider._websocket_manager) == 2
 
-        # Verify CALL_A and CALL_C are still active
+        # Verify CALL_A and CALL_C are untouched
         assert "CALL_A" in channel._conversations
         assert "CALL_C" in channel._conversations
         assert channel._provider._websocket_manager.has_websocket("CALL_A")
         assert channel._provider._websocket_manager.has_websocket("CALL_C")
 
-        # Clean up remaining WebSockets
         await channel._provider._cleanup_connection("CALL_A")
         await channel._provider._cleanup_connection("CALL_C")
 
-        # Verify WebSockets cleaned up but conversations still tracked
         assert len(channel._provider._websocket_manager) == 0
-        assert len(channel._conversations) == 3
+        assert len(channel._conversations) == 0
 
     @pytest.mark.asyncio
     async def test_websocket_manager_get_all_conversation_ids(self) -> None:
@@ -980,29 +981,51 @@ class TestVoiceChannel:
 
         await channel._provider._cleanup_connection("CALL_CB1")
 
-        # Callback should NOT be called (conversation still tracked for webhook)
+        # In orchestrated mode the *conversation* isn't over yet — Conversation
+        # Orchestrator's CLOSED webhook owns that hook — but the call is, so
+        # local state is gone.
         assert len(captured) == 0
-        # Conversation should still be tracked
-        assert "CALL_CB1" in channel._conversations
-        # WebSocket should be removed
-        assert not channel._provider._websocket_manager.has_websocket("CALL_CB1")
+        assert_no_residual_state(channel, "CALL_CB1")
 
     @pytest.mark.asyncio
-    async def test_cleanup_connection_removes_websocket_only(self) -> None:
-        """_cleanup_connection removes WebSocket but keeps conversation tracked."""
+    async def test_call_ended_fires_with_the_live_session_on_cleanup(self) -> None:
+        """on_call_ended fires at teardown in orchestrated mode, with the session."""
         tac = TAC(get_test_config())
         channel = VoiceChannel(tac)
+        captured: list[ConversationSession] = []
 
-        channel._start_conversation("CALL_CB2", "prof_cb2")
-        mock_ws = MagicMock()
-        channel._provider._websocket_manager.add_websocket("CALL_CB2", mock_ws)
+        async def on_call_ended(session: ConversationSession) -> None:
+            captured.append(session)
+
+        channel.on_call_ended(on_call_ended)
+
+        session = channel._start_conversation("CALL_CB2", "prof_cb2")
+        session.call_sid = "CA_CB2"
+        session.metadata["transcript"] = [{"role": "user", "text": "hi"}]
+        channel._provider._websocket_manager.add_websocket("CALL_CB2", MagicMock())
 
         await channel._provider._cleanup_connection("CALL_CB2")
 
-        # Conversation still tracked (waiting for webhook)
-        assert "CALL_CB2" in channel._conversations
-        # WebSocket removed
-        assert not channel._provider._websocket_manager.has_websocket("CALL_CB2")
+        assert len(captured) == 1
+        assert captured[0] is session
+        assert captured[0].call_sid == "CA_CB2"
+        assert captured[0].metadata["transcript"] == [{"role": "user", "text": "hi"}]
+        assert_no_residual_state(channel, "CALL_CB2")
+
+    @pytest.mark.asyncio
+    async def test_call_ended_handler_error_does_not_block_teardown(self) -> None:
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+
+        async def boom(session: ConversationSession) -> None:
+            raise RuntimeError("handler exploded")
+
+        channel.on_call_ended(boom)
+        channel._start_conversation("CALL_BOOM", None)
+
+        await channel._provider._cleanup_connection("CALL_BOOM")
+
+        assert_no_residual_state(channel, "CALL_BOOM")
 
     @pytest.mark.asyncio
     async def test_webhook_triggers_conversation_ended_callback(self) -> None:
@@ -1021,7 +1044,11 @@ class TestVoiceChannel:
         # Process webhook with CLOSED status
         webhook_data = {
             "eventType": "CONVERSATION_UPDATED",
-            "data": {"id": "CALL_ASYNC1", "status": "CLOSED"},
+            "data": {
+                "id": "CALL_ASYNC1",
+                "status": "CLOSED",
+                "configurationId": "conv_configuration_test123",
+            },
         }
         await channel.process_webhook(webhook_data)
 
@@ -1043,12 +1070,10 @@ class TestVoiceChannel:
         channel._provider._websocket_manager.add_websocket("CALL_NOCB", mock_ws)
 
         await channel._provider._cleanup_connection("CALL_NOCB")
-        # Second cleanup should be a no-op (websocket already removed)
+        # Second cleanup should be a no-op (everything already released)
         await channel._provider._cleanup_connection("CALL_NOCB")
 
-        # Conversation still tracked (only webhook removes it)
-        assert "CALL_NOCB" in channel._conversations
-        assert not channel._provider._websocket_manager.has_websocket("CALL_NOCB")
+        assert_no_residual_state(channel, "CALL_NOCB")
 
     @pytest.mark.asyncio
     async def test_task_cancellation_with_unified_workflow(self) -> None:
@@ -2207,11 +2232,8 @@ class TestConversationInitializationFlow:
         the caller's first utterance instead of adding to it.
 
         If the call disconnects before any prompt arrives to claim the
-        result, the websocket the lookup already registered (as a side
-        effect of `_initialize_conversation`) must still be cleaned up, not
-        leaked. (The conversation itself intentionally stays in
-        `_conversations` until CO's CLOSED webhook, same as any other
-        orchestrator-mode call — see `_cleanup_connection`.)
+        result, everything the lookup already registered (as a side effect of
+        `_initialize_conversation`) must still be cleaned up, not leaked.
         """
         from tac.channels.websocket_protocol import WebSocketDisconnectError
         from tac.models.conversation import ParticipantAddress, ParticipantResponse
@@ -2268,12 +2290,9 @@ class TestConversationInitializationFlow:
         )
         co_client.list_participants.assert_called_once_with("CH_setup_test")
 
-        # The websocket registration is cleaned up (not leaked) even though
-        # no prompt ever arrived to claim conv_id itself.
-        assert not channel._provider._websocket_manager.has_websocket("CH_setup_test")
-        # The conversation entry legitimately stays until CO's CLOSED
-        # webhook — same as any other orchestrator-mode call.
-        assert list(channel._conversations.keys()) == ["CH_setup_test"]
+        # Everything the lookup registered is cleaned up (not leaked) even
+        # though no prompt ever arrived to claim conv_id itself.
+        assert_no_residual_state(channel, "CH_setup_test")
 
     @pytest.mark.asyncio
     async def test_subsequent_prompts_reuse_conversation(self) -> None:
@@ -2705,13 +2724,13 @@ class TestEndCall:
         # Simulate an active orchestrator-mode session (conv id != call sid).
         session = channel._start_conversation("conv_abc")
         session.call_sid = "CA1"
-        channel._end_conversation = AsyncMock()  # type: ignore[method-assign]
+        channel._release_session = AsyncMock()  # type: ignore[method-assign]
 
         mock_client = MagicMock()
         with patch.object(channel, "_get_twilio_client", return_value=mock_client):
             await channel.end_call("CA1")
 
-        channel._end_conversation.assert_awaited_once_with("conv_abc")
+        channel._release_session.assert_awaited_once_with("conv_abc")
 
     @pytest.mark.asyncio
     async def test_hangup_failure_returns_false_without_raising(self) -> None:
@@ -2730,28 +2749,28 @@ class TestEndCall:
         channel = VoiceChannel(tac)
         session = channel._start_conversation("conv_abc")
         session.call_sid = "CA1"
-        channel._end_conversation = AsyncMock()  # type: ignore[method-assign]
+        channel._release_session = AsyncMock()  # type: ignore[method-assign]
 
         mock_client = MagicMock()
         mock_client.calls("CA1").update.side_effect = RuntimeError("Twilio 400")
         with patch.object(channel, "_get_twilio_client", return_value=mock_client):
             assert await channel.end_call("CA1") is False
 
-        channel._end_conversation.assert_awaited_once_with("conv_abc")
+        channel._release_session.assert_awaited_once_with("conv_abc")
 
     @pytest.mark.asyncio
     async def test_hangup_works_without_tracked_session(self) -> None:
         """A machine may never prompt (no session); the hangup must still work."""
         tac = TAC(get_test_config())
         channel = VoiceChannel(tac)
-        channel._end_conversation = AsyncMock()  # type: ignore[method-assign]
+        channel._release_session = AsyncMock()  # type: ignore[method-assign]
 
         mock_client = MagicMock()
         with patch.object(channel, "_get_twilio_client", return_value=mock_client):
             assert await channel.end_call("CA_unknown") is True
 
         mock_client.calls().update.assert_called_with(status="completed")
-        channel._end_conversation.assert_not_awaited()
+        channel._release_session.assert_not_awaited()
 
 
 class TestGetConversationSessionByCallSid:

--- a/tests/test_voice_scaling.py
+++ b/tests/test_voice_scaling.py
@@ -1,0 +1,569 @@
+"""Voice behaviour that horizontal scaling depends on.
+
+Three things have to hold for N replicas behind a load balancer:
+
+1. A call's WebSocket closing frees **everything** local, on every path.
+2. ``on_conversation_ended`` fires on whichever instance Conversation
+   Orchestrator's CLOSED webhook happens to reach, even one that never saw
+   the call.
+3. Shutdown drains live calls instead of dropping them silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tac import TAC
+from tac.channels.voice import VoiceChannel
+from tac.channels.voice.conversation_relay import ConversationRelayProviderConfig
+from tac.channels.websocket_protocol import WebSocketDisconnectError
+from tac.models.conversation import ParticipantAddress, ParticipantResponse
+from tac.models.session import ConversationSession
+from tac.session import ThreadSafeSessionManager
+from tests.voice_invariants import assert_no_residual_state
+
+CONFIGURATION_ID = "conv_configuration_test123"
+
+
+def get_test_config(**overrides: Any) -> dict:
+    config = {
+        "account_sid": "ACtest123",
+        "auth_token": "test_token_123",
+        "api_key": "SK123",
+        "api_secret": "test_api_token",
+        "conversation_configuration_id": CONFIGURATION_ID,
+        "phone_number": "+15551234567",
+        "voice_public_domain": "example.com",
+    }
+    config.update(overrides)
+    return config
+
+
+def closed_webhook(conv_id: str, call_sid: str | None = None) -> dict:
+    data: dict[str, Any] = {
+        "id": conv_id,
+        "status": "CLOSED",
+        "configurationId": CONFIGURATION_ID,
+    }
+    if call_sid is not None:
+        data["channelId"] = call_sid
+    return {"eventType": "CONVERSATION_UPDATED", "data": data}
+
+
+def collect(sink: list[ConversationSession]) -> Any:
+    """An async handler that records the session it's given."""
+
+    async def handler(session: ConversationSession) -> None:
+        sink.append(session)
+
+    return handler
+
+
+def voice_participants(conv_id: str) -> list[ParticipantResponse]:
+    """A realistic post-call participant set: customer + TAC's AI_AGENT."""
+    return [
+        ParticipantResponse(
+            id="PA_customer",
+            conversation_id=conv_id,
+            account_id="ACtest123",
+            name="Caller",
+            type="CUSTOMER",
+            profile_id="profile_caller",
+            addresses=[ParticipantAddress(channel="VOICE", address="+15559998888")],
+        ),
+        ParticipantResponse(
+            id="PA_agent",
+            conversation_id=conv_id,
+            account_id="ACtest123",
+            name="TAC Agent",
+            type="AI_AGENT",
+            addresses=[ParticipantAddress(channel="VOICE", address="+15551234567")],
+        ),
+    ]
+
+
+class TestHookSplit:
+    """``on_call_ended`` is the call; ``on_conversation_ended`` is the conversation."""
+
+    @pytest.mark.asyncio
+    async def test_orchestrated_teardown_fires_call_ended_only(self) -> None:
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        call_ended: list[ConversationSession] = []
+        conversation_ended: list[ConversationSession] = []
+
+        channel.on_call_ended(collect(call_ended))
+        tac.on_conversation_ended(lambda s: conversation_ended.append(s))
+
+        channel._start_conversation("conv_1", "profile_caller")
+        await channel._provider._cleanup_connection("conv_1")
+
+        assert [s.conversation_id for s in call_ended] == ["conv_1"]
+        assert conversation_ended == []
+        assert_no_residual_state(channel, "conv_1")
+
+    @pytest.mark.asyncio
+    async def test_relay_only_teardown_fires_both(self) -> None:
+        """No Conversation Orchestrator conversation exists, so nothing will
+        close it later — the channel must fire both hooks itself."""
+        tac = TAC(get_test_config(conversation_configuration_id=None))
+        channel = VoiceChannel(tac)
+        call_ended: list[ConversationSession] = []
+        conversation_ended: list[ConversationSession] = []
+
+        channel.on_call_ended(collect(call_ended))
+        tac.on_conversation_ended(lambda s: conversation_ended.append(s))
+
+        channel._start_conversation("CA_relay", None)
+        await channel._provider._cleanup_connection("CA_relay")
+
+        assert [s.conversation_id for s in call_ended] == ["CA_relay"]
+        assert [s.conversation_id for s in conversation_ended] == ["CA_relay"]
+        assert_no_residual_state(channel, "CA_relay")
+
+    @pytest.mark.asyncio
+    async def test_call_ended_carries_state_the_rebuild_cannot(self) -> None:
+        """The transcript only exists in memory — this hook is its last chance."""
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        captured: list[ConversationSession] = []
+
+        channel.on_call_ended(collect(captured))
+
+        session = channel._start_conversation("conv_2", None)
+        session.call_sid = "CA_2"
+        session.metadata["transcript"] = [{"role": "user", "text": "hello"}]
+
+        await channel._provider._cleanup_connection("conv_2")
+
+        assert captured[0].metadata["transcript"] == [{"role": "user", "text": "hello"}]
+        assert captured[0].call_sid == "CA_2"
+
+
+class TestStatelessConversationClosed:
+    """CLOSED must work on an instance that never held the call (§7.3)."""
+
+    @pytest.mark.asyncio
+    async def test_fires_on_an_instance_that_never_saw_the_call(self) -> None:
+        tac_a = TAC(get_test_config())
+        tac_b = TAC(get_test_config())
+        instance_a = VoiceChannel(tac_a)
+        instance_b = VoiceChannel(tac_b)
+
+        ended: list[ConversationSession] = []
+        tac_b.on_conversation_ended(lambda s: ended.append(s))
+
+        # Instance A takes the call and tears it down when the caller hangs up.
+        instance_a._start_conversation("conv_shared", "profile_caller")
+        await instance_a._provider._cleanup_connection("conv_shared")
+
+        # CO's CLOSED webhook lands on B, which has never seen this call.
+        tac_b.conversation_orchestrator_client.list_participants = AsyncMock(
+            return_value=voice_participants("conv_shared")
+        )
+        await instance_b.process_webhook(closed_webhook("conv_shared", call_sid="CA_shared"))
+
+        assert len(ended) == 1
+        rebuilt = ended[0]
+        assert rebuilt.conversation_id == "conv_shared"
+        assert rebuilt.call_sid == "CA_shared"
+        assert rebuilt.profile_id == "profile_caller"
+        assert rebuilt.author_info is not None
+        assert rebuilt.author_info.address == "+15559998888"
+        assert rebuilt.ai_agent_info is not None
+        assert rebuilt.ai_agent_info.participant_id == "PA_agent"
+
+    @pytest.mark.asyncio
+    async def test_fires_once_after_local_teardown_on_the_same_instance(self) -> None:
+        """The common single-instance path: teardown, then CLOSED arrives here."""
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        ended: list[ConversationSession] = []
+        tac.on_conversation_ended(lambda s: ended.append(s))
+
+        channel._start_conversation("conv_3", None)
+        await channel._provider._cleanup_connection("conv_3")
+        assert ended == []
+
+        tac.conversation_orchestrator_client.list_participants = AsyncMock(
+            return_value=voice_participants("conv_3")
+        )
+        await channel.process_webhook(closed_webhook("conv_3"))
+
+        assert len(ended) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_callback_registered_costs_no_api_call(self) -> None:
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        list_participants = AsyncMock(return_value=voice_participants("conv_4"))
+        tac.conversation_orchestrator_client.list_participants = list_participants
+
+        await channel.process_webhook(closed_webhook("conv_4"))
+
+        list_participants.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ignores_a_conversation_with_no_voice_participant(self) -> None:
+        """A CHAT conversation closing must not fire the voice channel's hook."""
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        ended: list[ConversationSession] = []
+        tac.on_conversation_ended(lambda s: ended.append(s))
+
+        tac.conversation_orchestrator_client.list_participants = AsyncMock(
+            return_value=[
+                ParticipantResponse(
+                    id="PA_chat",
+                    conversation_id="conv_chat",
+                    account_id="ACtest123",
+                    name="Chat User",
+                    type="CUSTOMER",
+                    addresses=[ParticipantAddress(channel="CHAT", address="user-1")],
+                )
+            ]
+        )
+        await channel.process_webhook(closed_webhook("conv_chat"))
+
+        assert ended == []
+
+    @pytest.mark.asyncio
+    async def test_ignores_another_configurations_conversation(self) -> None:
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        ended: list[ConversationSession] = []
+        tac.on_conversation_ended(lambda s: ended.append(s))
+        list_participants = AsyncMock(return_value=voice_participants("conv_other"))
+        tac.conversation_orchestrator_client.list_participants = list_participants
+
+        webhook = closed_webhook("conv_other")
+        webhook["data"]["configurationId"] = "conv_configuration_someone_else"
+        await channel.process_webhook(webhook)
+
+        assert ended == []
+        list_participants.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_participant_lookup_failure_is_survivable(self) -> None:
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        ended: list[ConversationSession] = []
+        tac.on_conversation_ended(lambda s: ended.append(s))
+        tac.conversation_orchestrator_client.list_participants = AsyncMock(
+            side_effect=RuntimeError("CO unreachable")
+        )
+
+        await channel.process_webhook(closed_webhook("conv_5"))
+
+        assert ended == []
+
+    @pytest.mark.asyncio
+    async def test_relay_only_closed_webhook_does_not_double_fire(self) -> None:
+        """Relay-only already fired at teardown; a CLOSED must not fire again."""
+        tac = TAC(get_test_config(conversation_configuration_id=None))
+        channel = VoiceChannel(tac)
+        ended: list[ConversationSession] = []
+        tac.on_conversation_ended(lambda s: ended.append(s))
+
+        channel._start_conversation("CA_relay2", None)
+        await channel._provider._cleanup_connection("CA_relay2")
+        assert len(ended) == 1
+
+        await channel.process_webhook(closed_webhook("CA_relay2"))
+
+        assert len(ended) == 1
+
+
+class TestTeardownInvariant:
+    """No failure mode may leave residue behind (§3.2)."""
+
+    @staticmethod
+    def _channel() -> VoiceChannel:
+        return VoiceChannel(
+            TAC(get_test_config(conversation_configuration_id=None)),
+            config=ConversationRelayProviderConfig(session_manager=ThreadSafeSessionManager()),
+        )
+
+    @staticmethod
+    def _websocket(messages: list[dict], *, error: Exception | None = None) -> Any:
+        """A websocket yielding ``messages`` then raising ``error`` (disconnect by default)."""
+        queue = list(messages)
+        ws = AsyncMock()
+
+        async def receive_json() -> dict:
+            if queue:
+                return queue.pop(0)
+            raise error or WebSocketDisconnectError()
+
+        ws.receive_json = receive_json
+        return ws
+
+    @pytest.mark.asyncio
+    async def test_normal_hangup(self) -> None:
+        channel = self._channel()
+        await channel.handle_websocket(
+            self._websocket(
+                [
+                    {"type": "setup", "callSid": "CA_a", "from": "+15559998888"},
+                    {"type": "prompt", "voicePrompt": "hi", "final": True},
+                ]
+            )
+        )
+        assert_no_residual_state(channel, "CA_a")
+
+    @pytest.mark.asyncio
+    async def test_disconnect_before_any_prompt(self) -> None:
+        channel = self._channel()
+        await channel.handle_websocket(
+            self._websocket([{"type": "setup", "callSid": "CA_b", "from": "+15559998888"}])
+        )
+        assert_no_residual_state(channel, "CA_b")
+
+    @pytest.mark.asyncio
+    async def test_abrupt_error_mid_stream(self) -> None:
+        channel = self._channel()
+        await channel.handle_websocket(
+            self._websocket(
+                [
+                    {"type": "setup", "callSid": "CA_c", "from": "+15559998888"},
+                    {"type": "prompt", "voicePrompt": "hi", "final": True},
+                ],
+                error=RuntimeError("socket blew up"),
+            )
+        )
+        assert_no_residual_state(channel, "CA_c")
+
+    @pytest.mark.asyncio
+    async def test_message_ready_callback_raising(self) -> None:
+        channel = self._channel()
+
+        async def boom(message: str, session: ConversationSession, memory: Any) -> str:
+            raise RuntimeError("LLM exploded")
+
+        channel.tac.on_message_ready(boom)
+        await channel.handle_websocket(
+            self._websocket(
+                [
+                    {"type": "setup", "callSid": "CA_d", "from": "+15559998888"},
+                    {"type": "prompt", "voicePrompt": "hi", "final": True},
+                ]
+            )
+        )
+        assert_no_residual_state(channel, "CA_d")
+
+    @pytest.mark.asyncio
+    async def test_initialize_conversation_raising(self) -> None:
+        """Orchestrated mode where the CO lookup fails outright."""
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        tac.conversation_orchestrator_client.list_conversations = AsyncMock(
+            side_effect=RuntimeError("CO unreachable")
+        )
+
+        await channel.handle_websocket(
+            self._websocket(
+                [
+                    {"type": "setup", "callSid": "CA_e", "from": "+15559998888"},
+                    {"type": "prompt", "voicePrompt": "hi", "final": True},
+                ]
+            )
+        )
+        assert channel._conversations == {}
+
+    @pytest.mark.asyncio
+    async def test_leak_loop(self) -> None:
+        """Many connect/disconnect cycles leave nothing behind in aggregate."""
+        channel = self._channel()
+        for i in range(25):
+            await channel.handle_websocket(
+                self._websocket(
+                    [
+                        {"type": "setup", "callSid": f"CA_loop_{i}", "from": "+15559998888"},
+                        {"type": "prompt", "voicePrompt": "hi", "final": True},
+                    ]
+                )
+            )
+            assert_no_residual_state(channel, f"CA_loop_{i}")
+
+        assert channel._conversations == {}
+        assert len(channel._provider._websocket_manager) == 0
+
+
+class TestDrain:
+    @pytest.mark.asyncio
+    async def test_releases_sessions_still_live_at_shutdown(self) -> None:
+        tac = TAC(get_test_config(conversation_configuration_id=None))
+        channel = VoiceChannel(tac)
+        call_ended: list[ConversationSession] = []
+        conversation_ended: list[ConversationSession] = []
+        channel.on_call_ended(collect(call_ended))
+        tac.on_conversation_ended(lambda s: conversation_ended.append(s))
+
+        channel._start_conversation("CA_drain_1", None)
+        channel._start_conversation("CA_drain_2", None)
+
+        await channel.aclose(grace_period=0)
+
+        assert {s.conversation_id for s in call_ended} == {"CA_drain_1", "CA_drain_2"}
+        assert len(conversation_ended) == 2
+        assert channel._conversations == {}
+
+    @pytest.mark.asyncio
+    async def test_waits_for_a_call_that_ends_on_its_own(self) -> None:
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        channel._start_conversation("CA_drain_3", None)
+
+        async def hang_up_shortly() -> None:
+            await asyncio.sleep(0.05)
+            await channel._release_session("CA_drain_3")
+
+        asyncio.create_task(hang_up_shortly())
+        await channel.aclose(grace_period=5)
+
+        assert channel._conversations == {}
+
+    @pytest.mark.asyncio
+    async def test_refuses_new_calls_once_draining(self) -> None:
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        await channel.aclose(grace_period=0)
+
+        websocket = AsyncMock()
+        await channel.handle_websocket(websocket)
+
+        websocket.close.assert_awaited_once()
+        websocket.accept.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_is_idempotent(self) -> None:
+        channel = VoiceChannel(TAC(get_test_config()))
+        await channel.aclose(grace_period=0)
+        await channel.aclose(grace_period=0)
+
+
+class TestServerDrainWiring:
+    def test_shutdown_handler_registered(self) -> None:
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        server = TACFastAPIServer(tac=tac, voice_channel=channel)
+
+        assert server.aclose in server.app.router.on_shutdown
+
+    @pytest.mark.asyncio
+    async def test_aclose_drains_the_voice_channel(self) -> None:
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        server = TACFastAPIServer(tac=tac, voice_channel=channel)
+        with patch.object(channel, "aclose", new=AsyncMock()) as aclose:
+            await server.aclose()
+        aclose.assert_awaited_once_with(grace_period=server.config.shutdown_grace_period)
+
+    @pytest.mark.asyncio
+    async def test_aclose_without_a_voice_channel_is_a_noop(self) -> None:
+        from tac.channels.sms import SMSChannel
+        from tac.server import TACFastAPIServer
+
+        tac = TAC(get_test_config())
+        server = TACFastAPIServer(tac=tac, messaging_channels=[SMSChannel(tac)])
+        await server.aclose()
+
+
+class TestEndCallDoesNotDoubleFire:
+    @pytest.mark.asyncio
+    async def test_orchestrated_end_call_leaves_conversation_ended_to_the_webhook(self) -> None:
+        tac = TAC(get_test_config())
+        channel = VoiceChannel(tac)
+        conversation_ended: list[ConversationSession] = []
+        tac.on_conversation_ended(lambda s: conversation_ended.append(s))
+
+        session = channel._start_conversation("conv_end", None)
+        session.call_sid = "CA_end"
+
+        with patch.object(channel, "_get_twilio_client", return_value=MagicMock()):
+            await channel.end_call("CA_end")
+
+        assert conversation_ended == []
+
+        tac.conversation_orchestrator_client.list_participants = AsyncMock(
+            return_value=voice_participants("conv_end")
+        )
+        await channel.process_webhook(closed_webhook("conv_end"))
+
+        assert len(conversation_ended) == 1
+
+
+class TestInstanceAffinity:
+    """Every URL TAC hands Twilio for a live call points at the process
+    holding that call, when the deployment can address one."""
+
+    @staticmethod
+    def _channel(**overrides: Any) -> VoiceChannel:
+        tac = TAC(get_test_config(**overrides))
+        channel = VoiceChannel(tac)
+        # Registering the handlers is what makes TAC pass the callback URLs.
+        channel.on_call_status(AsyncMock())
+        channel.on_amd(AsyncMock())
+        channel.on_recording(AsyncMock())
+        return channel
+
+    @pytest.mark.asyncio
+    async def test_inbound_twiml_uses_the_instance_domain(self) -> None:
+        channel = self._channel(instance_public_domain="pod-7.voice.svc.cluster.local")
+
+        twiml = await channel.handle_incoming_call()
+
+        assert 'url="wss://pod-7.voice.svc.cluster.local/ws"' in twiml
+        assert 'action="https://pod-7.voice.svc.cluster.local' in twiml
+        assert "example.com" not in twiml
+
+    def test_call_event_urls_use_the_instance_domain(self) -> None:
+        channel = self._channel(instance_public_domain="pod-7.voice.svc.cluster.local")
+
+        for kind in ("status", "amd", "recording"):
+            url = channel.tac.config.call_event_url(kind)  # type: ignore[arg-type]
+            assert url is not None
+            assert url.startswith("https://pod-7.voice.svc.cluster.local/")
+
+    @pytest.mark.asyncio
+    async def test_outbound_call_pins_every_callback_to_this_instance(self) -> None:
+        channel = self._channel(instance_public_domain="pod-7.voice.svc.cluster.local")
+        twilio_client = MagicMock()
+        twilio_client.calls.create.return_value = MagicMock(sid="CA_out")
+
+        from tac.models.outbound import InitiateVoiceConversationOptions
+
+        with patch.object(channel, "_get_twilio_client", return_value=twilio_client):
+            await channel.initiate_outbound_conversation(
+                InitiateVoiceConversationOptions(to="+15559998888")
+            )
+
+        kwargs = twilio_client.calls.create.call_args.kwargs
+        assert "wss://pod-7.voice.svc.cluster.local/ws" in kwargs["twiml"]
+        for param in ("status_callback", "async_amd_status_callback", "recording_status_callback"):
+            assert kwargs[param].startswith("https://pod-7.voice.svc.cluster.local/")
+
+    @pytest.mark.asyncio
+    async def test_shared_domain_remains_the_default(self) -> None:
+        """Deployments without per-pod addressing are unaffected."""
+        channel = self._channel()
+
+        twiml = await channel.handle_incoming_call()
+
+        assert 'url="wss://example.com/ws"' in twiml
+        assert channel.tac.config.call_event_url("status") == (
+            "https://example.com/twilio/call-events/status"
+        )
+
+    def test_scheme_and_trailing_slash_are_stripped(self) -> None:
+        channel = self._channel(instance_public_domain="https://pod-7.example.com/")
+
+        assert channel.tac.config.instance_public_domain == "pod-7.example.com"

--- a/tests/test_whatsapp_channel.py
+++ b/tests/test_whatsapp_channel.py
@@ -160,8 +160,7 @@ async def test_conversation_created_webhook(whatsapp_channel: WhatsAppChannel) -
     # CONVERSATION_CREATED events are ignored (no action needed)
     await whatsapp_channel.process_webhook(webhook)
 
-    # Conversations are not started until COMMUNICATION_CREATED
-    assert "conv_123" not in whatsapp_channel._conversations
+    # Nothing to assert on locally — the channel stores no sessions.
 
 
 @pytest.mark.asyncio
@@ -340,8 +339,6 @@ async def test_conversation_updated_closed(whatsapp_channel: WhatsAppChannel) ->
         mock_reconcile.return_value = (mock_agent, mock_customer)
         await whatsapp_channel.process_webhook(webhook)
 
-    assert conversation_id in whatsapp_channel._conversations
-
     # Mock the conversation ended callback
     callback_called = False
     callback_context = None
@@ -359,10 +356,15 @@ async def test_conversation_updated_closed(whatsapp_channel: WhatsAppChannel) ->
         timestamp="2025-01-15T10:20:30Z",
     )
 
-    await whatsapp_channel.process_webhook(close_webhook)
+    with patch.object(
+        whatsapp_channel.tac.conversation_orchestrator_client,
+        "list_participants",
+        new=AsyncMock(return_value=[mock_agent, mock_customer]),
+    ):
+        await whatsapp_channel.process_webhook(close_webhook)
 
-    # Verify conversation was ended
-    assert conversation_id not in whatsapp_channel._conversations
+    # The session handed to the callback is rebuilt from Conversation
+    # Orchestrator, so it fires on any instance — not just this one.
     assert callback_called
     assert callback_context.conversation_id == conversation_id
 

--- a/tests/voice_invariants.py
+++ b/tests/voice_invariants.py
@@ -1,0 +1,43 @@
+"""The voice teardown invariant, as one assertion.
+
+However a call ends — normal hangup, abrupt disconnect, an exception during
+setup, cancellation — the process must hold nothing for it afterwards. Every
+voice test that opens a socket asserts this, so a new teardown path can't
+quietly start leaking.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tac.channels.voice.channel import VoiceChannel
+
+
+def assert_no_residual_state(channel: VoiceChannel, conv_id: str) -> None:
+    """Assert no local state survives for ``conv_id`` on ``channel``.
+
+    Covers the channel's session, the provider's WebSocket registry and
+    session manager, and (for Media Streams providers) the call state and
+    stashed per-call session config.
+    """
+    assert conv_id not in channel._conversations, f"session for {conv_id} was not released"
+
+    provider: Any = channel._provider
+
+    ws_manager = getattr(provider, "_websocket_manager", None)
+    if ws_manager is not None:
+        assert not ws_manager.has_websocket(conv_id), f"websocket for {conv_id} was not removed"
+
+    session_manager = getattr(provider, "session_manager", None)
+    if session_manager is not None:
+        assert not session_manager.has_session(conv_id), (
+            f"session state for {conv_id} was not removed"
+        )
+
+    calls = getattr(provider, "_calls", None)
+    if calls is not None:
+        assert conv_id not in calls, f"call state for {conv_id} was not removed"
+
+    session_configs = getattr(provider, "_call_session_configs", None)
+    if session_configs is not None:
+        assert conv_id not in session_configs, f"session config for {conv_id} was not removed"


### PR DESCRIPTION
## Summary

Makes the SDK safe behind a load balancer with **no Redis, no database, and no sticky sessions** for messaging. Implements [TAC Horizontal Scaling Plan](https://github.com/twilio/twilio-agent-connect-python/blob/main/docs/deployment.md) in four phases (P0a/P0b/P1/P2 + docs).

Two problems, two answers:

**Messaging is now stateless.** `MessagingChannel` has no session store. Each webhook derives a `ConversationSession` from the payload, config, and one `list_participants` call it already needed for the self-message check and reconciliation — so any replica serves any webhook.

**Voice stays instance-local, correctly** — a WebSocket pins a call to one process — so the fix is guaranteed teardown plus a way for the call's other traffic to find it.

### Bugs this fixes

| | Before | After |
|---|---|---|
| `CONVERSATION_UPDATED`/CLOSED | filtered on locally-tracked state, so with N instances `on_conversation_ended` usually never fired and the session leaked for the process lifetime | rebuilt from Conversation Orchestrator; fires once, on whichever replica Twilio picked |
| Voice teardown in orchestrated mode | `_cleanup_connection` deliberately skipped `_end_conversation`, waiting for a CLOSED webhook that lands on a random instance — the socket closed, the session stayed | always releases; new `on_call_ended` hook fires with the live session |
| Media Streams `_call_session_configs` | written during the TwiML request, read when the WebSocket connects — two requests that can hit different instances — and never evicted for calls that don't connect | rides the TwiML as a `<Stream>` custom parameter (as outbound already did); the remaining bridge is bounded + expiring |
| Call events (status/AMD/recording) | carry only a `CallSid`, resolve to `None` on any instance that didn't hold the call | `TACConfig.instance_public_domain` mints every callback URL against this process |
| Scale-in / redeploy | live calls dropped with no callback at all | `VoiceChannel.aclose()` drains, wired to the FastAPI shutdown event |

### API-call budget

Statelessness is not paid for with extra calls. Per inbound message, pinned by a regression test:

| `memory_mode` | Before | After |
|---|---|---|
| `"never"` (default) | 2 | **2** |
| `"always"` | 3 | 4 (`get_profile`) |
| `"always"` + `fetch_profile_traits=False` | — | **3** |

`profile_id` now comes off the participant list we already fetch — no `lookup_profile`, and more reliable than the address-based fallback, which infers the identifier type and misses on CHAT and RCS. A conversation's *first* message is one call cheaper than before (the double `list_participants` is deduplicated).

### New API

- `VoiceChannel.on_call_ended(handler)` — fires at WebSocket teardown with the live session. The only place the transcript is still reachable.
- `VoiceChannel.aclose(grace_period=...)` / `TACFastAPIServer.aclose()`
- `TACConfig.instance_public_domain`, `TwilioMemoryConfig.fetch_profile_traits`, `TACServerConfig.shutdown_grace_period`

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Release / version bump

### Breaking changes

1. `MessagingChannel.get_agent_address(session)` — was `get_agent_address(conversation_id)`. The channel no longer holds a session to look up. Affects anyone subclassing `MessagingChannel` directly.
2. `MessagingChannel.send_response(conversation, ...)` — first parameter was named `conversation_id` and now accepts a `ConversationSession` too. Positional calls are unaffected; keyword calls need updating. **Pass the session** and the send costs no extra API call.
3. Messaging channels reject `memory_mode="once"` at construction. It caches a recall on a long-lived session, which messaging no longer has; statelessly it would cost the same as `"always"` with strictly worse relevance, so it fails loudly rather than degrading silently. `"always"` is the drop-in replacement. **Unchanged on Voice**, where it's the mode that matters most.

Also worth flagging (not breaking, but a behavior change): in orchestrated voice mode `on_conversation_ended` now receives a session rebuilt from Conversation Orchestrator, so in-memory state (transcript, application `metadata`) is gone by then. Use `on_call_ended` for that.

## Checklist

- [x] Tests added/updated — 1004 passing (was 946). New: `tests/test_voice_scaling.py`, `tests/test_messaging_scaling.py`, `tests/test_expiring_dict.py`, and `tests/voice_invariants.py` (the `assert_no_residual_state` teardown invariant, asserted by every voice test that opens a socket). `tests/test_memory_mode_once.py` moved from SMS to Voice.
- [x] Documentation updated — new `docs/deployment.md`; the CLAUDE.md "horizontal scaling limitation" caveat is now a description of the model.
- [ ] Tested E2E — **not done, see below.**

### Not verified against a live account

Two items need a real Twilio account and are the main thing to check before merging:

1. **Address-mode send.** The plan called for `from` = `{address, channel}` (Actions API mode 3), gated on a live test. I couldn't run it, so `send_response` prefers the participant id when it has one — which reconciliation always establishes on the inbound path — and falls back to address mode only when there isn't one. That keeps today's verified behavior on the hot path. If the live test passes, this can be simplified to address-only; if it fails, nothing to undo.
2. **What v2-native capture assigns as a participant type.** `_reconcile_participants`' docstring claims it's a v1-bridge-only repair pass; nothing in the repo establishes that. Reconcile is now unconditional (and free — it reuses the fetched participant list and writes nothing on the happy path), so the answer doesn't change behavior, but it would settle a standing unknown in the code's own documentation.

## SDK Parity

- [ ] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->

Not Python-specific — the TypeScript SDK has the same architecture and the same leak. A parity PR should follow; not created yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
