### PR TITLE
feat(core): add on_model_event callback for raw provider model events

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,7 @@ plugins:
             signature_crossrefs: true
             merge_init_into_class: true
             filters:
-              ["!^_", "!^trigger_message_ready$", "!^trigger_interrupt$", "!^trigger_conversation_ended$", "!^register_partner_connector$", "!^is_orchestrator_enabled$"]
+              ["!^_", "!^trigger_message_ready$", "!^trigger_interrupt$", "!^trigger_conversation_ended$", "!^trigger_model_event$", "!^register_partner_connector$", "!^is_orchestrator_enabled$"]
 
 markdown_extensions:
   - admonition

--- a/src/tac/channels/voice/media_streams/shared/openai_provider.py
+++ b/src/tac/channels/voice/media_streams/shared/openai_provider.py
@@ -155,6 +155,7 @@ class MediaStreamsOpenAIProvider(VoiceProvider, Generic[TCallState]):
                     session = self.channel._conversations.get(conv_id)
                     if session is None:
                         continue
+                    await self.channel.tac.trigger_model_event(conv_id, event)
                     await self._dispatch_model_event(conv_id, session, event)
                 except asyncio.CancelledError:
                     raise

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -392,10 +392,11 @@ class TAC:
         dedicated callback (e.g. transcript fragments, usage updates) — not tied to any
         specific model or provider.
 
-        Fire-and-forget: the return value is ignored, and an exception raised by the
-        callback is logged and swallowed rather than affecting call handling. The event
-        stream can be high-frequency and its shape is provider-specific and may change,
-        so read fields defensively and check `event["type"]` first.
+        Best-effort: the return value is ignored; if the callback is async it is awaited
+        (so keep it fast), and an exception raised by the callback is logged and swallowed
+        rather than affecting call handling. The event stream can be high-frequency and
+        provider-specific and may change, so read fields defensively and check
+        `event.get("type")`.
 
         Example:
             ```python
@@ -572,7 +573,8 @@ class TAC:
         if self._model_event_callback is None:
             return
         try:
-            result = self._model_event_callback(conversation_id, event)
+            callback_event = event.copy()
+            result = self._model_event_callback(conversation_id, callback_event)
             if inspect.isawaitable(result):
                 await result
         except asyncio.CancelledError:

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -573,7 +574,7 @@ class TAC:
         if self._model_event_callback is None:
             return
         try:
-            callback_event = event.copy()
+            callback_event = copy.deepcopy(event)
             result = self._model_event_callback(conversation_id, callback_event)
             if inspect.isawaitable(result):
                 await result

--- a/src/tac/core/tac.py
+++ b/src/tac/core/tac.py
@@ -130,6 +130,12 @@ class TAC:
             | None
         ) = None
 
+        self._model_event_callback: (
+            Callable[[str, dict[str, Any]], None]
+            | Callable[[str, dict[str, Any]], Awaitable[None]]
+            | None
+        ) = None
+
     def is_orchestrator_enabled(self) -> bool:
         """True if TAC is configured with Conversation Orchestrator (not relay-only mode)."""
         return self.conversation_orchestrator_client is not None
@@ -374,6 +380,38 @@ class TAC:
         """
         self._error_callback = callback
 
+    def on_model_event(
+        self,
+        callback: (
+            Callable[[str, dict[str, Any]], None] | Callable[[str, dict[str, Any]], Awaitable[None]]
+        ),
+    ) -> None:
+        """Register callback invoked for every raw event received from the underlying model.
+
+        A generic passthrough for model events TAC does not otherwise surface as a
+        dedicated callback (e.g. transcript fragments, usage updates) — not tied to any
+        specific model or provider.
+
+        Fire-and-forget: the return value is ignored, and an exception raised by the
+        callback is logged and swallowed rather than affecting call handling. The event
+        stream can be high-frequency and its shape is provider-specific and may change,
+        so read fields defensively and check `event["type"]` first.
+
+        Example:
+            ```python
+            def handle_model_event(conversation_id: str, event: dict) -> None:
+                if event.get("type") == "response.audio_transcript.delta":
+                    print(event.get("delta"))
+
+
+            tac.on_model_event(handle_model_event)
+            ```
+
+        Args:
+            callback: Function to call with (conversation_id, event). Supports sync and async.
+        """
+        self._model_event_callback = callback
+
     def register_partner_connector(
         self,
         connector: PartnerConnector,
@@ -512,5 +550,35 @@ class TAC:
         except Exception:
             self.logger.error(
                 "on_error callback raised an exception",
+                exc_info=True,
+            )
+
+    async def trigger_model_event(
+        self,
+        conversation_id: str,
+        event: dict[str, Any],
+    ) -> None:
+        """Trigger the registered model event callback.
+
+        No-op when no handler is registered, so callers can invoke it
+        unconditionally. The handler is invoked defensively: an exception
+        raised by the handler itself is logged and swallowed so a broken
+        handler cannot affect call handling.
+
+        Args:
+            conversation_id: The conversation the event belongs to.
+            event: The raw, provider-specific event payload.
+        """
+        if self._model_event_callback is None:
+            return
+        try:
+            result = self._model_event_callback(conversation_id, event)
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self.logger.error(
+                "on_model_event callback raised an exception",
                 exc_info=True,
             )

--- a/tests/test_model_event_callback.py
+++ b/tests/test_model_event_callback.py
@@ -193,6 +193,59 @@ class TestModelEventWiring:
         ]
 
     @pytest.mark.asyncio
+    async def test_callback_mutation_does_not_affect_dispatch(self) -> None:
+        """A callback that mutates its event (including nested payloads) must not
+        alter what _dispatch_model_event subsequently sees for the same event."""
+        channel = make_channel()
+        provider = channel._provider
+
+        def mutating_handler(conv_id: str, event: dict[str, Any]) -> None:
+            if event.get("type") == "response.done":
+                event["response"]["output"] = []
+
+        channel.tac.on_model_event(mutating_handler)
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {"event": "start", "start": {"callSid": "CA777", "streamSid": "MZ777"}},
+                {"event": "stop"},
+            ]
+        )
+        model_ws = FakeModelWebSocket(
+            events=[
+                {
+                    "type": "response.done",
+                    "response": {
+                        "output": [
+                            {
+                                "role": "assistant",
+                                "content": [{"transcript": "hello there"}],
+                            }
+                        ]
+                    },
+                },
+            ]
+        )
+
+        captured_transcripts: list[list[dict[str, Any]]] = []
+        original_dispatch = provider._dispatch_model_event
+
+        async def spying_dispatch(conv_id: str, session: Any, event: dict[str, Any]) -> None:
+            await original_dispatch(conv_id, session, event)
+            captured_transcripts.append(list(session.metadata.get("transcript", [])))
+
+        with (
+            patch(
+                "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+                new=AsyncMock(return_value=model_ws),
+            ),
+            patch.object(provider, "_dispatch_model_event", side_effect=spying_dispatch),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert captured_transcripts == [[{"role": "assistant", "text": "hello there"}]]
+
+    @pytest.mark.asyncio
     async def test_no_handler_registered_does_not_break_dispatch(self) -> None:
         """Without on_model_event registered, model events are still dispatched
         normally (trigger_model_event is a no-op, not an error)."""

--- a/tests/test_model_event_callback.py
+++ b/tests/test_model_event_callback.py
@@ -1,0 +1,216 @@
+"""Tests for the on_model_event callback and its wiring into Media Streams providers.
+
+Covers:
+- TAC.on_model_event / TAC.trigger_model_event registration and sync/async invocation.
+- MediaStreamsOpenAIProvider forwarding every raw model event to trigger_model_event
+  before it is interpreted by _dispatch_model_event.
+"""
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tac import TAC
+from tac.channels.voice import VoiceChannel
+from tac.channels.voice.media_streams.openai_realtime import OpenAIRealtimeProviderConfig
+from tac.channels.voice.media_streams.openai_realtime.provider import (
+    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+)
+
+
+def get_test_config() -> dict[str, Any]:
+    return {
+        "account_sid": "ACtest123",
+        "auth_token": "test_token_123",
+        "api_key": "SK123",
+        "api_secret": "test_api_token",
+        "conversation_configuration_id": "conv_configuration_test123",
+        "phone_number": "+15551234567",
+        "voice_public_domain": "example.com",
+    }
+
+
+class TestModelEventCallbackRegistration:
+    """TAC.on_model_event registration and trigger_model_event dispatch."""
+
+    @pytest.mark.asyncio
+    async def test_sync_model_event_callback(self) -> None:
+        tac = TAC(get_test_config())
+        received: list[tuple[str, dict[str, Any]]] = []
+
+        def handler(conversation_id: str, event: dict[str, Any]) -> None:
+            received.append((conversation_id, event))
+
+        tac.on_model_event(handler)
+
+        await tac.trigger_model_event("CA1", {"type": "turn.done"})
+
+        assert len(received) == 1
+        assert received[0] == ("CA1", {"type": "turn.done"})
+
+    @pytest.mark.asyncio
+    async def test_async_model_event_callback(self) -> None:
+        tac = TAC(get_test_config())
+        received: list[tuple[str, dict[str, Any]]] = []
+
+        async def handler(conversation_id: str, event: dict[str, Any]) -> None:
+            received.append((conversation_id, event))
+
+        tac.on_model_event(handler)
+
+        await tac.trigger_model_event("CA2", {"type": "response.audio_transcript.delta"})
+
+        assert len(received) == 1
+        assert received[0] == ("CA2", {"type": "response.audio_transcript.delta"})
+
+    @pytest.mark.asyncio
+    async def test_no_handler_is_noop(self) -> None:
+        """No handler registered → trigger_model_event is a no-op."""
+        tac = TAC(get_test_config())
+        # Must not raise.
+        await tac.trigger_model_event("CA1", {"type": "turn.done"})
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_is_swallowed_and_logged(self) -> None:
+        """A handler that raises must not propagate; the failure is logged instead."""
+        tac = TAC(get_test_config())
+
+        def bad_handler(conversation_id: str, event: dict[str, Any]) -> None:
+            raise ValueError("handler blew up")
+
+        tac.on_model_event(bad_handler)
+
+        with patch.object(tac.logger, "error") as mock_error:
+            # Must not raise despite the handler raising.
+            await tac.trigger_model_event("CA1", {"type": "turn.done"})
+
+        mock_error.assert_called_once()
+        assert "on_model_event callback raised an exception" in mock_error.call_args.args[0]
+
+
+class FakeModelWebSocket:
+    """Fake OpenAI model WebSocket. Async-iterates over queued raw events, then
+    ends the stream (a closed connection)."""
+
+    def __init__(self, events: list[dict]) -> None:
+        self._events = list(events)
+        self.sent: list[dict] = []
+        self.closed = False
+
+    def __aiter__(self) -> "FakeModelWebSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        if self._events:
+            return json.dumps(self._events.pop(0))
+        raise StopAsyncIteration
+
+    async def send(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeTwilioWebSocket:
+    """Fake Twilio-facing WebSocket. Yields queued events, then hangs forever
+    until the awaiting task is cancelled."""
+
+    def __init__(self, events: list[dict]) -> None:
+        self._events = list(events)
+        self.accepted = False
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive_json(self) -> dict:
+        if self._events:
+            return self._events.pop(0)
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def send_text(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def make_channel() -> VoiceChannel:
+    tac = TAC(get_test_config())
+    config = OpenAIRealtimeProviderConfig(
+        openai_api_key="sk-test",
+        default_session_config={
+            "model": "gpt-realtime-test",
+            "audio": {
+                "input": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+                "output": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+            },
+        },
+    )
+    return VoiceChannel(tac, config=config)
+
+
+class TestModelEventWiring:
+    """Every raw event read off the model WebSocket must reach on_model_event,
+    regardless of whether _dispatch_model_event also interprets it."""
+
+    @pytest.mark.asyncio
+    async def test_model_events_forwarded_to_on_model_event(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        received: list[tuple[str, dict[str, Any]]] = []
+        channel.tac.on_model_event(lambda conv_id, event: received.append((conv_id, event)))
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {"event": "start", "start": {"callSid": "CA999", "streamSid": "MZ999"}},
+                {"event": "stop"},
+            ]
+        )
+        model_ws = FakeModelWebSocket(
+            events=[
+                {"type": "session.created"},
+                {"type": "response.audio_transcript.delta", "delta": "hi"},
+            ]
+        )
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert received == [
+            ("CA999", {"type": "session.created"}),
+            ("CA999", {"type": "response.audio_transcript.delta", "delta": "hi"}),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_handler_registered_does_not_break_dispatch(self) -> None:
+        """Without on_model_event registered, model events are still dispatched
+        normally (trigger_model_event is a no-op, not an error)."""
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {"event": "start", "start": {"callSid": "CA111", "streamSid": "MZ111"}},
+                {"event": "stop"},
+            ]
+        )
+        model_ws = FakeModelWebSocket(events=[{"type": "session.created"}])
+
+        with patch(
+            "tac.channels.voice.media_streams.openai_realtime.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert provider._calls == {}


### PR DESCRIPTION
## Summary

- Adds `TAC.on_model_event` / `TAC.trigger_model_event`, a generic, provider-agnostic passthrough for raw events read off a voice provider's underlying model connection.
- Wires it into `MediaStreamsOpenAIProvider._handle_model_events`, so every raw event is forwarded before `_dispatch_model_event` interprets it — currently exercised by `OpenAIRealtimeProvider`.
- Motivated by a request to expose transcript deltas as they happen during a call, instead of only the assembled transcript after `on_conversation_ended`. Rather than adding a dedicated callback per event type (transcript delta, turn completion, usage, etc.), this adds one generic hook so applications can observe any event TAC doesn't already surface, without TAC needing to grow a new callback for each one.

### Follow-up (review feedback)

- `trigger_model_event` now passes a shallow copy of the event to the callback, so a mutating handler can't corrupt the object `_dispatch_model_event` reads afterward.
- Clarified the `on_model_event` docstring: async callbacks are awaited (not fire-and-forget), so they should stay fast; updated the field-access example to use `event.get("type")`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Release / version bump

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [ ] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

- [ ] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->

The concept is generic and would likely apply to the TypeScript SDK too, but no TS PR has been created yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)