### PR TITLE
feat(voice): add GPT-Live support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Seamlessly integrate with Twilio Conversation Memory and Conversation Orchestrat
 
 ## Key Features
 
-- **Multi-Channel Support**: Built-in handling for Voice (ConversationRelay), SMS, RCS, WhatsApp, and Chat
+- **Multi-Channel Support**: Built-in handling for Voice (Twilio ConversationRelay, OpenAI GPT-Live, OpenAI Realtime API), SMS, RCS, WhatsApp, and Chat
 - **Outbound Conversations**: Agent-initiated conversations across all supported channels
 - **ConversationRelay-Only Mode**: Get started quickly with TAC's voice plumbing (TwiML, WebSocket, callbacks) before adding Conversation Orchestrator or Conversation Memory
 - **Memory Management**: Automatic integration with Twilio Conversation Memory for persistent user context
@@ -56,6 +56,13 @@ For server support (includes FastAPI and uvicorn for TACFastAPIServer):
 
 ```bash
 pip install "twilio-agent-connect[server]"
+```
+
+For speech-to-speech voice over Twilio Media Streams:
+
+```bash
+pip install "twilio-agent-connect[server,gpt-live]"         # OpenAI GPT-Live
+pip install "twilio-agent-connect[server,openai-realtime]"  # OpenAI Realtime
 ```
 
 TAC requires **Python 3.10 or newer**.
@@ -171,6 +178,7 @@ For detailed architecture and advanced usage, see [CLAUDE.md](https://github.com
 **Examples & Guides:**
 - **[Getting Started Guide](https://github.com/twilio/twilio-agent-connect-python/tree/main/getting_started/)** - Setup wizard, examples, and comprehensive documentation
 - **[Partner SDK Examples](https://github.com/twilio/twilio-agent-connect-python/tree/main/getting_started/examples/partners/)** - Integration examples for OpenAI, AWS Bedrock Agent, AWS Bedrock AgentCore, and AWS Strands
+- **Speech-to-Speech Voice** - Twilio Media Streams bridged to [OpenAI GPT-Live](https://github.com/twilio/twilio-agent-connect-python/blob/main/getting_started/examples/partners/openai_gpt_live.py) or the [OpenAI Realtime API](https://github.com/twilio/twilio-agent-connect-python/blob/main/getting_started/examples/partners/openai_realtime.py)
 - **[ConversationRelay-Only Mode](https://github.com/twilio/twilio-agent-connect-python/blob/main/getting_started/examples/features/relay_only.py)** - Get started with voice using just ConversationRelay
 - More examples coming soon
 

--- a/docs/api/media_streams.md
+++ b/docs/api/media_streams.md
@@ -6,8 +6,8 @@ under [Channels](channels.md).
 
 The providers below bridge Twilio
 [Media Streams](https://www.twilio.com/docs/voice/twiml/stream)
-(`<Connect><Stream>`) to an OpenAI speech-to-speech API, relaying audio between
-Twilio's WebSocket and the model's. Both need the optional `websockets`
+(`<Connect><Stream>`) to a speech-to-speech model API, relaying audio between
+Twilio's WebSocket and the model's. Each needs the optional `websockets`
 dependency:
 
 ```bash
@@ -16,9 +16,9 @@ pip install "tac[server,openai-realtime]"  # Realtime
 ```
 
 Twilio's bidirectional `<Stream>` only ever carries 8kHz G.711 u-law audio, so
-each provider exports the constant to put in your `session_config` — the two
-APIs describe that same audio with different schemas, so the constants are
-**not** interchangeable.
+each provider exports the constant to put in your `session_config` — model APIs
+describe that same audio with different schemas, so the constants are **not**
+interchangeable.
 
 ## OpenAI GPT-Live
 
@@ -43,7 +43,7 @@ APIs describe that same audio with different schemas, so the constants are
 
 ## Shared
 
-Used by both providers.
+Used by every Media Streams provider.
 
 ::: tac.channels.voice.media_streams.twiml
     options:

--- a/docs/api/media_streams.md
+++ b/docs/api/media_streams.md
@@ -1,0 +1,60 @@
+# Media Streams Providers
+
+`VoiceChannel` delegates the real-time media transport to a pluggable
+`VoiceProvider`. The default one, `ConversationRelayProvider`, is documented
+under [Channels](channels.md).
+
+The providers below bridge Twilio
+[Media Streams](https://www.twilio.com/docs/voice/twiml/stream)
+(`<Connect><Stream>`) to an OpenAI speech-to-speech API, relaying audio between
+Twilio's WebSocket and the model's. Both need the optional `websockets`
+dependency:
+
+```bash
+pip install "tac[server,gpt-live]"         # GPT-Live
+pip install "tac[server,openai-realtime]"  # Realtime
+```
+
+Twilio's bidirectional `<Stream>` only ever carries 8kHz G.711 u-law audio, so
+each provider exports the constant to put in your `session_config` — the two
+APIs describe that same audio with different schemas, so the constants are
+**not** interchangeable.
+
+## OpenAI GPT-Live
+
+::: tac.channels.voice.media_streams.gpt_live
+    options:
+      members:
+        - GPTLiveProvider
+        - GPTLiveProviderConfig
+        - InitiateVoiceConversationOptionsGPTLive
+        - TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE
+
+## OpenAI Realtime
+
+::: tac.channels.voice.media_streams.openai_realtime
+    options:
+      members:
+        - OpenAIRealtimeProvider
+        - OpenAIRealtimeProviderConfig
+        - InitiateVoiceConversationOptionsOpenAIRealtime
+        - TWILIO_AUDIO_FORMAT_FOR_REALTIME
+
+## Shared
+
+Used by both providers.
+
+::: tac.channels.voice.media_streams.twiml
+    options:
+      members:
+        - generate_twiml
+
+::: tac.models.voice
+    options:
+      members:
+        - VoiceTwiMLOptionsMediaStreams
+
+::: tac.models.stream
+    options:
+      members:
+        - StreamStartMessage

--- a/docs/api/media_streams.md
+++ b/docs/api/media_streams.md
@@ -29,6 +29,7 @@ APIs describe that same audio with different schemas, so the constants are
         - GPTLiveProviderConfig
         - InitiateVoiceConversationOptionsGPTLive
         - TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE
+        - GPT_LIVE_SESSION_ID_METADATA_KEY
 
 ## OpenAI Realtime
 

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -47,6 +47,8 @@ Learn the core pattern for manually extracting and injecting TAC memory into **a
 Production-ready examples integrating TAC with partner SDKs:
 - **`openai_chat_completions.py`**: OpenAI Chat Completions API with automatic memory injection via `with_tac_memory()`
 - **`openai_responses_api.py`**: OpenAI Responses API with automatic memory injection
+- **`openai_realtime.py`**: Speech-to-speech voice calls bridging Twilio Media Streams to the OpenAI Realtime API
+- **`openai_gpt_live.py`**: Speech-to-speech voice calls bridging Twilio Media Streams to OpenAI GPT-Live
 - **`aws_bedrock_agent.py`**: AWS Bedrock Agent integration
 - **`aws_bedrock_agentcore.py`**: AWS Bedrock AgentCore integration
 - **`aws_strands.py`**: AWS Strands agents integration
@@ -86,6 +88,8 @@ walks up from the script's directory, so it'll find
 uv run getting_started/examples/overview.py
 uv run getting_started/examples/partners/openai_chat_completions.py
 uv run getting_started/examples/partners/openai_responses_api.py
+uv run getting_started/examples/partners/openai_realtime.py
+uv run getting_started/examples/partners/openai_gpt_live.py
 uv run getting_started/examples/partners/aws_bedrock_agent.py
 uv run getting_started/examples/partners/aws_bedrock_agentcore.py
 uv run getting_started/examples/partners/aws_strands.py

--- a/getting_started/examples/partners/openai_gpt_live.py
+++ b/getting_started/examples/partners/openai_gpt_live.py
@@ -44,6 +44,7 @@ from fastapi import FastAPI
 from tac import TAC, TACConfig
 from tac.channels.voice import VoiceChannel
 from tac.channels.voice.media_streams.gpt_live import (
+    GPT_LIVE_SESSION_ID_METADATA_KEY,
     TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE,
     GPTLiveProviderConfig,
 )
@@ -103,7 +104,8 @@ voice_channel = VoiceChannel(
 async def handle_conversation_ended(context: ConversationSession) -> None:
     """Print the full transcript once the Media Stream WebSocket closes."""
     transcript = context.metadata.get("transcript", [])
-    print(f"Call {context.conversation_id} ended. Transcript:")
+    session_id = context.metadata.get(GPT_LIVE_SESSION_ID_METADATA_KEY)
+    print(f"Call {context.conversation_id} ended (GPT-Live session {session_id}). Transcript:")
     for turn in transcript:
         print(f"  {turn['role']}: {turn['text']}")
 

--- a/getting_started/examples/partners/openai_gpt_live.py
+++ b/getting_started/examples/partners/openai_gpt_live.py
@@ -1,0 +1,138 @@
+"""
+Example: OpenAI GPT-Live voice calls via Twilio Media Streams.
+
+GPT-Live is an unreleased OpenAI alpha API, approved-project access only.
+This example will fail to connect unless OPENAI_API_KEY belongs to a
+GPT-Live alpha-approved project.
+
+Twilio streams call audio to our own WebSocket, and this provider relays it
+to/from the GPT-Live WebSocket. Unlike the Realtime API provider:
+- GPT-Live is full-duplex — there's no barge-in/truncate to configure, the
+  model handles interruption itself.
+- Tool calls go through Responses delegation (`session_config["delegation"]`),
+  not direct function-calling — `web_search` below is a hosted tool OpenAI
+  runs server-side, no code needed here for it to work.
+- The greeting is sent via `welcome_instruction` (a `session.context.append`
+  once `session.started` arrives), not a `response.create`-equivalent. Unlike
+  Realtime's `welcome_greeting_response`, the caller supplies the full
+  instruction verbatim — GPT-Live won't speak first from a bare greeting
+  string, so word it as an instruction, e.g. "Greet the caller using: ...".
+
+Unlike the ConversationRelay examples, this runs in relay-only mode
+regardless of TAC's Conversation Orchestrator configuration — there's no
+profile lookup or CO conversation for a Media Streams call.
+
+One-time account setup: same as openai_realtime.py.
+
+Env vars required:
+- TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_API_KEY, TWILIO_API_SECRET
+- TWILIO_PHONE_NUMBER
+- TWILIO_VOICE_PUBLIC_DOMAIN (your ngrok domain or similar)
+- OPENAI_API_KEY (must belong to a GPT-Live alpha-approved project)
+
+Install the extra dependencies this example needs:
+    pip install "tac[server,gpt-live]"
+
+Usage:
+    python openai_gpt_live.py                    # inbound only
+    # also place an outbound call — make sure you have permission to call
+    # this number; unsolicited calls risk the number being flagged as spam
+    python openai_gpt_live.py --to +16505551234
+"""
+
+import argparse
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from dotenv import load_dotenv
+from fastapi import FastAPI
+
+from tac import TAC, TACConfig
+from tac.channels.voice import VoiceChannel
+from tac.channels.voice.media_streams.gpt_live import (
+    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    GPTLiveProviderConfig,
+)
+from tac.models.outbound import InitiateVoiceConversationOptionsGPTLive
+from tac.models.session import ConversationSession
+from tac.server import TACFastAPIServer
+from tac.tools import function_tool
+
+load_dotenv()
+
+tac = TAC(config=TACConfig.from_env())
+
+
+@function_tool()
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    return f"It's sunny and 72F in {city}."
+
+
+DEFAULT_SESSION_CONFIG = {
+    "instructions": (
+        "You are a warm, friendly voice assistant speaking with a caller over the phone. "
+        "Keep responses short — a sentence or two per turn. No markdown, emojis, or "
+        "bullet lists; your words will be spoken aloud."
+    ),
+    "audio": {
+        "format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+        "output": {"voice": "marin"},
+    },
+    "delegation": {
+        "type": "responses",
+        "responses": {
+            "model": "gpt-5.6-sol",
+            "tools": [{"type": "web_search"}, get_weather.to_realtime_format()],
+            "tool_choice": "auto",
+        },
+    },
+}
+
+
+voice_channel = VoiceChannel(
+    tac,
+    config=GPTLiveProviderConfig(
+        tools=[get_weather],
+        welcome_instruction=(
+            "Greet the caller immediately using the exact text below. Do not wait "
+            "for the caller to speak first. After the greeting, pause and listen."
+            "\n\nHello! How can I help you today?"
+        ),
+        default_session_config=DEFAULT_SESSION_CONFIG,
+    ),
+)
+
+
+@tac.on_conversation_ended
+async def handle_conversation_ended(context: ConversationSession) -> None:
+    """Print the full transcript once the Media Stream WebSocket closes."""
+    transcript = context.metadata.get("transcript", [])
+    print(f"Call {context.conversation_id} ended. Transcript:")
+    for turn in transcript:
+        print(f"  {turn['role']}: {turn['text']}")
+
+
+async def place_outbound_call(to: str) -> None:
+    result = await voice_channel.initiate_outbound_conversation(
+        InitiateVoiceConversationOptionsGPTLive(to=to)
+    )
+    print(f"Call placed to {to} (SID: {result.call_sid})")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="GPT-Live voice example")
+    parser.add_argument("--to", help="Destination phone number to call, e.g. +16505551234")
+    args = parser.parse_args()
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        if args.to:
+            asyncio.create_task(place_outbound_call(args.to))
+        yield
+
+    app = FastAPI(title="TAC GPT-Live Example", lifespan=lifespan)
+
+    server = TACFastAPIServer(tac=tac, voice_channel=voice_channel, app=app)
+    server.start()

--- a/getting_started/examples/partners/openai_gpt_live.py
+++ b/getting_started/examples/partners/openai_gpt_live.py
@@ -1,10 +1,6 @@
 """
 Example: OpenAI GPT-Live voice calls via Twilio Media Streams.
 
-GPT-Live is an unreleased OpenAI alpha API, approved-project access only.
-This example will fail to connect unless OPENAI_API_KEY belongs to a
-GPT-Live alpha-approved project.
-
 Twilio streams call audio to our own WebSocket, and this provider relays it
 to/from the GPT-Live WebSocket:
 - GPT-Live is full-duplex — there's no barge-in/truncate to configure, the
@@ -27,7 +23,7 @@ Env vars required:
 - TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_API_KEY, TWILIO_API_SECRET
 - TWILIO_PHONE_NUMBER
 - TWILIO_VOICE_PUBLIC_DOMAIN (your ngrok domain or similar)
-- OPENAI_API_KEY (must belong to a GPT-Live alpha-approved project)
+- OPENAI_API_KEY
 
 Install the extra dependencies this example needs:
     pip install "tac[server,gpt-live]"
@@ -48,7 +44,7 @@ from fastapi import FastAPI
 from tac import TAC, TACConfig
 from tac.channels.voice import VoiceChannel
 from tac.channels.voice.media_streams.gpt_live import (
-    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE,
     GPTLiveProviderConfig,
 )
 from tac.models.outbound import InitiateVoiceConversationOptionsGPTLive
@@ -68,14 +64,14 @@ def get_weather(city: str) -> str:
 
 
 DEFAULT_SESSION_CONFIG = {
-    "model": "gpt-live-1-diamond-alpha",
+    "model": "gpt-live-1",
     "instructions": (
         "You are a warm, friendly voice assistant speaking with a caller over the phone. "
         "Keep responses short — a sentence or two per turn. No markdown, emojis, or "
         "bullet lists; your words will be spoken aloud."
     ),
     "audio": {
-        "format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+        "format": TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE,
         "output": {"voice": "marin"},
     },
     "delegation": {

--- a/getting_started/examples/partners/openai_gpt_live.py
+++ b/getting_started/examples/partners/openai_gpt_live.py
@@ -34,9 +34,7 @@ Install the extra dependencies this example needs:
 
 Usage:
     python openai_gpt_live.py                    # inbound only
-    # also place an outbound call — make sure you have permission to call
-    # this number; unsolicited calls risk the number being flagged as spam
-    python openai_gpt_live.py --to +16505551234
+    python openai_gpt_live.py --to +16505551234  # place an outbound call
 """
 
 import argparse

--- a/getting_started/examples/partners/openai_gpt_live.py
+++ b/getting_started/examples/partners/openai_gpt_live.py
@@ -6,21 +6,20 @@ This example will fail to connect unless OPENAI_API_KEY belongs to a
 GPT-Live alpha-approved project.
 
 Twilio streams call audio to our own WebSocket, and this provider relays it
-to/from the GPT-Live WebSocket. Unlike the Realtime API provider:
+to/from the GPT-Live WebSocket:
 - GPT-Live is full-duplex — there's no barge-in/truncate to configure, the
   model handles interruption itself.
-- Tool calls go through Responses delegation (`session_config["delegation"]`),
-  not direct function-calling — `web_search` below is a hosted tool OpenAI
-  runs server-side, no code needed here for it to work.
-- The greeting is sent via `welcome_instruction` (a `session.context.append`
-  once `session.started` arrives), not a `response.create`-equivalent. Unlike
-  Realtime's `welcome_greeting_response`, the caller supplies the full
-  instruction verbatim — GPT-Live won't speak first from a bare greeting
-  string, so word it as an instruction, e.g. "Greet the caller using: ...".
+- Tool calls go through Responses delegation (`session_config["delegation"]`)
+  — `web_search` below is a hosted tool OpenAI runs server-side, no code
+  needed here for it to work.
+- The greeting is sent via `welcome_instruction` (a `session.commentary.append`
+  once `session.started` arrives). The caller supplies the full instruction
+  verbatim — GPT-Live won't speak first from a bare greeting string, so word
+  it as an instruction, e.g. "Greet the caller using: ...".
 
-Unlike the ConversationRelay examples, this runs in relay-only mode
-regardless of TAC's Conversation Orchestrator configuration — there's no
-profile lookup or CO conversation for a Media Streams call.
+This runs in relay-only mode regardless of TAC's Conversation Orchestrator
+configuration — there's no profile lookup or CO conversation for a Media
+Streams call.
 
 One-time account setup: same as openai_realtime.py.
 
@@ -71,6 +70,7 @@ def get_weather(city: str) -> str:
 
 
 DEFAULT_SESSION_CONFIG = {
+    "model": "gpt-live-1-diamond-alpha",
     "instructions": (
         "You are a warm, friendly voice assistant speaking with a caller over the phone. "
         "Keep responses short — a sentence or two per turn. No markdown, emojis, or "

--- a/getting_started/examples/partners/openai_realtime.py
+++ b/getting_started/examples/partners/openai_realtime.py
@@ -49,7 +49,7 @@ from fastapi import FastAPI
 from tac import TAC, TACConfig
 from tac.channels.voice import VoiceChannel
 from tac.channels.voice.media_streams.openai_realtime import (
-    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    TWILIO_AUDIO_FORMAT_FOR_REALTIME,
     OpenAIRealtimeProviderConfig,
 )
 from tac.models.outbound import InitiateVoiceConversationOptionsOpenAIRealtime
@@ -80,11 +80,11 @@ DEFAULT_SESSION_CONFIG = {
     ),
     "audio": {
         "input": {
-            "format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+            "format": TWILIO_AUDIO_FORMAT_FOR_REALTIME,
             "turn_detection": {"type": "semantic_vad", "eagerness": "high"},
             "transcription": {"model": "gpt-live-transcribe"},
         },
-        "output": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT, "voice": "marin"},
+        "output": {"format": TWILIO_AUDIO_FORMAT_FOR_REALTIME, "voice": "marin"},
     },
     "tools": [get_weather.to_realtime_format()],
     "tool_choice": "auto",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,9 @@ plugins:
         python:
           paths: [src]
           options:
+            extensions:
+              - griffe_pydantic:
+                  schema: false
             docstring_style: google
             show_source: false
             show_root_heading: true
@@ -72,6 +75,7 @@ nav:
   - API Reference:
       - Core: api/core.md
       - Channels: api/channels.md
+      - Media Streams Providers: api/media_streams.md
       - Context: api/context.md
       - Tools: api/tools.md
       - Adapters: api/adapters.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twilio-agent-connect"
-version = "2.3.0"
+version = "2.4.0"
 description = "A Python framework for building agentic applications with Twilio"
 authors = [{ name = "Twilio Conversation AI", email = "team_conversational-ai@twilio.com" }]
 readme = "README.md"
@@ -55,6 +55,9 @@ docs = [
     "mkdocs>=1.6.0,<2",
     "mkdocs-material>=9.5.0,<10",
     "mkdocstrings[python]>=1.0.0,<2",
+    # Teaches griffe to read Pydantic models, so Field(description=...) text
+    # renders as published documentation instead of being dropped.
+    "griffe-pydantic>=1.1.0,<2",
     "mike>=2.1.0,<3",
 ]
 examples = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ server = [
 openai-realtime = [
     "websockets>=14,<17",
 ]
+gpt-live = [
+    "websockets>=14,<17",
+]
 
 [dependency-groups]
 dev = [

--- a/src/tac/channels/voice/media_streams/gpt_live/__init__.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/__init__.py
@@ -1,11 +1,8 @@
-"""``GPTLiveProvider``: bridges Twilio Media Streams to OpenAI's GPT-Live alpha.
-
-GPT-Live is an unreleased OpenAI alpha API.
-"""
+"""``GPTLiveProvider``: bridges Twilio Media Streams to OpenAI's GPT-Live API."""
 
 from tac.channels.voice.media_streams.gpt_live.config import GPTLiveProviderConfig
 from tac.channels.voice.media_streams.gpt_live.provider import (
-    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE,
     GPTLiveProvider,
 )
 from tac.channels.voice.media_streams.twiml import generate_twiml
@@ -18,7 +15,7 @@ __all__ = [
     "GPTLiveProviderConfig",
     "InitiateVoiceConversationOptionsGPTLive",
     "StreamStartMessage",
-    "TWILIO_MEDIA_STREAM_AUDIO_FORMAT",
+    "TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE",
     "VoiceTwiMLOptionsMediaStreams",
     "generate_twiml",
 ]

--- a/src/tac/channels/voice/media_streams/gpt_live/__init__.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/__init__.py
@@ -1,0 +1,28 @@
+"""``GPTLiveProvider``: bridges Twilio Media Streams to OpenAI's GPT-Live alpha.
+
+GPT-Live is an unreleased OpenAI alpha API.
+"""
+
+from tac.channels.voice.media_streams.gpt_live.config import (
+    DEFAULT_GPT_LIVE_MODEL,
+    GPTLiveProviderConfig,
+)
+from tac.channels.voice.media_streams.gpt_live.provider import (
+    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    GPTLiveProvider,
+)
+from tac.channels.voice.media_streams.twiml import generate_twiml
+from tac.models.outbound import InitiateVoiceConversationOptionsGPTLive
+from tac.models.stream import StreamStartMessage
+from tac.models.voice import VoiceTwiMLOptionsMediaStreams
+
+__all__ = [
+    "DEFAULT_GPT_LIVE_MODEL",
+    "GPTLiveProvider",
+    "GPTLiveProviderConfig",
+    "InitiateVoiceConversationOptionsGPTLive",
+    "StreamStartMessage",
+    "TWILIO_MEDIA_STREAM_AUDIO_FORMAT",
+    "VoiceTwiMLOptionsMediaStreams",
+    "generate_twiml",
+]

--- a/src/tac/channels/voice/media_streams/gpt_live/__init__.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/__init__.py
@@ -3,10 +3,7 @@
 GPT-Live is an unreleased OpenAI alpha API.
 """
 
-from tac.channels.voice.media_streams.gpt_live.config import (
-    DEFAULT_GPT_LIVE_MODEL,
-    GPTLiveProviderConfig,
-)
+from tac.channels.voice.media_streams.gpt_live.config import GPTLiveProviderConfig
 from tac.channels.voice.media_streams.gpt_live.provider import (
     TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
     GPTLiveProvider,
@@ -17,7 +14,6 @@ from tac.models.stream import StreamStartMessage
 from tac.models.voice import VoiceTwiMLOptionsMediaStreams
 
 __all__ = [
-    "DEFAULT_GPT_LIVE_MODEL",
     "GPTLiveProvider",
     "GPTLiveProviderConfig",
     "InitiateVoiceConversationOptionsGPTLive",

--- a/src/tac/channels/voice/media_streams/gpt_live/__init__.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/__init__.py
@@ -2,6 +2,7 @@
 
 from tac.channels.voice.media_streams.gpt_live.config import GPTLiveProviderConfig
 from tac.channels.voice.media_streams.gpt_live.provider import (
+    GPT_LIVE_SESSION_ID_METADATA_KEY,
     TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE,
     GPTLiveProvider,
 )
@@ -11,6 +12,7 @@ from tac.models.stream import StreamStartMessage
 from tac.models.voice import VoiceTwiMLOptionsMediaStreams
 
 __all__ = [
+    "GPT_LIVE_SESSION_ID_METADATA_KEY",
     "GPTLiveProvider",
     "GPTLiveProviderConfig",
     "InitiateVoiceConversationOptionsGPTLive",

--- a/src/tac/channels/voice/media_streams/gpt_live/config.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/config.py
@@ -21,8 +21,6 @@ from tac.tools import TACTool
 if TYPE_CHECKING:
     from tac.channels.voice.channel import VoiceChannel
 
-DEFAULT_GPT_LIVE_MODEL = "gpt-live-1-marble-alpha"
-
 
 class GPTLiveProviderConfig(MediaStreamsOpenAIProviderConfig):
     """Configuration for ``GPTLiveProvider``."""
@@ -31,11 +29,6 @@ class GPTLiveProviderConfig(MediaStreamsOpenAIProviderConfig):
         default_factory=lambda: os.environ.get("OPENAI_API_KEY"),
         description="OpenAI API key for a GPT-Live alpha-approved project. A key from a "
         "non-approved project will fail to connect.",
-    )
-    model: str = Field(
-        default=DEFAULT_GPT_LIVE_MODEL,
-        description="GPT-Live model id, sent as the ?model= query param. Unlike "
-        "OpenAIRealtimeProviderConfig, this is not part of session_config.",
     )
     tools: list[TACTool] = Field(
         default_factory=list,
@@ -46,18 +39,19 @@ class GPTLiveProviderConfig(MediaStreamsOpenAIProviderConfig):
     )
     welcome_instruction: str | None = Field(
         default=None,
-        description="If set, sent verbatim as a `session.context.append` "
-        "(channel='speakable') once `session.started` arrives. Word it as an "
+        description="If set, sent verbatim as a `session.commentary.append` "
+        "once `session.started` arrives. Word it as an "
         "instruction, not just a greeting, e.g. 'Greet the caller immediately "
         "using: Hi, how can I help you today?' — a bare greeting won't make the "
         "model speak first.",
     )
     default_session_config: dict[str, Any] | None = Field(
         default=None,
-        description="The session.update payload's 'session' body, sent once the model "
+        description="The session.start payload's 'session' body, sent once the model "
         "connects — used for any call that doesn't supply its own via "
         "`on_inbound_call_session_config` or `InitiateVoiceConversationOptionsGPTLive`. "
-        "Set `audio.format` to `TWILIO_MEDIA_STREAM_AUDIO_FORMAT` and, for tool calling, "
+        "Must include `model` (e.g. 'gpt-live-1-diamond-alpha'). Set `audio.format` to "
+        "`TWILIO_MEDIA_STREAM_AUDIO_FORMAT` and, for tool calling, "
         "`delegation = {'type': 'responses', 'responses': {'model': ..., 'tools': [...]}}`.",
     )
     on_inbound_call_session_config: (

--- a/src/tac/channels/voice/media_streams/gpt_live/config.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/config.py
@@ -1,11 +1,7 @@
-"""``GPTLiveProvider`` configuration.
-
-GPT-Live is an unreleased OpenAI alpha API.
-"""
+"""``GPTLiveProvider`` configuration."""
 
 from __future__ import annotations
 
-import os
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -25,11 +21,6 @@ if TYPE_CHECKING:
 class GPTLiveProviderConfig(MediaStreamsOpenAIProviderConfig):
     """Configuration for ``GPTLiveProvider``."""
 
-    openai_api_key: str | None = Field(
-        default_factory=lambda: os.environ.get("OPENAI_API_KEY"),
-        description="OpenAI API key for a GPT-Live alpha-approved project. A key from a "
-        "non-approved project will fail to connect.",
-    )
     tools: list[TACTool] = Field(
         default_factory=list,
         description="Executable TACTool implementations, looked up by name to run "
@@ -50,8 +41,8 @@ class GPTLiveProviderConfig(MediaStreamsOpenAIProviderConfig):
         description="The session.start payload's 'session' body, sent once the model "
         "connects — used for any call that doesn't supply its own via "
         "`on_inbound_call_session_config` or `InitiateVoiceConversationOptionsGPTLive`. "
-        "Must include `model` (e.g. 'gpt-live-1-diamond-alpha'). Set `audio.format` to "
-        "`TWILIO_MEDIA_STREAM_AUDIO_FORMAT` and, for tool calling, "
+        "Must include `model` (e.g. 'gpt-live-1'). Set `audio.format` to "
+        "`TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE` and, for tool calling, "
         "`delegation = {'type': 'responses', 'responses': {'model': ..., 'tools': [...]}}`.",
     )
     on_inbound_call_session_config: (

--- a/src/tac/channels/voice/media_streams/gpt_live/config.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/config.py
@@ -1,0 +1,73 @@
+"""``GPTLiveProvider`` configuration.
+
+GPT-Live is an unreleased OpenAI alpha API.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from pydantic import Field
+
+from tac.channels.voice.media_streams.gpt_live.provider import GPTLiveProvider
+from tac.channels.voice.media_streams.shared.config import MediaStreamsOpenAIProviderConfig
+from tac.channels.voice.provider import VoiceProvider
+from tac.core.config import TACConfig
+from tac.models.voice import TwiMLRequest
+from tac.tools import TACTool
+
+if TYPE_CHECKING:
+    from tac.channels.voice.channel import VoiceChannel
+
+DEFAULT_GPT_LIVE_MODEL = "gpt-live-1-marble-alpha"
+
+
+class GPTLiveProviderConfig(MediaStreamsOpenAIProviderConfig):
+    """Configuration for ``GPTLiveProvider``."""
+
+    openai_api_key: str | None = Field(
+        default_factory=lambda: os.environ.get("OPENAI_API_KEY"),
+        description="OpenAI API key for a GPT-Live alpha-approved project. A key from a "
+        "non-approved project will fail to connect.",
+    )
+    model: str = Field(
+        default=DEFAULT_GPT_LIVE_MODEL,
+        description="GPT-Live model id, sent as the ?model= query param. Unlike "
+        "OpenAIRealtimeProviderConfig, this is not part of session_config.",
+    )
+    tools: list[TACTool] = Field(
+        default_factory=list,
+        description="Executable TACTool implementations, looked up by name to run "
+        "Responses-delegated tool calls. This alone does not tell the model these tools "
+        "exist — also add each tool's `to_realtime_format()` schema to "
+        "`default_session_config['delegation']['responses']['tools']`.",
+    )
+    welcome_instruction: str | None = Field(
+        default=None,
+        description="If set, sent verbatim as a `session.context.append` "
+        "(channel='speakable') once `session.started` arrives. Word it as an "
+        "instruction, not just a greeting, e.g. 'Greet the caller immediately "
+        "using: Hi, how can I help you today?' — a bare greeting won't make the "
+        "model speak first.",
+    )
+    default_session_config: dict[str, Any] | None = Field(
+        default=None,
+        description="The session.update payload's 'session' body, sent once the model "
+        "connects — used for any call that doesn't supply its own via "
+        "`on_inbound_call_session_config` or `InitiateVoiceConversationOptionsGPTLive`. "
+        "Set `audio.format` to `TWILIO_MEDIA_STREAM_AUDIO_FORMAT` and, for tool calling, "
+        "`delegation = {'type': 'responses', 'responses': {'model': ..., 'tools': [...]}}`.",
+    )
+    on_inbound_call_session_config: (
+        Callable[[TwiMLRequest], Awaitable[dict[str, Any] | None]] | None
+    ) = Field(
+        default=None,
+        description="Per-inbound-call override for `default_session_config`, called with "
+        "the TwiMLRequest. Its return value is used verbatim (not merged with "
+        "`default_session_config`); return None to fall back to it.",
+    )
+
+    def create_provider(self, channel: VoiceChannel, tac_config: TACConfig) -> VoiceProvider:
+        return GPTLiveProvider(channel, tac_config, self)

--- a/src/tac/channels/voice/media_streams/gpt_live/models.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/models.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import asyncio
+from dataclasses import dataclass, field
 
 from tac.channels.voice.media_streams.shared.models import MediaStreamsOpenAICallState
 
 
 @dataclass
 class _CallState(MediaStreamsOpenAICallState):
-    """Per-call bookkeeping this provider needs beyond ``ConversationSession``.
+    """Per-call bookkeeping this provider needs beyond ``ConversationSession``."""
 
-    No barge-in state, unlike ``OpenAIRealtimeProvider``'s ``_CallState`` —
-    GPT-Live is full-duplex and handles interruption itself; there's no
-    client-driven truncate/cancel to track state for.
-    """
+    #: Set once ``session.closed`` arrives, so ``_cleanup_call`` can wait for
+    #: graceful finalization before tearing down the socket.
+    closed_event: asyncio.Event = field(default_factory=asyncio.Event)

--- a/src/tac/channels/voice/media_streams/gpt_live/models.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/models.py
@@ -1,0 +1,17 @@
+"""Per-call state for ``GPTLiveProvider``, not part of the public API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tac.channels.voice.media_streams.shared.models import MediaStreamsOpenAICallState
+
+
+@dataclass
+class _CallState(MediaStreamsOpenAICallState):
+    """Per-call bookkeeping this provider needs beyond ``ConversationSession``.
+
+    No barge-in state, unlike ``OpenAIRealtimeProvider``'s ``_CallState`` —
+    GPT-Live is full-duplex and handles interruption itself; there's no
+    client-driven truncate/cancel to track state for.
+    """

--- a/src/tac/channels/voice/media_streams/gpt_live/provider.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/provider.py
@@ -1,6 +1,4 @@
-"""``GPTLiveProvider``: bridges Twilio Media Streams to OpenAI's GPT-Live alpha.
-
-GPT-Live is an unreleased OpenAI alpha API.
+"""``GPTLiveProvider``: bridges Twilio Media Streams to OpenAI's GPT-Live API.
 
 GPT-Live is full-duplex — the model handles interruption server-side, so
 there's no client-driven barge-in truncate to manage — and tool calls go
@@ -37,11 +35,6 @@ from tac.utils.redaction import mask_phone, redact_twiml_parameters
 if TYPE_CHECKING:
     from tac.channels.voice.media_streams.gpt_live.config import GPTLiveProviderConfig
 
-# TODO: remove once GPT-Live is released (GA drops the alpha header requirement).
-#: Required on every GPT-Live alpha request — omitting it is rejected.
-_OPENAI_ALPHA_HEADER_NAME = "OpenAI-Alpha"
-_OPENAI_ALPHA_HEADER_VALUE = "quicksilver=v3"
-
 #: Reserved <Stream> custom_parameters key used to correlate an outbound
 #: call's session_config override to its WebSocket start event. calls.create()
 #: returning call.sid doesn't happen-before Twilio connecting the stream, so
@@ -49,10 +42,11 @@ _OPENAI_ALPHA_HEADER_VALUE = "quicksilver=v3"
 #: before the call is placed, can.
 _SESSION_CONFIG_TOKEN_PARAM = "_tac_session_config_token"
 
-#: GPT-Live speaks Twilio's exact wire format natively — a single shared
-#: session.audio.format, selected once at WebSocket startup and immutable
-#: after. No transcoding needed on either leg between Twilio and GPT-Live.
-TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu", "rate": 8000}
+#: Twilio Media Streams always sends/expects 8kHz G.711 u-law — see
+#: https://www.twilio.com/docs/voice/media-streams/websocket-messages. Not
+#: configurable. Spelled with an explicit ``rate``, which GPT-Live's schema
+#: wants and Realtime's rejects.
+TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE: dict[str, Any] = {"type": "audio/pcmu", "rate": 8000}
 
 #: How long to wait for `session.closed` before closing the socket anyway.
 _CLOSE_TIMEOUT_SECONDS = 5.0
@@ -64,7 +58,7 @@ _SESSION_CONFIG_TOKEN_TTL_SECONDS = 120.0
 
 
 class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
-    """``VoiceProvider`` bridging Twilio Media Streams to OpenAI's GPT-Live alpha.
+    """``VoiceProvider`` bridging Twilio Media Streams to OpenAI's GPT-Live API.
 
     Example:
         ```python
@@ -327,11 +321,11 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 "and default_session_config isn't set either."
             )
         audio_format = (session_config.get("audio") or {}).get("format")
-        if audio_format != TWILIO_MEDIA_STREAM_AUDIO_FORMAT:
+        if audio_format != TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE:
             raise ValueError(
-                f"session_config for call {conv_id} has audio.format={audio_format!r} — "
-                f"Twilio Media Streams always sends/expects {TWILIO_MEDIA_STREAM_AUDIO_FORMAT!r}, "
-                "this isn't configurable. Set audio.format to TWILIO_MEDIA_STREAM_AUDIO_FORMAT."
+                f"session_config for call {conv_id} has audio.format={audio_format!r}, "
+                f"expected {TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE!r}. Twilio Media Streams is "
+                "always 8kHz G.711 u-law; set audio.format to TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE."
             )
         if "model" not in session_config:
             raise ValueError(f"session_config for call {conv_id} must include 'model'.")
@@ -341,7 +335,6 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
             additional_headers={
                 "Authorization": f"Bearer {self.config.openai_api_key}",
                 "User-Agent": OPENAI_USER_AGENT,
-                _OPENAI_ALPHA_HEADER_NAME: _OPENAI_ALPHA_HEADER_VALUE,
             },
         )
         call = self._calls.get(conv_id)

--- a/src/tac/channels/voice/media_streams/gpt_live/provider.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/provider.py
@@ -2,10 +2,9 @@
 
 GPT-Live is an unreleased OpenAI alpha API.
 
-Unlike ``OpenAIRealtimeProvider``, GPT-Live is full-duplex — there's no
-client-driven barge-in truncate, the model handles interruption itself — and
-tool calls go through Responses delegation instead of direct function-calling
-events.
+GPT-Live is full-duplex — the model handles interruption server-side, so
+there's no client-driven barge-in truncate to manage — and tool calls go
+through Responses delegation rather than direct function-calling events.
 """
 
 from __future__ import annotations
@@ -40,7 +39,7 @@ if TYPE_CHECKING:
 # TODO: remove once GPT-Live is released (GA drops the alpha header requirement).
 #: Required on every GPT-Live alpha request — omitting it is rejected.
 _OPENAI_ALPHA_HEADER_NAME = "OpenAI-Alpha"
-_OPENAI_ALPHA_HEADER_VALUE = "quicksilver=v2"
+_OPENAI_ALPHA_HEADER_VALUE = "quicksilver=v3"
 
 #: Reserved <Stream> custom_parameters key used to correlate an outbound
 #: call's session_config override to its WebSocket start event. calls.create()
@@ -49,11 +48,13 @@ _OPENAI_ALPHA_HEADER_VALUE = "quicksilver=v2"
 #: before the call is placed, can.
 _SESSION_CONFIG_TOKEN_PARAM = "_tac_session_config_token"
 
-#: GPT-Live speaks Twilio's exact wire format natively — unlike the Realtime
-#: API's separate session.audio.input/output.format, this is a single shared
+#: GPT-Live speaks Twilio's exact wire format natively — a single shared
 #: session.audio.format, selected once at WebSocket startup and immutable
 #: after. No transcoding needed on either leg between Twilio and GPT-Live.
 TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu", "rate": 8000}
+
+#: How long to wait for `session.closed` before closing the socket anyway.
+_CLOSE_TIMEOUT_SECONDS = 5.0
 
 
 class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
@@ -222,7 +223,7 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                     if conv_id is not None and media.get("payload"):
                         await self._model_send(
                             conv_id,
-                            {"type": "input_audio.append", "audio": media["payload"]},
+                            {"type": "session.input_audio.append", "audio": media["payload"]},
                         )
 
                 elif event == "stop":
@@ -234,13 +235,13 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
         except Exception as e:
             self.logger.error(f"Media stream WebSocket error: {e}", exc_info=True)
         finally:
+            if conv_id is not None:
+                await self._cleanup_call(conv_id)
             if model_reader is not None and not model_reader.done():
                 model_reader.cancel()
             if model_reader is not None:
                 with contextlib.suppress(asyncio.CancelledError):
                     await model_reader
-            if conv_id is not None:
-                await self._cleanup_call(conv_id)
 
     def _register_call(self, start: dict[str, Any], websocket: WebSocketProtocol) -> str:
         """Handle Twilio's ``start`` event, returning the conversation id."""
@@ -286,17 +287,11 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 f"Twilio Media Streams always sends/expects {TWILIO_MEDIA_STREAM_AUDIO_FORMAT!r}, "
                 "this isn't configurable. Set audio.format to TWILIO_MEDIA_STREAM_AUDIO_FORMAT."
             )
-        if "model" in session_config:
-            # The model is selected via the WebSocket URL's ?model= query
-            # param; GPT-Live rejects repeating it in the initial session.update.
-            raise ValueError(
-                f"session_config for call {conv_id} must not include 'model' — GPT-Live "
-                "selects it from the ?model= query param (GPTLiveProviderConfig.model), "
-                "not from session_config."
-            )
+        if "model" not in session_config:
+            raise ValueError(f"session_config for call {conv_id} must include 'model'.")
 
         model_ws = await websockets.connect(
-            f"wss://api.openai.com/v1/live?model={self.config.model}",
+            "wss://api.openai.com/v1/live/sessions",
             additional_headers={
                 "Authorization": f"Bearer {self.config.openai_api_key}",
                 "User-Agent": OPENAI_USER_AGENT,
@@ -308,7 +303,7 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
             call.model_ws = model_ws
         self.logger.info("Connected to GPT-Live", conversation_id=conv_id)
 
-        await self._model_send(conv_id, {"type": "session.update", "session": session_config})
+        await self._model_send(conv_id, {"type": "session.start", "session": session_config})
         # welcome_instruction is sent once session.started arrives — see _dispatch_model_event.
 
     async def _dispatch_model_event(
@@ -321,8 +316,13 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 "GPT-Live error event", conversation_id=conv_id, error=event.get("error")
             )
 
+        elif event_type == "session.closed":
+            call = self._calls.get(conv_id)
+            if call is not None:
+                call.closed_event.set()
+
         elif event_type == "session.started":
-            # session.context.append before this event is undocumented behavior.
+            # session.commentary.append before this event is undocumented behavior.
             instruction = self.config.welcome_instruction
             if instruction is not None:
                 # Sent verbatim — caller must word it as an instruction, not a
@@ -330,44 +330,57 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 await self._model_send(
                     conv_id,
                     {
-                        "type": "session.context.append",
-                        "channel": "speakable",
-                        "content": [{"type": "input_text", "text": instruction}],
+                        "type": "session.commentary.append",
+                        "delegation_id": None,
+                        "content": instruction,
                     },
                 )
 
-        elif event_type == "turn.done":
-            # One assembled entry per turn — unlike Realtime's fragment-level
-            # *_transcript.added events.
-            turn = event.get("turn") or {}
-            text = turn.get("transcript")
-            role = turn.get("role")
-            if text and role:
-                session.metadata.setdefault("transcript", []).append({"role": role, "text": text})
+        elif event_type == "session.input_transcript.delta":
+            self._append_transcript_delta(session, "user", event)
 
-        elif event_type == "output_audio.delta" and event.get("audio"):
+        elif event_type == "session.output_transcript.delta":
+            self._append_transcript_delta(session, "assistant", event)
+
+        elif event_type == "session.output_audio.delta":
             # No item_id/barge-in bookkeeping needed — GPT-Live is
             # full-duplex and handles interruption server-side.
-            await self._twilio_send(
-                conv_id,
-                {
-                    "event": "media",
-                    "streamSid": session.metadata.get("stream_sid"),
-                    "media": {"payload": event["audio"]},
-                },
-            )
+            delta = event.get("delta")
+            if delta:
+                await self._twilio_send(
+                    conv_id,
+                    {
+                        "event": "media",
+                        "streamSid": session.metadata.get("stream_sid"),
+                        "media": {"payload": delta},
+                    },
+                )
 
-        elif event_type == "response.output_item.done":
-            # "completed" excludes calls cut short mid-generation.
-            item = event.get("item") or {}
-            if item.get("type") == "function_call" and item.get("status") == "completed":
-                await self._handle_function_call(conv_id, item)
+        elif event_type == "response.event":
+            inner = event.get("event") or {}
+            if inner.get("type") == "response.output_item.done":
+                # "completed" excludes calls cut short mid-generation.
+                item = inner.get("item") or {}
+                if item.get("type") == "function_call" and item.get("status") == "completed":
+                    await self._handle_function_call(conv_id, item)
+
+    @staticmethod
+    def _append_transcript_delta(
+        session: ConversationSession, role: str, event: dict[str, Any]
+    ) -> None:
+        """Accumulate one transcript delta into the in-progress turn."""
+        text = event.get("delta")
+        if not text:
+            return
+        transcript: list[dict[str, str]] = session.metadata.setdefault("transcript", [])
+        if transcript and transcript[-1]["role"] == role:
+            transcript[-1]["text"] += text
+        else:
+            transcript.append({"role": role, "text": text})
 
     async def _handle_function_call(self, conv_id: str, item: dict[str, Any]) -> None:
         """Run a Responses-delegated tool call and hand the result back.
 
-        Unlike Realtime, no follow-up ``response.create`` is sent — GPT-Live
-        continues on its own once the delegation output is acknowledged.
         Always sends a function_call_output when call_id is present — even a
         tool that ran successfully can return a non-JSON-serializable object
         (a datetime, a Pydantic model, ...), and the model would otherwise be
@@ -408,7 +421,7 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
         await self._model_send(
             conv_id,
             {
-                "type": "delegation.function_call_output.create",
+                "type": "response.item.create",
                 "item": {
                     "type": "function_call_output",
                     "call_id": call_id,
@@ -416,16 +429,17 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 },
             },
         )
+        await self._model_send(conv_id, {"type": "response.create"})
 
     async def _cleanup_call(self, conv_id: str) -> None:
-        call = self._calls.pop(conv_id, None)
+        call = self._calls.get(conv_id)
         if call is not None and call.model_ws is not None:
-            # Known limitation: doesn't wait for session.closed before
-            # closing the socket out from under it.
             with contextlib.suppress(Exception):
                 await call.model_ws.send(json.dumps({"type": "session.close"}))
+                await asyncio.wait_for(call.closed_event.wait(), timeout=_CLOSE_TIMEOUT_SECONDS)
             try:
                 await call.model_ws.close()
             except Exception as e:
                 self.logger.debug(f"Error closing model socket: {e}", conversation_id=conv_id)
+        self._calls.pop(conv_id, None)
         await self.channel._end_conversation(conv_id)

--- a/src/tac/channels/voice/media_streams/gpt_live/provider.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/provider.py
@@ -48,6 +48,12 @@ _SESSION_CONFIG_TOKEN_PARAM = "_tac_session_config_token"
 #: wants and Realtime's rejects.
 TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE: dict[str, Any] = {"type": "audio/pcmu", "rate": 8000}
 
+#: ``ConversationSession.metadata`` key holding OpenAI's id for the GPT-Live
+#: session behind this call, set once ``session.started`` arrives. Quote it to
+#: OpenAI support when reporting a session. Opaque — the prefix differs across
+#: the alpha (``rtc_``) and GA (``live_``), so don't parse or assert on it.
+GPT_LIVE_SESSION_ID_METADATA_KEY = "gpt_live_session_id"
+
 #: How long to wait for `session.closed` before closing the socket anyway.
 _CLOSE_TIMEOUT_SECONDS = 5.0
 
@@ -64,6 +70,14 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
         ```python
         channel = VoiceChannel(tac, config=GPTLiveProviderConfig(default_session_config=...))
         ```
+
+    OpenAI's id for the GPT-Live session behind a call is exposed on the
+    session under `GPT_LIVE_SESSION_ID_METADATA_KEY` — quote it to OpenAI
+    support when reporting a session:
+
+    ```python
+    session.metadata[GPT_LIVE_SESSION_ID_METADATA_KEY]  # e.g. "live_123"
+    ```
     """
 
     config: GPTLiveProviderConfig
@@ -356,11 +370,15 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
             )
 
         elif event_type == "session.closed":
+            # Carries the session snapshot too — a backstop if session.started
+            # was missed.
+            self._record_gpt_live_session_id(conv_id, session, event)
             call = self._calls.get(conv_id)
             if call is not None:
                 call.closed_event.set()
 
         elif event_type == "session.started":
+            self._record_gpt_live_session_id(conv_id, session, event)
             # session.commentary.append before this event is undocumented behavior.
             instruction = self.config.welcome_instruction
             if instruction is not None:
@@ -402,6 +420,27 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 item = inner.get("item") or {}
                 if item.get("type") == "function_call" and item.get("status") == "completed":
                     await self._handle_function_call(conv_id, item)
+
+    def _record_gpt_live_session_id(
+        self, conv_id: str, session: ConversationSession, event: dict[str, Any]
+    ) -> None:
+        """Surface the GPT-Live session id from a session-snapshot event.
+
+        OpenAI support asks for this id when investigating a session, so it's
+        put where a caller can reach it (``session.metadata``, which outlives
+        the call into ``on_conversation_ended``) and logged once per call.
+        Treated as an opaque string — the prefix differs across the alpha
+        (``rtc_``) and GA (``live_``), so it's never parsed or validated.
+        """
+        session_id = (event.get("session") or {}).get("id")
+        if not isinstance(session_id, str) or not session_id:
+            return
+        if session.metadata.get(GPT_LIVE_SESSION_ID_METADATA_KEY) == session_id:
+            return
+        session.metadata[GPT_LIVE_SESSION_ID_METADATA_KEY] = session_id
+        self.logger.info(
+            "GPT-Live session id", conversation_id=conv_id, gpt_live_session_id=session_id
+        )
 
     @staticmethod
     def _append_transcript_delta(

--- a/src/tac/channels/voice/media_streams/gpt_live/provider.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/provider.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import json
 import uuid
 from typing import TYPE_CHECKING, Any
@@ -75,10 +76,12 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        # Strong references for fire-and-forget _expire_session_config_token
-        # tasks — asyncio only weakly references a task with no other
-        # referrer, so without this the task can be GC'd mid-sleep.
-        self._pending_token_expiries: set[asyncio.Task[None]] = set()
+        # Keyed by session_config_token so _register_call can cancel a
+        # call's expiry task as soon as the token is claimed, instead of
+        # leaving it sleeping for the full TTL. Also the strong reference
+        # asyncio needs — it only weakly references a task with no other
+        # referrer, so without this the task could be GC'd mid-sleep.
+        self._pending_token_expiries: dict[str, asyncio.Task[None]] = {}
 
     @property
     def channel_name(self) -> str:
@@ -182,8 +185,10 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 expiry_task = asyncio.create_task(
                     self._expire_session_config_token(session_config_token)
                 )
-                self._pending_token_expiries.add(expiry_task)
-                expiry_task.add_done_callback(self._pending_token_expiries.discard)
+                self._pending_token_expiries[session_config_token] = expiry_task
+                expiry_task.add_done_callback(
+                    functools.partial(self._forget_token_expiry, session_config_token)
+                )
 
             return InitiateVoiceConversationResult(call_sid=call.sid)
 
@@ -203,9 +208,14 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
 
         Covers no-answer, busy, and other outbound-call outcomes that never
         trigger ``_register_call`` — the only other place this token is popped.
+        Cancelled by ``_register_call`` as soon as it claims the token, so
+        this only actually runs to completion when the call never connects.
         """
         await asyncio.sleep(_SESSION_CONFIG_TOKEN_TTL_SECONDS)
         self._call_session_configs.pop(token, None)
+
+    def _forget_token_expiry(self, token: str, _task: asyncio.Task[None]) -> None:
+        self._pending_token_expiries.pop(token, None)
 
     async def handle_websocket(self, websocket: WebSocketProtocol) -> None:
         """Drive one Twilio Media Stream connection from accept to disconnect.
@@ -261,7 +271,12 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
         except WebSocketDisconnectError:
             self.logger.info("Media stream WebSocket closed", conversation_id=conv_id)
         except Exception as e:
-            self.logger.error(f"Media stream WebSocket error: {e}", exc_info=True)
+            self.logger.error(
+                "Media stream WebSocket error",
+                error=str(e),
+                conversation_id=conv_id,
+                exc_info=True,
+            )
         finally:
             if conv_id is not None:
                 await self._cleanup_call(conv_id)
@@ -281,6 +296,9 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
             session_config = self._call_session_configs.pop(token, None)
             if session_config is not None:
                 self._call_session_configs[conv_id] = session_config
+            expiry_task = self._pending_token_expiries.get(token)
+            if expiry_task is not None:
+                expiry_task.cancel()
 
         self._calls[conv_id] = _CallState(twilio_ws=websocket)
 
@@ -420,7 +438,7 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
             self.logger.error(
                 "Received malformed function_call item without call_id",
                 conversation_id=conv_id,
-                item=item,
+                item_keys=list(item.keys()),
             )
             return
 
@@ -430,7 +448,7 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 "Received malformed function_call item without tool name",
                 conversation_id=conv_id,
                 call_id=call_id,
-                item=item,
+                item_keys=list(item.keys()),
             )
             output_json = json.dumps({"error": "Malformed function call: missing tool name."})
         else:
@@ -462,12 +480,30 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
     async def _cleanup_call(self, conv_id: str) -> None:
         call = self._calls.get(conv_id)
         if call is not None and call.model_ws is not None:
-            with contextlib.suppress(Exception):
+            try:
                 await call.model_ws.send(json.dumps({"type": "session.close"}))
-                await asyncio.wait_for(call.closed_event.wait(), timeout=_CLOSE_TIMEOUT_SECONDS)
+            except Exception as e:
+                self.logger.debug(
+                    "Error sending session.close to model socket",
+                    error=str(e),
+                    conversation_id=conv_id,
+                )
+            else:
+                try:
+                    await asyncio.wait_for(call.closed_event.wait(), timeout=_CLOSE_TIMEOUT_SECONDS)
+                except asyncio.TimeoutError:
+                    self.logger.debug(
+                        "Timed out waiting for session.closed", conversation_id=conv_id
+                    )
+                except Exception as e:
+                    self.logger.debug(
+                        "Error waiting for session.closed", error=str(e), conversation_id=conv_id
+                    )
             try:
                 await call.model_ws.close()
             except Exception as e:
-                self.logger.debug(f"Error closing model socket: {e}", conversation_id=conv_id)
+                self.logger.debug(
+                    "Error closing model socket", error=str(e), conversation_id=conv_id
+                )
         self._calls.pop(conv_id, None)
         await self.channel._end_conversation(conv_id)

--- a/src/tac/channels/voice/media_streams/gpt_live/provider.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/provider.py
@@ -56,6 +56,11 @@ TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu", "rate"
 #: How long to wait for `session.closed` before closing the socket anyway.
 _CLOSE_TIMEOUT_SECONDS = 5.0
 
+#: How long a _call_session_configs entry can outlive its outbound call
+#: before it's purged — covers no-answer, busy, and other cases where
+#: Twilio never connects the Media Stream to consume it via _register_call.
+_SESSION_CONFIG_TOKEN_TTL_SECONDS = 120.0
+
 
 class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
     """``VoiceProvider`` bridging Twilio Media Streams to OpenAI's GPT-Live alpha.
@@ -67,6 +72,13 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
     """
 
     config: GPTLiveProviderConfig
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Strong references for fire-and-forget _expire_session_config_token
+        # tasks — asyncio only weakly references a task with no other
+        # referrer, so without this the task can be GC'd mid-sleep.
+        self._pending_token_expiries: set[asyncio.Task[None]] = set()
 
     @property
     def channel_name(self) -> str:
@@ -166,6 +178,13 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 to=mask_phone(options.to),
             )
 
+            if session_config_token is not None:
+                expiry_task = asyncio.create_task(
+                    self._expire_session_config_token(session_config_token)
+                )
+                self._pending_token_expiries.add(expiry_task)
+                expiry_task.add_done_callback(self._pending_token_expiries.discard)
+
             return InitiateVoiceConversationResult(call_sid=call.sid)
 
         except Exception as e:
@@ -178,6 +197,15 @@ class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
                 exc_info=True,
             )
             raise
+
+    async def _expire_session_config_token(self, token: str) -> None:
+        """Purge a stashed session_config token if it's still unclaimed after the TTL.
+
+        Covers no-answer, busy, and other outbound-call outcomes that never
+        trigger ``_register_call`` — the only other place this token is popped.
+        """
+        await asyncio.sleep(_SESSION_CONFIG_TOKEN_TTL_SECONDS)
+        self._call_session_configs.pop(token, None)
 
     async def handle_websocket(self, websocket: WebSocketProtocol) -> None:
         """Drive one Twilio Media Stream connection from accept to disconnect.

--- a/src/tac/channels/voice/media_streams/gpt_live/provider.py
+++ b/src/tac/channels/voice/media_streams/gpt_live/provider.py
@@ -1,0 +1,431 @@
+"""``GPTLiveProvider``: bridges Twilio Media Streams to OpenAI's GPT-Live alpha.
+
+GPT-Live is an unreleased OpenAI alpha API.
+
+Unlike ``OpenAIRealtimeProvider``, GPT-Live is full-duplex — there's no
+client-driven barge-in truncate, the model handles interruption itself — and
+tool calls go through Responses delegation instead of direct function-calling
+events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import websockets
+
+from tac.channels.voice.media_streams.gpt_live.models import _CallState
+from tac.channels.voice.media_streams.shared.openai_provider import (
+    OPENAI_USER_AGENT,
+    MediaStreamsOpenAIProvider,
+)
+from tac.channels.websocket_protocol import WebSocketDisconnectError, WebSocketProtocol
+from tac.models.outbound import (
+    InitiateVoiceConversationOptions,
+    InitiateVoiceConversationOptionsGPTLive,
+    InitiateVoiceConversationResult,
+)
+from tac.models.session import ConversationSession
+from tac.models.stream import StreamStartMessage
+from tac.models.voice import VoiceTwiMLOptionsMediaStreams
+from tac.utils.redaction import mask_phone, redact_twiml_parameters
+
+if TYPE_CHECKING:
+    from tac.channels.voice.media_streams.gpt_live.config import GPTLiveProviderConfig
+
+# TODO: remove once GPT-Live is released (GA drops the alpha header requirement).
+#: Required on every GPT-Live alpha request — omitting it is rejected.
+_OPENAI_ALPHA_HEADER_NAME = "OpenAI-Alpha"
+_OPENAI_ALPHA_HEADER_VALUE = "quicksilver=v2"
+
+#: Reserved <Stream> custom_parameters key used to correlate an outbound
+#: call's session_config override to its WebSocket start event. calls.create()
+#: returning call.sid doesn't happen-before Twilio connecting the stream, so
+#: call.sid can't be the correlation key — this token, embedded in the TwiML
+#: before the call is placed, can.
+_SESSION_CONFIG_TOKEN_PARAM = "_tac_session_config_token"
+
+#: GPT-Live speaks Twilio's exact wire format natively — unlike the Realtime
+#: API's separate session.audio.input/output.format, this is a single shared
+#: session.audio.format, selected once at WebSocket startup and immutable
+#: after. No transcoding needed on either leg between Twilio and GPT-Live.
+TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu", "rate": 8000}
+
+
+class GPTLiveProvider(MediaStreamsOpenAIProvider[_CallState]):
+    """``VoiceProvider`` bridging Twilio Media Streams to OpenAI's GPT-Live alpha.
+
+    Example:
+        ```python
+        channel = VoiceChannel(tac, config=GPTLiveProviderConfig(default_session_config=...))
+        ```
+    """
+
+    config: GPTLiveProviderConfig
+
+    @property
+    def channel_name(self) -> str:
+        return "VOICE_MEDIA_STREAM_OPENAI_GPT_LIVE"
+
+    async def initiate_outbound_conversation(
+        self,
+        options: InitiateVoiceConversationOptions,
+    ) -> InitiateVoiceConversationResult:
+        """Initiate an outbound voice conversation.
+
+        Places an outbound call with inline TwiML that connects to a Media
+        Stream. Unlike inbound, there's no local session yet at this point —
+        it's created when Twilio's WebSocket ``start`` event arrives, the
+        same as ``_register_call`` does for inbound.
+
+        TwiML fields are merged per-field — see ``TwiMLBuilderMediaStreams.build``.
+        The WebSocket URL is derived from ``TACConfig.voice_public_domain`` +
+        ``TACConfig.voice_websocket_path``, unless overridden per-call via
+        ``options.websocket_url``.
+
+        Pass ``InitiateVoiceConversationOptionsGPTLive`` with ``session_config``
+        set to override the default for this call.
+        """
+        twiml_options = options.twiml_options
+        if twiml_options is not None and not isinstance(
+            twiml_options, VoiceTwiMLOptionsMediaStreams
+        ):
+            raise TypeError(
+                "GPTLiveProvider.initiate_outbound_conversation requires "
+                "options.twiml_options to be a VoiceTwiMLOptionsMediaStreams, got "
+                f"{type(twiml_options).__name__}"
+            )
+
+        # A token embedded in the TwiML below correlates this override to its
+        # WebSocket start event — not call.sid, since Twilio connecting the
+        # stream doesn't happen-after calls.create() returning call.sid.
+        # Building the token/TwiML here doesn't touch _call_session_configs
+        # yet; that's deferred until right before the call is placed (below),
+        # so a failure in _twiml.build() has nothing to leak.
+        session_config = (
+            options.session_config
+            if isinstance(options, InitiateVoiceConversationOptionsGPTLive)
+            else None
+        )
+        session_config_token: str | None = None
+        if session_config is not None:
+            session_config_token = uuid.uuid4().hex
+            existing_params = (twiml_options.custom_parameters or {}) if twiml_options else {}
+            twiml_options = (twiml_options or VoiceTwiMLOptionsMediaStreams()).model_copy(
+                update={
+                    "custom_parameters": {
+                        **existing_params,
+                        _SESSION_CONFIG_TOKEN_PARAM: session_config_token,
+                    }
+                }
+            )
+
+        from_number = self.channel.tac.config.phone_number
+
+        self.logger.info(
+            "Initiating outbound voice conversation",
+            to=mask_phone(options.to),
+            from_number=mask_phone(from_number),
+        )
+
+        twiml_xml = self._twiml.build(
+            "initiate_outbound_conversation",
+            per_call=twiml_options,
+            websocket_url=options.websocket_url,
+        )
+
+        call_kwargs = self._build_call_kwargs(options.call_options)
+
+        if session_config_token is not None and session_config is not None:
+            self._call_session_configs[session_config_token] = session_config
+
+        try:
+            self.logger.debug(
+                "Outbound call TwiML",
+                twiml=redact_twiml_parameters(twiml_xml),
+                to=mask_phone(options.to),
+            )
+
+            client = self.channel._get_twilio_client()
+            call = await asyncio.to_thread(
+                client.calls.create,
+                to=options.to,
+                from_=from_number,
+                twiml=twiml_xml,
+                **call_kwargs,
+            )
+
+            self.logger.info(
+                "Outbound voice call placed",
+                call_sid=call.sid,
+                to=mask_phone(options.to),
+            )
+
+            return InitiateVoiceConversationResult(call_sid=call.sid)
+
+        except Exception as e:
+            if session_config_token is not None:
+                self._call_session_configs.pop(session_config_token, None)
+            self.logger.error(
+                "Failed to initiate outbound call",
+                to=mask_phone(options.to),
+                error=str(e),
+                exc_info=True,
+            )
+            raise
+
+    async def handle_websocket(self, websocket: WebSocketProtocol) -> None:
+        """Drive one Twilio Media Stream connection from accept to disconnect.
+
+        Races the Twilio read against the GPT-Live model-event reader so that
+        if the model side disconnects first, we stop pumping caller audio
+        into a dead socket and tear the call down immediately instead of
+        leaving the caller connected to silence.
+        """
+        await websocket.accept()
+
+        conv_id: str | None = None
+        model_reader: asyncio.Task[None] | None = None
+
+        try:
+            while True:
+                recv_task: asyncio.Task[dict[str, Any]] = asyncio.create_task(
+                    websocket.receive_json()
+                )
+                waiters: list[asyncio.Task[Any]] = [recv_task]
+                if model_reader is not None:
+                    waiters.append(model_reader)
+
+                done, _pending = await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
+
+                if model_reader is not None and model_reader in done:
+                    recv_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await recv_task
+                    self.logger.info("Model connection ended", conversation_id=conv_id)
+                    break
+
+                data = recv_task.result()
+                event = data.get("event")
+
+                if event == "start":
+                    conv_id = self._register_call(data.get("start") or {}, websocket)
+                    await self._connect_model(conv_id)
+                    model_reader = asyncio.create_task(self._handle_model_events(conv_id))
+
+                elif event == "media":
+                    media = data.get("media") or {}
+                    if conv_id is not None and media.get("payload"):
+                        await self._model_send(
+                            conv_id,
+                            {"type": "input_audio.append", "audio": media["payload"]},
+                        )
+
+                elif event == "stop":
+                    self.logger.info("Media stream stopped", conversation_id=conv_id)
+                    break
+
+        except WebSocketDisconnectError:
+            self.logger.info("Media stream WebSocket closed", conversation_id=conv_id)
+        except Exception as e:
+            self.logger.error(f"Media stream WebSocket error: {e}", exc_info=True)
+        finally:
+            if model_reader is not None and not model_reader.done():
+                model_reader.cancel()
+            if model_reader is not None:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await model_reader
+            if conv_id is not None:
+                await self._cleanup_call(conv_id)
+
+    def _register_call(self, start: dict[str, Any], websocket: WebSocketProtocol) -> str:
+        """Handle Twilio's ``start`` event, returning the conversation id."""
+        message = StreamStartMessage(**start)
+        conv_id = message.conversation_id
+
+        token = message.custom_parameters.get(_SESSION_CONFIG_TOKEN_PARAM)
+        if token is not None:
+            session_config = self._call_session_configs.pop(token, None)
+            if session_config is not None:
+                self._call_session_configs[conv_id] = session_config
+
+        self._calls[conv_id] = _CallState(twilio_ws=websocket)
+
+        session = self.channel._start_conversation(conv_id, profile_id=None)
+        session.call_sid = message.call_sid
+        session.metadata.update({"stream_sid": message.stream_sid, "transcript": []})
+
+        self.logger.debug(
+            "Media stream started", conversation_id=conv_id, media_format=message.media_format
+        )
+        return conv_id
+
+    async def _connect_model(self, conv_id: str) -> None:
+        """Open the GPT-Live WebSocket and send the session config.
+
+        Uses this call's ``_call_session_configs`` entry if one was stashed
+        (by ``handle_incoming_call`` or ``initiate_outbound_conversation``),
+        else falls back to ``default_session_config``.
+        """
+        session_config = self._call_session_configs.pop(conv_id, None)
+        if session_config is None:
+            session_config = self.config.default_session_config
+        if session_config is None:
+            raise ValueError(
+                f"No session_config available for call {conv_id} — this call supplied none "
+                "and default_session_config isn't set either."
+            )
+        audio_format = (session_config.get("audio") or {}).get("format")
+        if audio_format != TWILIO_MEDIA_STREAM_AUDIO_FORMAT:
+            raise ValueError(
+                f"session_config for call {conv_id} has audio.format={audio_format!r} — "
+                f"Twilio Media Streams always sends/expects {TWILIO_MEDIA_STREAM_AUDIO_FORMAT!r}, "
+                "this isn't configurable. Set audio.format to TWILIO_MEDIA_STREAM_AUDIO_FORMAT."
+            )
+        if "model" in session_config:
+            # The model is selected via the WebSocket URL's ?model= query
+            # param; GPT-Live rejects repeating it in the initial session.update.
+            raise ValueError(
+                f"session_config for call {conv_id} must not include 'model' — GPT-Live "
+                "selects it from the ?model= query param (GPTLiveProviderConfig.model), "
+                "not from session_config."
+            )
+
+        model_ws = await websockets.connect(
+            f"wss://api.openai.com/v1/live?model={self.config.model}",
+            additional_headers={
+                "Authorization": f"Bearer {self.config.openai_api_key}",
+                "User-Agent": OPENAI_USER_AGENT,
+                _OPENAI_ALPHA_HEADER_NAME: _OPENAI_ALPHA_HEADER_VALUE,
+            },
+        )
+        call = self._calls.get(conv_id)
+        if call is not None:
+            call.model_ws = model_ws
+        self.logger.info("Connected to GPT-Live", conversation_id=conv_id)
+
+        await self._model_send(conv_id, {"type": "session.update", "session": session_config})
+        # welcome_instruction is sent once session.started arrives — see _dispatch_model_event.
+
+    async def _dispatch_model_event(
+        self, conv_id: str, session: ConversationSession, event: dict[str, Any]
+    ) -> None:
+        event_type = event.get("type")
+
+        if event_type == "error":
+            self.logger.error(
+                "GPT-Live error event", conversation_id=conv_id, error=event.get("error")
+            )
+
+        elif event_type == "session.started":
+            # session.context.append before this event is undocumented behavior.
+            instruction = self.config.welcome_instruction
+            if instruction is not None:
+                # Sent verbatim — caller must word it as an instruction, not a
+                # bare greeting, or the model won't speak first.
+                await self._model_send(
+                    conv_id,
+                    {
+                        "type": "session.context.append",
+                        "channel": "speakable",
+                        "content": [{"type": "input_text", "text": instruction}],
+                    },
+                )
+
+        elif event_type == "turn.done":
+            # One assembled entry per turn — unlike Realtime's fragment-level
+            # *_transcript.added events.
+            turn = event.get("turn") or {}
+            text = turn.get("transcript")
+            role = turn.get("role")
+            if text and role:
+                session.metadata.setdefault("transcript", []).append({"role": role, "text": text})
+
+        elif event_type == "output_audio.delta" and event.get("audio"):
+            # No item_id/barge-in bookkeeping needed — GPT-Live is
+            # full-duplex and handles interruption server-side.
+            await self._twilio_send(
+                conv_id,
+                {
+                    "event": "media",
+                    "streamSid": session.metadata.get("stream_sid"),
+                    "media": {"payload": event["audio"]},
+                },
+            )
+
+        elif event_type == "response.output_item.done":
+            # "completed" excludes calls cut short mid-generation.
+            item = event.get("item") or {}
+            if item.get("type") == "function_call" and item.get("status") == "completed":
+                await self._handle_function_call(conv_id, item)
+
+    async def _handle_function_call(self, conv_id: str, item: dict[str, Any]) -> None:
+        """Run a Responses-delegated tool call and hand the result back.
+
+        Unlike Realtime, no follow-up ``response.create`` is sent — GPT-Live
+        continues on its own once the delegation output is acknowledged.
+        Always sends a function_call_output when call_id is present — even a
+        tool that ran successfully can return a non-JSON-serializable object
+        (a datetime, a Pydantic model, ...), and the model would otherwise be
+        left waiting on a call_id it never gets a result for. Without a
+        call_id there's nothing to reply to, so the item is dropped instead.
+        """
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            self.logger.error(
+                "Received malformed function_call item without call_id",
+                conversation_id=conv_id,
+                item=item,
+            )
+            return
+
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            self.logger.error(
+                "Received malformed function_call item without tool name",
+                conversation_id=conv_id,
+                call_id=call_id,
+                item=item,
+            )
+            output_json = json.dumps({"error": "Malformed function call: missing tool name."})
+        else:
+            output = await self._run_tool_call(conv_id, name, item.get("arguments"))
+            try:
+                output_json = json.dumps(output)
+            except TypeError as e:
+                self.logger.error(
+                    f"Tool '{name}' returned a non-JSON-serializable result: {e}",
+                    conversation_id=conv_id,
+                )
+                output_json = json.dumps(
+                    {"error": f"Tool '{name}' returned a non-serializable result."}
+                )
+
+        await self._model_send(
+            conv_id,
+            {
+                "type": "delegation.function_call_output.create",
+                "item": {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": output_json,
+                },
+            },
+        )
+
+    async def _cleanup_call(self, conv_id: str) -> None:
+        call = self._calls.pop(conv_id, None)
+        if call is not None and call.model_ws is not None:
+            # Known limitation: doesn't wait for session.closed before
+            # closing the socket out from under it.
+            with contextlib.suppress(Exception):
+                await call.model_ws.send(json.dumps({"type": "session.close"}))
+            try:
+                await call.model_ws.close()
+            except Exception as e:
+                self.logger.debug(f"Error closing model socket: {e}", conversation_id=conv_id)
+        await self.channel._end_conversation(conv_id)

--- a/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/__init__.py
@@ -2,7 +2,7 @@
 
 from tac.channels.voice.media_streams.openai_realtime.config import OpenAIRealtimeProviderConfig
 from tac.channels.voice.media_streams.openai_realtime.provider import (
-    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    TWILIO_AUDIO_FORMAT_FOR_REALTIME,
     OpenAIRealtimeProvider,
 )
 from tac.channels.voice.media_streams.twiml import generate_twiml
@@ -11,7 +11,7 @@ from tac.models.stream import StreamStartMessage
 from tac.models.voice import VoiceTwiMLOptionsMediaStreams
 
 __all__ = [
-    "TWILIO_MEDIA_STREAM_AUDIO_FORMAT",
+    "TWILIO_AUDIO_FORMAT_FOR_REALTIME",
     "InitiateVoiceConversationOptionsOpenAIRealtime",
     "OpenAIRealtimeProvider",
     "OpenAIRealtimeProviderConfig",

--- a/src/tac/channels/voice/media_streams/openai_realtime/provider.py
+++ b/src/tac/channels/voice/media_streams/openai_realtime/provider.py
@@ -41,13 +41,11 @@ if TYPE_CHECKING:
     )
 
 
-#: Twilio Media Streams always sends/expects 8kHz G.711 u-law audio — per
-#: https://www.twilio.com/docs/voice/media-streams/websocket-messages, this
-#: isn't a provider choice or a default, it's the only format Twilio's
-#: bidirectional Stream supports. No ``rate`` field — OpenAI's Realtime
-#: ``session.audio.*.format`` schema rejects it as unknown (g711 is
-#: inherently fixed-rate, so it isn't settable).
-TWILIO_MEDIA_STREAM_AUDIO_FORMAT: dict[str, Any] = {"type": "audio/pcmu"}
+#: Twilio Media Streams always sends/expects 8kHz G.711 u-law — see
+#: https://www.twilio.com/docs/voice/media-streams/websocket-messages. Not
+#: configurable. No ``rate`` key — Realtime's schema rejects it as unknown
+#: (g711 is inherently fixed-rate).
+TWILIO_AUDIO_FORMAT_FOR_REALTIME: dict[str, Any] = {"type": "audio/pcmu"}
 
 #: G.711 u-law at 8kHz is 1 byte/sample, 8000 samples/sec — a fixed,
 #: non-configurable rate, so audio byte count converts to milliseconds by
@@ -296,12 +294,12 @@ class OpenAIRealtimeProvider(MediaStreamsOpenAIProvider[_CallState]):
             )
         for direction in ("input", "output"):
             fmt = ((session_config.get("audio") or {}).get(direction) or {}).get("format")
-            if fmt != TWILIO_MEDIA_STREAM_AUDIO_FORMAT:
+            if fmt != TWILIO_AUDIO_FORMAT_FOR_REALTIME:
                 raise ValueError(
-                    f"session_config for call {conv_id} has audio.{direction}.format={fmt!r} — "
-                    f"Twilio Media Streams always sends/expects "
-                    f"{TWILIO_MEDIA_STREAM_AUDIO_FORMAT!r}, this isn't configurable. Set "
-                    f"audio.{direction}.format to TWILIO_MEDIA_STREAM_AUDIO_FORMAT."
+                    f"session_config for call {conv_id} has audio.{direction}.format={fmt!r}, "
+                    f"expected {TWILIO_AUDIO_FORMAT_FOR_REALTIME!r}. Twilio Media Streams is "
+                    f"always 8kHz G.711 u-law; set audio.{direction}.format to "
+                    "TWILIO_AUDIO_FORMAT_FOR_REALTIME."
                 )
 
         model_ws = await websockets.connect(

--- a/src/tac/channels/voice/media_streams/shared/openai_provider.py
+++ b/src/tac/channels/voice/media_streams/shared/openai_provider.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 #: Identifies this SDK to OpenAI on every WebSocket connection, per OpenAI's
 #: requested User-Agent pattern: [Company/Library name]/[Language] [Version].
-OPENAI_USER_AGENT = f"twilio-agent-connect-python/Python {__version__}"
+OPENAI_USER_AGENT = f"twilio-agent-connect/Python {__version__}"
 
 TCallState = TypeVar("TCallState", bound=MediaStreamsOpenAICallState)
 

--- a/src/tac/models/outbound.py
+++ b/src/tac/models/outbound.py
@@ -227,6 +227,16 @@ class InitiateVoiceConversationOptionsOpenAIRealtime(InitiateVoiceConversationOp
     )
 
 
+class InitiateVoiceConversationOptionsGPTLive(InitiateVoiceConversationOptions):
+    """Outbound options for ``GPTLiveProvider``, adding a per-call ``session_config``."""
+
+    session_config: dict[str, Any] | None = Field(
+        default=None,
+        description="Used verbatim in place of "
+        "GPTLiveProviderConfig.default_session_config for this call.",
+    )
+
+
 class InitiateVoiceConversationResult(BaseModel):
     """Result of initiating an outbound voice conversation."""
 

--- a/tests/test_gpt_live_provider.py
+++ b/tests/test_gpt_live_provider.py
@@ -1,0 +1,621 @@
+"""Tests for GPTLiveProvider: connection lifecycle, tool calls, transcript."""
+
+import asyncio
+import json
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tac import TAC
+from tac.channels.voice import VoiceChannel
+from tac.channels.voice.media_streams.gpt_live import (
+    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    GPTLiveProviderConfig,
+)
+from tac.channels.voice.media_streams.gpt_live.models import _CallState
+from tac.channels.voice.media_streams.gpt_live.provider import _SESSION_CONFIG_TOKEN_PARAM
+from tac.models.outbound import (
+    InitiateVoiceConversationOptions,
+    InitiateVoiceConversationOptionsGPTLive,
+)
+from tac.models.voice import TwiMLRequest
+from tac.tools import function_tool
+
+_VALID_SESSION_CONFIG = {
+    # No "model" here — GPT-Live's WebSocket docs say not to repeat it in
+    # session.update; the model is selected via the ?model= query param
+    # (GPTLiveProviderConfig.model) instead.
+    "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+}
+
+
+def _extract_custom_parameter(twiml: str, name: str) -> str:
+    """Pull a <Parameter name="..." value="..."> value out of generated TwiML."""
+    match = re.search(rf'<Parameter name="{re.escape(name)}" value="([^"]*)"', twiml)
+    assert match, f"parameter {name!r} not found in TwiML: {twiml}"
+    return match.group(1)
+
+
+def get_test_tac_config() -> dict:
+    return {
+        "account_sid": "ACtest123",
+        "auth_token": "test_token_123",
+        "api_key": "SK123",
+        "api_secret": "test_api_token",
+        "conversation_configuration_id": "conv_configuration_test123",
+        "phone_number": "+15551234567",
+        "voice_public_domain": "example.com",
+    }
+
+
+def make_channel(**config_kwargs: object) -> VoiceChannel:
+    tac = TAC(get_test_tac_config())
+    config = GPTLiveProviderConfig(
+        openai_api_key="sk-test",
+        default_session_config=dict(_VALID_SESSION_CONFIG),
+        **config_kwargs,
+    )
+    return VoiceChannel(tac, config=config)
+
+
+class FakeTwilioWebSocket:
+    """Fake Twilio-facing WebSocket. Yields queued events, then hangs
+    forever (like a real, still-open connection with nothing new to say)
+    until the awaiting task is cancelled."""
+
+    def __init__(self, events: list[dict]) -> None:
+        self._events = list(events)
+        self.accepted = False
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive_json(self) -> dict:
+        if self._events:
+            return self._events.pop(0)
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def send_text(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeModelWebSocket:
+    """Fake GPT-Live WebSocket. Async-iterates over queued raw events.
+
+    When ``events`` runs out: if ``stay_open`` is True, hangs forever (a
+    live connection with nothing new to say). Otherwise ends the stream
+    immediately (a closed connection).
+    """
+
+    def __init__(self, events: list[dict] | None = None, stay_open: bool = False) -> None:
+        self._events = list(events or [])
+        self._stay_open = stay_open
+        self.sent: list[dict] = []
+        self.closed = False
+
+    def __aiter__(self) -> "FakeModelWebSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        if self._events:
+            return json.dumps(self._events.pop(0))
+        if self._stay_open:
+            await asyncio.Event().wait()
+        raise StopAsyncIteration
+
+    async def send(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class TestConfigValidation:
+    def test_requires_openai_api_key(self) -> None:
+        with pytest.raises(ValueError, match="openai_api_key is required"):
+            GPTLiveProviderConfig(
+                openai_api_key=None, default_session_config=dict(_VALID_SESSION_CONFIG)
+            )
+
+    def test_neither_source_alone_is_also_valid(self) -> None:
+        """Legitimate for an outbound-only provider supplying session_config
+        per-call via InitiateVoiceConversationOptionsGPTLive."""
+        GPTLiveProviderConfig(openai_api_key="sk-test")
+
+    def test_on_inbound_call_session_config_alone_is_valid(self) -> None:
+        async def customizer(req: TwiMLRequest) -> dict | None:
+            return dict(_VALID_SESSION_CONFIG)
+
+        GPTLiveProviderConfig(openai_api_key="sk-test", on_inbound_call_session_config=customizer)
+
+    def test_model_defaults(self) -> None:
+        config = GPTLiveProviderConfig(
+            openai_api_key="sk-test", default_session_config=dict(_VALID_SESSION_CONFIG)
+        )
+        assert config.model == "gpt-live-1-marble-alpha"
+
+
+class TestOutboundCallSessionConfig:
+    """Per-outbound-call session_config via InitiateVoiceConversationOptionsGPTLive."""
+
+    @pytest.mark.asyncio
+    async def test_session_config_stashed_under_a_token_before_call_is_placed(self) -> None:
+        """Stashed under a token embedded in the TwiML, not call.sid — Twilio
+        connecting the stream doesn't happen-after calls.create() returning
+        call.sid, so keying by call.sid can race _register_call."""
+        channel = make_channel()
+        provider = channel._provider
+
+        mock_call = MagicMock(sid="CA_OUT")
+        mock_client = MagicMock()
+        mock_client.calls.create.return_value = mock_call
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            result = await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptionsGPTLive(
+                    to="+15551234567",
+                    session_config=dict(_VALID_SESSION_CONFIG),
+                )
+            )
+
+        assert result.call_sid == "CA_OUT"
+        assert "CA_OUT" not in provider._call_session_configs
+        twiml = mock_client.calls.create.call_args.kwargs["twiml"]
+        token = _extract_custom_parameter(twiml, _SESSION_CONFIG_TOKEN_PARAM)
+        assert provider._call_session_configs[token] == _VALID_SESSION_CONFIG
+
+    @pytest.mark.asyncio
+    async def test_session_config_token_rekeyed_to_call_sid_on_connect(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        mock_call = MagicMock(sid="CA_OUT4")
+        mock_client = MagicMock()
+        mock_client.calls.create.return_value = mock_call
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptionsGPTLive(
+                    to="+15551234567",
+                    session_config={
+                        "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+                        "instructions": "outbound override",
+                    },
+                )
+            )
+
+        twiml = mock_client.calls.create.call_args.kwargs["twiml"]
+        token = _extract_custom_parameter(twiml, _SESSION_CONFIG_TOKEN_PARAM)
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {
+                    "event": "start",
+                    "start": {
+                        "callSid": "CA_OUT4",
+                        "streamSid": "MZ_OUT4",
+                        "customParameters": {_SESSION_CONFIG_TOKEN_PARAM: token},
+                    },
+                }
+            ]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=False)
+
+        with patch(
+            "tac.channels.voice.media_streams.gpt_live.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        sent_session = next(m for m in model_ws.sent if m["type"] == "session.update")
+        assert sent_session["session"]["instructions"] == "outbound override"
+        assert provider._call_session_configs == {}
+
+    @pytest.mark.asyncio
+    async def test_session_config_token_cleaned_up_if_call_creation_fails(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        mock_client = MagicMock()
+        mock_client.calls.create.side_effect = RuntimeError("boom")
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            with pytest.raises(RuntimeError):
+                await provider.initiate_outbound_conversation(
+                    InitiateVoiceConversationOptionsGPTLive(
+                        to="+15551234567",
+                        session_config=dict(_VALID_SESSION_CONFIG),
+                    )
+                )
+
+        assert provider._call_session_configs == {}
+
+    @pytest.mark.asyncio
+    async def test_plain_options_type_ignored_falls_back_to_default(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        mock_call = MagicMock(sid="CA_OUT2")
+        mock_client = MagicMock()
+        mock_client.calls.create.return_value = mock_call
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptions(to="+15551234567")
+            )
+
+        assert provider._call_session_configs == {}
+
+    @pytest.mark.asyncio
+    async def test_outbound_only_config_with_no_default_connects_via_per_call_override(
+        self,
+    ) -> None:
+        tac = TAC(get_test_tac_config())
+        config = GPTLiveProviderConfig(openai_api_key="sk-test")
+        channel = VoiceChannel(tac, config=config)
+        provider = channel._provider
+
+        mock_call = MagicMock(sid="CA_OUT3")
+        mock_client = MagicMock()
+        mock_client.calls.create.return_value = mock_call
+
+        with patch.object(channel, "_get_twilio_client", return_value=mock_client):
+            await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptionsGPTLive(
+                    to="+15551234567",
+                    session_config=dict(_VALID_SESSION_CONFIG),
+                )
+            )
+
+        twiml = mock_client.calls.create.call_args.kwargs["twiml"]
+        token = _extract_custom_parameter(twiml, _SESSION_CONFIG_TOKEN_PARAM)
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {
+                    "event": "start",
+                    "start": {
+                        "callSid": "CA_OUT3",
+                        "streamSid": "MZ_OUT3",
+                        "customParameters": {_SESSION_CONFIG_TOKEN_PARAM: token},
+                    },
+                }
+            ]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=False)
+
+        with patch(
+            "tac.channels.voice.media_streams.gpt_live.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ) as mock_connect:
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert "v1/live?model=gpt-live-1-marble-alpha" in mock_connect.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_session_config_token_not_leaked_if_twiml_build_fails(self) -> None:
+        """A failure building the TwiML itself (e.g. no resolvable WebSocket
+        URL) happens before calls.create() is ever attempted — the token
+        must not be stashed until that succeeds, or it's never cleaned up."""
+        tac = TAC(get_test_tac_config())
+        config = GPTLiveProviderConfig(
+            openai_api_key="sk-test", default_session_config=dict(_VALID_SESSION_CONFIG)
+        )
+        channel = VoiceChannel(tac, config=config)
+        provider = channel._provider
+        channel.tac.config.voice_public_domain = None  # no fallback WebSocket URL
+
+        with pytest.raises(ValueError, match="needs a WebSocket URL"):
+            await provider.initiate_outbound_conversation(
+                InitiateVoiceConversationOptionsGPTLive(
+                    to="+15551234567",
+                    session_config=dict(_VALID_SESSION_CONFIG),
+                )
+            )
+
+        assert provider._call_session_configs == {}
+
+
+class TestHandleWebSocketLifecycle:
+    @pytest.mark.asyncio
+    async def test_model_disconnect_ends_call_without_hanging(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[{"event": "start", "start": {"callSid": "CA123", "streamSid": "MZ123"}}]
+        )
+        model_ws = FakeModelWebSocket(events=[])  # ends immediately
+
+        with patch(
+            "tac.channels.voice.media_streams.gpt_live.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert provider._calls == {}
+        assert model_ws.closed is True
+        assert "CA123" not in channel._conversations
+
+    @pytest.mark.asyncio
+    async def test_input_audio_forwarded_with_gpt_live_event_shape(self) -> None:
+        """Unlike Realtime's input_audio_buffer.append, GPT-Live uses
+        input_audio.append."""
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {"event": "start", "start": {"callSid": "CA789", "streamSid": "MZ789"}},
+                {"event": "media", "media": {"payload": "abcd"}},
+                {"event": "stop"},
+            ]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=True)
+
+        with patch(
+            "tac.channels.voice.media_streams.gpt_live.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert {"type": "input_audio.append", "audio": "abcd"} in model_ws.sent
+
+    @pytest.mark.asyncio
+    async def test_session_close_sent_on_teardown(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[
+                {"event": "start", "start": {"callSid": "CA_CLOSE", "streamSid": "MZ_CLOSE"}},
+                {"event": "stop"},
+            ]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=True)
+
+        with patch(
+            "tac.channels.voice.media_streams.gpt_live.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert {"type": "session.close"} in model_ws.sent
+
+
+class TestConnectModelSessionConfig:
+    @pytest.mark.asyncio
+    async def test_missing_audio_format_raises_at_connect_time(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+        provider._call_session_configs["CA_BAD"] = {"instructions": "no audio.format here"}
+
+        with pytest.raises(ValueError, match="audio.format"):
+            await provider._connect_model("CA_BAD")
+
+    @pytest.mark.asyncio
+    async def test_model_key_in_session_config_raises_at_connect_time(self) -> None:
+        """GPT-Live rejects repeating 'model' in the initial session.update — it
+        comes from the ?model= query param (GPTLiveProviderConfig.model) instead."""
+        channel = make_channel()
+        provider = channel._provider
+        provider._call_session_configs["CA_MODEL"] = {
+            "model": "gpt-live-1-marble-alpha",
+            "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+        }
+
+        with pytest.raises(ValueError, match="must not include 'model'"):
+            await provider._connect_model("CA_MODEL")
+
+    @pytest.mark.asyncio
+    async def test_wss_url_uses_configured_model(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[{"event": "start", "start": {"callSid": "CA_URL", "streamSid": "MZ_URL"}}]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=False)
+
+        with patch(
+            "tac.channels.voice.media_streams.gpt_live.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ) as mock_connect:
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        assert "v1/live?model=gpt-live-1-marble-alpha" in mock_connect.call_args.args[0]
+        headers = mock_connect.call_args.kwargs["additional_headers"]
+        assert headers["OpenAI-Alpha"] == "quicksilver=v2"
+
+
+class TestInboundCallSessionConfig:
+    @pytest.mark.asyncio
+    async def test_customizer_result_used_verbatim_for_that_call(self) -> None:
+        async def customizer(req: TwiMLRequest) -> dict | None:
+            if req.caller_country == "MX":
+                return {
+                    "instructions": "Habla en español.",
+                    "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+                }
+            return None
+
+        channel = make_channel(on_inbound_call_session_config=customizer)
+        provider = channel._provider
+
+        await provider.handle_incoming_call(
+            twiml_request=TwiMLRequest(call_sid="CA_MX", caller_country="MX")
+        )
+        assert provider._call_session_configs["CA_MX"]["instructions"] == "Habla en español."
+
+        twilio_ws = FakeTwilioWebSocket(
+            events=[{"event": "start", "start": {"callSid": "CA_MX", "streamSid": "MZ_MX"}}]
+        )
+        model_ws = FakeModelWebSocket(events=[], stay_open=False)
+
+        with patch(
+            "tac.channels.voice.media_streams.gpt_live.provider.websockets.connect",
+            new=AsyncMock(return_value=model_ws),
+        ):
+            await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
+
+        sent_session = next(m for m in model_ws.sent if m["type"] == "session.update")
+        assert sent_session["session"]["instructions"] == "Habla en español."
+        assert "CA_MX" not in provider._call_session_configs
+
+
+class TestTurnDoneTranscript:
+    @pytest.mark.asyncio
+    async def test_turn_done_captures_transcript(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        provider._calls["CA1"] = _CallState()
+        session = channel._start_conversation("CA1", profile_id=None)
+
+        await provider._dispatch_model_event(
+            "CA1", session, {"type": "turn.done", "turn": {"role": "user", "transcript": "hi"}}
+        )
+
+        assert session.metadata["transcript"] == [{"role": "user", "text": "hi"}]
+
+
+class TestOutputAudioDelta:
+    @pytest.mark.asyncio
+    async def test_output_audio_delta_relayed_to_twilio(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        twilio_ws = FakeTwilioWebSocket(events=[])
+        provider._calls["CA2"] = _CallState(twilio_ws=twilio_ws)
+        session = channel._start_conversation("CA2", profile_id=None)
+        session.metadata["stream_sid"] = "MZ2"
+
+        await provider._dispatch_model_event(
+            "CA2", session, {"type": "output_audio.delta", "audio": "xyz"}
+        )
+
+        assert twilio_ws.sent == [
+            {"event": "media", "streamSid": "MZ2", "media": {"payload": "xyz"}}
+        ]
+
+
+class TestToolCalls:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error_without_raising(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        result = await provider._run_tool_call("CA6", "does_not_exist", "{}")
+
+        assert result == {"error": "Unknown tool 'does_not_exist'"}
+
+    @pytest.mark.asyncio
+    async def test_function_call_uses_delegation_event_with_no_followup(self) -> None:
+        """Unlike Realtime's two-send pattern (function_call_output +
+        response.create), GPT-Live's Responses delegation only needs one
+        send — no follow-up response.create."""
+
+        @function_tool()
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        channel = make_channel(tools=[add])
+        provider = channel._provider
+
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA3"] = _CallState(model_ws=model_ws)
+
+        await provider._handle_function_call(
+            "CA3",
+            {
+                "call_id": "call_1",
+                "name": "add",
+                "arguments": json.dumps({"a": 2, "b": 3}),
+            },
+        )
+
+        assert len(model_ws.sent) == 1
+        sent = model_ws.sent[0]
+        assert sent["type"] == "delegation.function_call_output.create"
+        assert sent["item"]["call_id"] == "call_1"
+        assert json.loads(sent["item"]["output"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_non_serializable_output_still_sends_function_call_output(self) -> None:
+        @function_tool()
+        def broken_output() -> object:
+            """Return a value json.dumps can't serialize."""
+            return object()
+
+        channel = make_channel(tools=[broken_output])
+        provider = channel._provider
+
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA4"] = _CallState(model_ws=model_ws)
+
+        await provider._handle_function_call(
+            "CA4", {"call_id": "call_1", "name": "broken_output", "arguments": "{}"}
+        )
+
+        assert len(model_ws.sent) == 1
+        payload = json.loads(model_ws.sent[0]["item"]["output"])
+        assert "error" in payload
+
+    @pytest.mark.asyncio
+    async def test_missing_call_id_is_dropped_without_sending_anything(self) -> None:
+        """No call_id means we can't tell GPT-Live which delegation this
+        answers — sending a function_call_output with call_id=None would
+        likely be rejected and leaves the real pending call still hanging."""
+
+        @function_tool()
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        channel = make_channel(tools=[add])
+        provider = channel._provider
+
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA5"] = _CallState(model_ws=model_ws)
+
+        await provider._handle_function_call(
+            "CA5", {"name": "add", "arguments": json.dumps({"a": 2, "b": 3})}
+        )
+
+        assert model_ws.sent == []
+
+    @pytest.mark.asyncio
+    async def test_missing_name_sends_structured_error_without_running_a_tool(self) -> None:
+        ran = False
+
+        @function_tool()
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            nonlocal ran
+            ran = True
+            return a + b
+
+        channel = make_channel(tools=[add])
+        provider = channel._provider
+
+        model_ws = FakeModelWebSocket()
+        provider._calls["CA6"] = _CallState(model_ws=model_ws)
+
+        await provider._handle_function_call(
+            "CA6", {"call_id": "call_1", "arguments": json.dumps({"a": 2, "b": 3})}
+        )
+
+        assert ran is False
+        assert len(model_ws.sent) == 1
+        sent = model_ws.sent[0]
+        assert sent["item"]["call_id"] == "call_1"
+        payload = json.loads(sent["item"]["output"])
+        assert "error" in payload

--- a/tests/test_gpt_live_provider.py
+++ b/tests/test_gpt_live_provider.py
@@ -10,7 +10,7 @@ import pytest
 from tac import TAC
 from tac.channels.voice import VoiceChannel
 from tac.channels.voice.media_streams.gpt_live import (
-    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE,
     GPTLiveProviderConfig,
 )
 from tac.channels.voice.media_streams.gpt_live.models import _CallState
@@ -23,8 +23,8 @@ from tac.models.voice import TwiMLRequest
 from tac.tools import function_tool
 
 _VALID_SESSION_CONFIG = {
-    "model": "gpt-live-1-diamond-alpha",
-    "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+    "model": "gpt-live-1",
+    "audio": {"format": TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE},
 }
 
 
@@ -141,7 +141,7 @@ class TestConfigValidation:
         config = GPTLiveProviderConfig(
             openai_api_key="sk-test", default_session_config=dict(_VALID_SESSION_CONFIG)
         )
-        assert config.default_session_config["model"] == "gpt-live-1-diamond-alpha"
+        assert config.default_session_config["model"] == "gpt-live-1"
 
 
 class TestOutboundCallSessionConfig:
@@ -187,8 +187,8 @@ class TestOutboundCallSessionConfig:
                 InitiateVoiceConversationOptionsGPTLive(
                     to="+15551234567",
                     session_config={
-                        "model": "gpt-live-1-diamond-alpha",
-                        "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+                        "model": "gpt-live-1",
+                        "audio": {"format": TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE},
                         "instructions": "outbound override",
                     },
                 )
@@ -406,14 +406,14 @@ class TestConnectModelSessionConfig:
         channel = make_channel()
         provider = channel._provider
         provider._call_session_configs["CA_MODEL"] = {
-            "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+            "audio": {"format": TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE},
         }
 
         with pytest.raises(ValueError, match="must include 'model'"):
             await provider._connect_model("CA_MODEL")
 
     @pytest.mark.asyncio
-    async def test_wss_connect_uses_configured_model_and_alpha_header(self) -> None:
+    async def test_wss_connect_uses_configured_model(self) -> None:
         channel = make_channel()
         provider = channel._provider
 
@@ -430,10 +430,11 @@ class TestConnectModelSessionConfig:
 
         assert mock_connect.call_args.args[0] == "wss://api.openai.com/v1/live/sessions"
         headers = mock_connect.call_args.kwargs["additional_headers"]
-        assert headers["OpenAI-Alpha"] == "quicksilver=v3"
+        assert headers["Authorization"] == "Bearer sk-test"
+        assert headers["User-Agent"].startswith("twilio-agent-connect-python/Python ")
 
         sent_session = next(m for m in model_ws.sent if m["type"] == "session.start")
-        assert sent_session["session"]["model"] == "gpt-live-1-diamond-alpha"
+        assert sent_session["session"]["model"] == "gpt-live-1"
 
 
 class TestInboundCallSessionConfig:
@@ -442,9 +443,9 @@ class TestInboundCallSessionConfig:
         async def customizer(req: TwiMLRequest) -> dict | None:
             if req.caller_country == "MX":
                 return {
-                    "model": "gpt-live-1-diamond-alpha",
+                    "model": "gpt-live-1",
                     "instructions": "Habla en español.",
-                    "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+                    "audio": {"format": TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE},
                 }
             return None
 

--- a/tests/test_gpt_live_provider.py
+++ b/tests/test_gpt_live_provider.py
@@ -10,6 +10,7 @@ import pytest
 from tac import TAC
 from tac.channels.voice import VoiceChannel
 from tac.channels.voice.media_streams.gpt_live import (
+    GPT_LIVE_SESSION_ID_METADATA_KEY,
     TWILIO_AUDIO_FORMAT_FOR_GPT_LIVE,
     GPTLiveProviderConfig,
 )
@@ -506,6 +507,53 @@ class TestTranscriptDeltas:
             )
 
         assert session.metadata["transcript"] == [{"role": "assistant", "text": "hello"}]
+
+
+class TestGPTLiveSessionId:
+    @pytest.mark.asyncio
+    async def test_session_started_records_session_id_on_the_session(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        provider._calls["CA1c"] = _CallState()
+        session = channel._start_conversation("CA1c", profile_id=None)
+
+        await provider._dispatch_model_event(
+            "CA1c",
+            session,
+            {"type": "session.started", "session": {"id": "rtc_123", "status": "active"}},
+        )
+
+        assert session.metadata[GPT_LIVE_SESSION_ID_METADATA_KEY] == "rtc_123"
+
+    @pytest.mark.asyncio
+    async def test_session_closed_records_session_id_when_started_was_missed(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        provider._calls["CA1d"] = _CallState()
+        session = channel._start_conversation("CA1d", profile_id=None)
+
+        await provider._dispatch_model_event(
+            "CA1d",
+            session,
+            {"type": "session.closed", "reason": "client_request", "session": {"id": "live_456"}},
+        )
+
+        assert session.metadata[GPT_LIVE_SESSION_ID_METADATA_KEY] == "live_456"
+        assert provider._calls["CA1d"].closed_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_without_an_id_leaves_metadata_untouched(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        provider._calls["CA1e"] = _CallState()
+        session = channel._start_conversation("CA1e", profile_id=None)
+
+        await provider._dispatch_model_event("CA1e", session, {"type": "session.started"})
+
+        assert GPT_LIVE_SESSION_ID_METADATA_KEY not in session.metadata
 
 
 class TestOutputAudioDelta:

--- a/tests/test_gpt_live_provider.py
+++ b/tests/test_gpt_live_provider.py
@@ -432,7 +432,7 @@ class TestConnectModelSessionConfig:
         assert mock_connect.call_args.args[0] == "wss://api.openai.com/v1/live/sessions"
         headers = mock_connect.call_args.kwargs["additional_headers"]
         assert headers["Authorization"] == "Bearer sk-test"
-        assert headers["User-Agent"].startswith("twilio-agent-connect-python/Python ")
+        assert headers["User-Agent"].startswith("twilio-agent-connect/Python ")
 
         sent_session = next(m for m in model_ws.sent if m["type"] == "session.start")
         assert sent_session["session"]["model"] == "gpt-live-1"

--- a/tests/test_gpt_live_provider.py
+++ b/tests/test_gpt_live_provider.py
@@ -23,9 +23,7 @@ from tac.models.voice import TwiMLRequest
 from tac.tools import function_tool
 
 _VALID_SESSION_CONFIG = {
-    # No "model" here — GPT-Live's WebSocket docs say not to repeat it in
-    # session.update; the model is selected via the ?model= query param
-    # (GPTLiveProviderConfig.model) instead.
+    "model": "gpt-live-1-diamond-alpha",
     "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
 }
 
@@ -97,6 +95,7 @@ class FakeModelWebSocket:
     def __init__(self, events: list[dict] | None = None, stay_open: bool = False) -> None:
         self._events = list(events or [])
         self._stay_open = stay_open
+        self._ended = False
         self.sent: list[dict] = []
         self.closed = False
 
@@ -108,9 +107,12 @@ class FakeModelWebSocket:
             return json.dumps(self._events.pop(0))
         if self._stay_open:
             await asyncio.Event().wait()
+        self._ended = True
         raise StopAsyncIteration
 
     async def send(self, data: str) -> None:
+        if self._ended:
+            raise RuntimeError("connection closed")
         self.sent.append(json.loads(data))
 
     async def close(self) -> None:
@@ -135,11 +137,11 @@ class TestConfigValidation:
 
         GPTLiveProviderConfig(openai_api_key="sk-test", on_inbound_call_session_config=customizer)
 
-    def test_model_defaults(self) -> None:
+    def test_default_session_config_carries_model(self) -> None:
         config = GPTLiveProviderConfig(
             openai_api_key="sk-test", default_session_config=dict(_VALID_SESSION_CONFIG)
         )
-        assert config.model == "gpt-live-1-marble-alpha"
+        assert config.default_session_config["model"] == "gpt-live-1-diamond-alpha"
 
 
 class TestOutboundCallSessionConfig:
@@ -185,6 +187,7 @@ class TestOutboundCallSessionConfig:
                 InitiateVoiceConversationOptionsGPTLive(
                     to="+15551234567",
                     session_config={
+                        "model": "gpt-live-1-diamond-alpha",
                         "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
                         "instructions": "outbound override",
                     },
@@ -214,7 +217,7 @@ class TestOutboundCallSessionConfig:
         ):
             await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
 
-        sent_session = next(m for m in model_ws.sent if m["type"] == "session.update")
+        sent_session = next(m for m in model_ws.sent if m["type"] == "session.start")
         assert sent_session["session"]["instructions"] == "outbound override"
         assert provider._call_session_configs == {}
 
@@ -297,7 +300,7 @@ class TestOutboundCallSessionConfig:
         ) as mock_connect:
             await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
 
-        assert "v1/live?model=gpt-live-1-marble-alpha" in mock_connect.call_args.args[0]
+        assert mock_connect.call_args.args[0] == "wss://api.openai.com/v1/live/sessions"
 
     @pytest.mark.asyncio
     async def test_session_config_token_not_leaked_if_twiml_build_fails(self) -> None:
@@ -346,8 +349,6 @@ class TestHandleWebSocketLifecycle:
 
     @pytest.mark.asyncio
     async def test_input_audio_forwarded_with_gpt_live_event_shape(self) -> None:
-        """Unlike Realtime's input_audio_buffer.append, GPT-Live uses
-        input_audio.append."""
         channel = make_channel()
         provider = channel._provider
 
@@ -358,7 +359,7 @@ class TestHandleWebSocketLifecycle:
                 {"event": "stop"},
             ]
         )
-        model_ws = FakeModelWebSocket(events=[], stay_open=True)
+        model_ws = FakeModelWebSocket(events=[{"type": "session.closed"}], stay_open=True)
 
         with patch(
             "tac.channels.voice.media_streams.gpt_live.provider.websockets.connect",
@@ -366,7 +367,7 @@ class TestHandleWebSocketLifecycle:
         ):
             await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
 
-        assert {"type": "input_audio.append", "audio": "abcd"} in model_ws.sent
+        assert {"type": "session.input_audio.append", "audio": "abcd"} in model_ws.sent
 
     @pytest.mark.asyncio
     async def test_session_close_sent_on_teardown(self) -> None:
@@ -379,7 +380,7 @@ class TestHandleWebSocketLifecycle:
                 {"event": "stop"},
             ]
         )
-        model_ws = FakeModelWebSocket(events=[], stay_open=True)
+        model_ws = FakeModelWebSocket(events=[{"type": "session.closed"}], stay_open=True)
 
         with patch(
             "tac.channels.voice.media_streams.gpt_live.provider.websockets.connect",
@@ -401,21 +402,18 @@ class TestConnectModelSessionConfig:
             await provider._connect_model("CA_BAD")
 
     @pytest.mark.asyncio
-    async def test_model_key_in_session_config_raises_at_connect_time(self) -> None:
-        """GPT-Live rejects repeating 'model' in the initial session.update — it
-        comes from the ?model= query param (GPTLiveProviderConfig.model) instead."""
+    async def test_missing_model_raises_at_connect_time(self) -> None:
         channel = make_channel()
         provider = channel._provider
         provider._call_session_configs["CA_MODEL"] = {
-            "model": "gpt-live-1-marble-alpha",
             "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
         }
 
-        with pytest.raises(ValueError, match="must not include 'model'"):
+        with pytest.raises(ValueError, match="must include 'model'"):
             await provider._connect_model("CA_MODEL")
 
     @pytest.mark.asyncio
-    async def test_wss_url_uses_configured_model(self) -> None:
+    async def test_wss_connect_uses_configured_model_and_alpha_header(self) -> None:
         channel = make_channel()
         provider = channel._provider
 
@@ -430,9 +428,12 @@ class TestConnectModelSessionConfig:
         ) as mock_connect:
             await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
 
-        assert "v1/live?model=gpt-live-1-marble-alpha" in mock_connect.call_args.args[0]
+        assert mock_connect.call_args.args[0] == "wss://api.openai.com/v1/live/sessions"
         headers = mock_connect.call_args.kwargs["additional_headers"]
-        assert headers["OpenAI-Alpha"] == "quicksilver=v2"
+        assert headers["OpenAI-Alpha"] == "quicksilver=v3"
+
+        sent_session = next(m for m in model_ws.sent if m["type"] == "session.start")
+        assert sent_session["session"]["model"] == "gpt-live-1-diamond-alpha"
 
 
 class TestInboundCallSessionConfig:
@@ -441,6 +442,7 @@ class TestInboundCallSessionConfig:
         async def customizer(req: TwiMLRequest) -> dict | None:
             if req.caller_country == "MX":
                 return {
+                    "model": "gpt-live-1-diamond-alpha",
                     "instructions": "Habla en español.",
                     "audio": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
                 }
@@ -465,14 +467,14 @@ class TestInboundCallSessionConfig:
         ):
             await asyncio.wait_for(provider.handle_websocket(twilio_ws), timeout=5)
 
-        sent_session = next(m for m in model_ws.sent if m["type"] == "session.update")
+        sent_session = next(m for m in model_ws.sent if m["type"] == "session.start")
         assert sent_session["session"]["instructions"] == "Habla en español."
         assert "CA_MX" not in provider._call_session_configs
 
 
-class TestTurnDoneTranscript:
+class TestTranscriptDeltas:
     @pytest.mark.asyncio
-    async def test_turn_done_captures_transcript(self) -> None:
+    async def test_input_transcript_delta_appends_user_turn(self) -> None:
         channel = make_channel()
         provider = channel._provider
 
@@ -480,10 +482,29 @@ class TestTurnDoneTranscript:
         session = channel._start_conversation("CA1", profile_id=None)
 
         await provider._dispatch_model_event(
-            "CA1", session, {"type": "turn.done", "turn": {"role": "user", "transcript": "hi"}}
+            "CA1",
+            session,
+            {"type": "session.input_transcript.delta", "delta": "hi"},
         )
 
         assert session.metadata["transcript"] == [{"role": "user", "text": "hi"}]
+
+    @pytest.mark.asyncio
+    async def test_consecutive_same_role_deltas_merge_into_one_entry(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        provider._calls["CA1b"] = _CallState()
+        session = channel._start_conversation("CA1b", profile_id=None)
+
+        for chunk in ("he", "llo"):
+            await provider._dispatch_model_event(
+                "CA1b",
+                session,
+                {"type": "session.output_transcript.delta", "delta": chunk},
+            )
+
+        assert session.metadata["transcript"] == [{"role": "assistant", "text": "hello"}]
 
 
 class TestOutputAudioDelta:
@@ -498,7 +519,7 @@ class TestOutputAudioDelta:
         session.metadata["stream_sid"] = "MZ2"
 
         await provider._dispatch_model_event(
-            "CA2", session, {"type": "output_audio.delta", "audio": "xyz"}
+            "CA2", session, {"type": "session.output_audio.delta", "delta": "xyz"}
         )
 
         assert twilio_ws.sent == [
@@ -517,11 +538,7 @@ class TestToolCalls:
         assert result == {"error": "Unknown tool 'does_not_exist'"}
 
     @pytest.mark.asyncio
-    async def test_function_call_uses_delegation_event_with_no_followup(self) -> None:
-        """Unlike Realtime's two-send pattern (function_call_output +
-        response.create), GPT-Live's Responses delegation only needs one
-        send — no follow-up response.create."""
-
+    async def test_function_call_sends_output_then_continues_response(self) -> None:
         @function_tool()
         def add(a: int, b: int) -> int:
             """Add two numbers."""
@@ -542,11 +559,12 @@ class TestToolCalls:
             },
         )
 
-        assert len(model_ws.sent) == 1
-        sent = model_ws.sent[0]
-        assert sent["type"] == "delegation.function_call_output.create"
-        assert sent["item"]["call_id"] == "call_1"
-        assert json.loads(sent["item"]["output"]) == 5
+        assert len(model_ws.sent) == 2
+        output_sent, continue_sent = model_ws.sent
+        assert output_sent["type"] == "response.item.create"
+        assert output_sent["item"]["call_id"] == "call_1"
+        assert json.loads(output_sent["item"]["output"]) == 5
+        assert continue_sent == {"type": "response.create"}
 
     @pytest.mark.asyncio
     async def test_non_serializable_output_still_sends_function_call_output(self) -> None:
@@ -565,9 +583,10 @@ class TestToolCalls:
             "CA4", {"call_id": "call_1", "name": "broken_output", "arguments": "{}"}
         )
 
-        assert len(model_ws.sent) == 1
+        assert len(model_ws.sent) == 2
         payload = json.loads(model_ws.sent[0]["item"]["output"])
         assert "error" in payload
+        assert model_ws.sent[1] == {"type": "response.create"}
 
     @pytest.mark.asyncio
     async def test_missing_call_id_is_dropped_without_sending_anything(self) -> None:
@@ -614,7 +633,8 @@ class TestToolCalls:
         )
 
         assert ran is False
-        assert len(model_ws.sent) == 1
+        assert len(model_ws.sent) == 2
+        assert model_ws.sent[1] == {"type": "response.create"}
         sent = model_ws.sent[0]
         assert sent["item"]["call_id"] == "call_1"
         payload = json.loads(sent["item"]["output"])

--- a/tests/test_media_streams_shared_provider.py
+++ b/tests/test_media_streams_shared_provider.py
@@ -1,0 +1,111 @@
+"""Tests for ``MediaStreamsOpenAIProvider``, the base shared by
+``OpenAIRealtimeProvider`` and ``GPTLiveProvider``.
+
+Exercised through ``OpenAIRealtimeProvider`` since the methods under test
+(``get_transcript``, ``get_websocket``, ``handle_incoming_call``'s type
+checks) are verified identical across both providers — see
+test_openai_realtime_provider.py's ``TestCallEventCallbackWiring`` docstring
+for the same reasoning applied to call-event wiring.
+"""
+
+import pytest
+
+from tac import TAC
+from tac.channels.voice import VoiceChannel
+from tac.channels.voice.media_streams.openai_realtime import OpenAIRealtimeProviderConfig
+from tac.channels.voice.media_streams.openai_realtime.provider import (
+    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+)
+from tac.models.voice import (
+    TwiMLRequest,
+    VoiceTwiMLOptionsConversationRelay,
+    VoiceTwiMLOptionsMediaStreams,
+)
+
+_VALID_AUDIO = {
+    "input": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+    "output": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+}
+
+
+def get_test_tac_config() -> dict:
+    return {
+        "account_sid": "ACtest123",
+        "auth_token": "test_token_123",
+        "api_key": "SK123",
+        "api_secret": "test_api_token",
+        "conversation_configuration_id": "conv_configuration_test123",
+        "phone_number": "+15551234567",
+        "voice_public_domain": "example.com",
+    }
+
+
+def make_channel(**config_kwargs: object) -> VoiceChannel:
+    tac = TAC(get_test_tac_config())
+    config = OpenAIRealtimeProviderConfig(
+        openai_api_key="sk-test",
+        default_session_config={"model": "gpt-realtime-test", "audio": _VALID_AUDIO},
+        **config_kwargs,
+    )
+    return VoiceChannel(tac, config=config)
+
+
+class TestGetTranscript:
+    def test_returns_transcript_from_session_metadata(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+        session = channel._start_conversation("CA1", profile_id=None)
+        session.metadata["transcript"] = [{"role": "user", "text": "hi"}]
+
+        assert provider.get_transcript("CA1") == [{"role": "user", "text": "hi"}]
+
+    def test_returns_empty_list_for_unknown_conversation(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        assert provider.get_transcript("no-such-call") == []
+
+
+class TestGetWebsocket:
+    def test_returns_none_for_unknown_conversation(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        assert provider.get_websocket("no-such-call") is None
+
+
+class TestHandleIncomingCallTypeChecks:
+    @pytest.mark.asyncio
+    async def test_wrong_host_twiml_options_type_raises(self) -> None:
+        channel = make_channel()
+        provider = channel._provider
+
+        with pytest.raises(TypeError, match="requires host_twiml_options"):
+            await provider.handle_incoming_call(
+                host_twiml_options=VoiceTwiMLOptionsConversationRelay()
+            )
+
+    @pytest.mark.asyncio
+    async def test_customizer_returning_valid_type_is_used(self) -> None:
+        async def customizer(req: TwiMLRequest) -> VoiceTwiMLOptionsMediaStreams:
+            return VoiceTwiMLOptionsMediaStreams(name="custom-stream")
+
+        channel = make_channel()
+        channel.on_inbound_call_twiml(customizer)
+        provider = channel._provider
+
+        twiml = await provider.handle_incoming_call(twiml_request=TwiMLRequest(call_sid="CA1"))
+
+        assert 'name="custom-stream"' in twiml
+
+    @pytest.mark.asyncio
+    async def test_customizer_returning_wrong_type_raises(self) -> None:
+        async def bad_customizer(req: TwiMLRequest) -> VoiceTwiMLOptionsConversationRelay:
+            return VoiceTwiMLOptionsConversationRelay()
+
+        channel = make_channel()
+        channel.on_inbound_call_twiml(bad_customizer)
+        provider = channel._provider
+
+        with pytest.raises(TypeError, match="on_inbound_call_twiml customizer"):
+            await provider.handle_incoming_call(twiml_request=TwiMLRequest(call_sid="CA1"))

--- a/tests/test_media_streams_shared_provider.py
+++ b/tests/test_media_streams_shared_provider.py
@@ -14,7 +14,7 @@ from tac import TAC
 from tac.channels.voice import VoiceChannel
 from tac.channels.voice.media_streams.openai_realtime import OpenAIRealtimeProviderConfig
 from tac.channels.voice.media_streams.openai_realtime.provider import (
-    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    TWILIO_AUDIO_FORMAT_FOR_REALTIME,
 )
 from tac.models.voice import (
     TwiMLRequest,
@@ -23,8 +23,8 @@ from tac.models.voice import (
 )
 
 _VALID_AUDIO = {
-    "input": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
-    "output": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+    "input": {"format": TWILIO_AUDIO_FORMAT_FOR_REALTIME},
+    "output": {"format": TWILIO_AUDIO_FORMAT_FOR_REALTIME},
 }
 
 

--- a/tests/test_openai_realtime_provider.py
+++ b/tests/test_openai_realtime_provider.py
@@ -14,7 +14,7 @@ from tac.channels.voice.media_streams.openai_realtime import OpenAIRealtimeProvi
 from tac.channels.voice.media_streams.openai_realtime.models import _BargeInState, _CallState
 from tac.channels.voice.media_streams.openai_realtime.provider import (
     _SESSION_CONFIG_TOKEN_PARAM,
-    TWILIO_MEDIA_STREAM_AUDIO_FORMAT,
+    TWILIO_AUDIO_FORMAT_FOR_REALTIME,
 )
 from tac.models.outbound import (
     InitiateVoiceConversationOptions,
@@ -24,8 +24,8 @@ from tac.models.voice import TwiMLRequest
 from tac.tools import function_tool
 
 _VALID_AUDIO = {
-    "input": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
-    "output": {"format": TWILIO_MEDIA_STREAM_AUDIO_FORMAT},
+    "input": {"format": TWILIO_AUDIO_FORMAT_FOR_REALTIME},
+    "output": {"format": TWILIO_AUDIO_FORMAT_FOR_REALTIME},
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -913,6 +913,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffe-pydantic"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/bd/d2eaeaf3f9910c9cd72793af0de18ee3d3a3a27bb30ab01cfd7659c08dc4/griffe_pydantic-1.3.1.tar.gz", hash = "sha256:f7caedfa0effedb22893bf01cc411fd567614f7b4de7ce0c1f4293eb7acb5c44", size = 38176, upload-time = "2026-02-21T09:38:49.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/88/17d656aa97406cd509e2be0e6eddcf81fc1666104bf81042b89721d4a44c/griffe_pydantic-1.3.1-py3-none-any.whl", hash = "sha256:475103794a1d5da3933d3968e82a2bd9d9a1fa507c06d5ee1a39ee1fadcca628", size = 15189, upload-time = "2026-02-20T11:34:14.965Z" },
 ]
 
 [[package]]
@@ -2768,7 +2780,7 @@ wheels = [
 
 [[package]]
 name = "twilio-agent-connect"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -2798,6 +2810,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "griffe-pydantic" },
     { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
@@ -2837,6 +2850,7 @@ dev = [
     { name = "ruff", specifier = ">=0.15.0,<1" },
 ]
 docs = [
+    { name = "griffe-pydantic", specifier = ">=1.1.0,<2" },
     { name = "mike", specifier = ">=2.1.0,<3" },
     { name = "mkdocs", specifier = ">=1.6.0,<2" },
     { name = "mkdocs-material", specifier = ">=9.5.0,<10" },

--- a/uv.lock
+++ b/uv.lock
@@ -2777,6 +2777,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+gpt-live = [
+    { name = "websockets" },
+]
 openai-realtime = [
     { name = "websockets" },
 ]
@@ -2820,9 +2823,10 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.20,<1" },
     { name = "twilio", specifier = ">=9.8.3,<10" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.32.0,<1" },
+    { name = "websockets", marker = "extra == 'gpt-live'", specifier = ">=14,<17" },
     { name = "websockets", marker = "extra == 'openai-realtime'", specifier = ">=14,<17" },
 ]
-provides-extras = ["server", "openai-realtime"]
+provides-extras = ["server", "openai-realtime", "gpt-live"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds support for OpenAI's GPT-Live speech-to-speech API as a Twilio Media Streams voice provider, alongside the existing OpenAI Realtime provider.

`GPTLiveProvider` bridges a Media Streams connection to a GPT-Live session, relaying audio in both directions and managing the session lifecycle, tool calls, transcripts, and graceful shutdown. Inbound and outbound calls are both supported, with session configuration supplied globally or per call.

Install with the new `gpt-live` extra:

```bash
pip install "twilio-agent-connect[server,gpt-live]"
```

A runnable example lives at `getting_started/examples/partners/openai_gpt_live.py`, and the full surface is documented in the API reference under Media Streams Providers.

> **Authorship:** @xinghaohuang91 is the main author of this work. It was developed on an internal repository ahead of GPT-Live's public release and moved here with commit authorship preserved.

## How to test

```bash
make check
```

Also verified end-to-end against real Twilio/OpenAI credentials via `getting_started/examples/partners/openai_gpt_live.py`: inbound and outbound calls, a tool call, and a clean, prompt hangup.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Release / version bump

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Tested E2E

## SDK Parity

This is the **Python SDK**. If this change affects shared functionality, ensure the [TypeScript SDK](https://github.com/twilio/twilio-agent-connect-typescript) is updated as well.

> **Tip:** Use the `/sync-to-ts-sdk` skill in Claude Code to automatically generate and create a TypeScript SDK PR from your changes.

- [x] Change is Python-specific (no TypeScript update needed)
- [ ] TypeScript SDK PR created: <!-- link to PR in twilio-agent-connect-typescript -->
